### PR TITLE
fix: speed up stream objects creation

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -289,10 +289,8 @@ export class AIOStreams {
     console.log('Sorted streams');
 
     // Create stream objects
-    for (const parsedStream of filteredResults) {
-      const stream = await this.createStreamObject(parsedStream);
-      if (stream) streams.push(stream);
-    }
+    const streamObjects = await Promise.all(filteredResults.map(this.createStreamObject.bind(this)));
+    streams.push(...streamObjects.filter(s => s !== null));
 
     console.log('Created stream objects');
     return streams;


### PR DESCRIPTION
Hi, thank you for the great plugin. 

I noticed it took some time to populate the streaming links when used with mediaflow-proxy. Therefore I propose a small change to make the experience a bit more seamless. 