### PR TITLE
fix: mediaflow proxy password not url encoded when fetching public ip

### DIFF
--- a/packages/utils/src/mediaflow.ts
+++ b/packages/utils/src/mediaflow.ts
@@ -74,7 +74,7 @@ export async function getMediaFlowPublicIp(mediaFlowConfig: Config["mediaFlowCon
 
   try {
     console.debug('|DBG| mediaflow > getMediaFlowPublicIp > GET /proxy/ip?api_password=***');
-    const response = await fetch(new URL(`/proxy/ip?api_password=${mediaFlowConfig.apiPassword}`, mediaFlowUrl).toString(), {
+    const response = await fetch(new URL(`/proxy/ip?api_password=${encodeURIComponent(mediaFlowConfig.apiPassword)}`, mediaFlowUrl).toString(), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
In case the password includes special chars, it has to be encoded in the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
	- Improved URL encoding for API password to prevent potential URL-related issues with special characters
	- Enhanced security handling of credentials during network requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->