### PR TITLE
feat: add optional API key validation and input to configuration

### DIFF
--- a/packages/addon/src/config.ts
+++ b/packages/addon/src/config.ts
@@ -97,7 +97,20 @@ export function validateConfig(config: Config): {
       `You can only select a maximum of ${Settings.MAX_ADDONS} addons`
     );
   }
-
+  // check for apiKey if Settings.API_KEY is set
+  if (Settings.API_KEY && !config.apiKey) {
+    return createResponse(
+      false,
+      'missingApiKey',
+      'The AIOStreams API key is required'
+    );
+  } else if (Settings.API_KEY && config.apiKey !== Settings.API_KEY) {
+    return createResponse(
+      false,
+      'invalidApiKey',
+      'Invalid AIOStreams API key. Please use the one defined in your environment variables'
+    );
+  }
   // check for any duplicate addons where both the ID and options are the same
   const duplicateAddons = config.addons.filter(
     (addon, index) =>

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -341,6 +341,7 @@ app.get('/get-addon-config', (req, res) => {
     maxMovieSize: Settings.MAX_MOVIE_SIZE,
     maxEpisodeSize: Settings.MAX_EPISODE_SIZE,
     torrentioDisabled: Settings.DISABLE_TORRENTIO,
+    apiKeyRequired: Settings.API_KEY ? true : false,
   });
 });
 

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -341,7 +341,7 @@ app.get('/get-addon-config', (req, res) => {
     maxMovieSize: Settings.MAX_MOVIE_SIZE,
     maxEpisodeSize: Settings.MAX_EPISODE_SIZE,
     torrentioDisabled: Settings.DISABLE_TORRENTIO,
-    apiKeyRequired: Settings.API_KEY ? true : false,
+    apiKeyRequired: !!Settings.API_KEY,
   });
 });
 

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -195,6 +195,7 @@ export default function Configure() {
     string[] | null
   >(null);
   const [overrideName, setOverrideName] = useState<string>('');
+  const [apiKey, setApiKey] = useState<string>('');
 
   const [disableButtons, setDisableButtons] = useState<boolean>(false);
   const [maxMovieSizeSlider, setMaxMovieSizeSlider] = useState<number>(
@@ -206,6 +207,7 @@ export default function Configure() {
   const [choosableAddons, setChoosableAddons] = useState<string[]>(
     addonDetails.map((addon) => addon.id)
   );
+  const [showApiKeyInput, setShowApiKeyInput] = useState<boolean>(false);
   const [manifestUrl, setManifestUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -216,6 +218,7 @@ export default function Configure() {
         if (data.success) {
           setMaxMovieSizeSlider(data.maxMovieSize);
           setMaxEpisodeSizeSlider(data.maxEpisodeSize);
+          setShowApiKeyInput(data.apiKeyRequired);
           // filter out 'torrentio' from choosableAddons if torrentioDisabled is true
           if (data.torrentioDisabled) {
             setChoosableAddons(
@@ -230,6 +233,7 @@ export default function Configure() {
 
   const createConfig = (): Config => {
     const config = {
+      apiKey: apiKey,
       overrideName,
       streamTypes,
       resolutions,
@@ -1318,6 +1322,30 @@ export default function Configure() {
             </div>
           }
         </div>
+
+        {showApiKeyInput && (
+          <div className={styles.section}>
+            <div className={styles.setting}>
+              <div className={styles.settingDescription}>
+                <h2 style={{ padding: '5px' }}>API Key</h2>
+                <p style={{ padding: '5px' }}>
+                  Enter your AIOStreams API Key to install and use this addon.
+                  You need to enter the one that is set in the{' '}
+                  <code>API_KEY</code> environment variable.
+                </p>
+              </div>
+              <div className={styles.settingInput}>
+                <CredentialInput
+                  credential={apiKey}
+                  setCredential={setApiKey}
+                  inputProps={{
+                    placeholder: 'Enter your API key',
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className={styles.installButtons}>
           <button

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -119,6 +119,7 @@ export type SortBy = { [key: string]: boolean | string | undefined };
 export type StreamType = { [key: string]: boolean };
 
 export interface Config {
+  apiKey?: string;
   overrideName?: string;
   instanceCache?: any;
   requestingIp?: string;

--- a/packages/utils/src/settings.ts
+++ b/packages/utils/src/settings.ts
@@ -16,13 +16,13 @@ export class Settings {
     process.env.BRANDING ?? process.env.NEXT_PUBLIC_ELFHOSTED_BRANDING;
   public static readonly SECRET_KEY = process.env.SECRET_KEY ?? '';
   public static readonly CUSTOM_CONFIGS = process.env.CUSTOM_CONFIGS || '';
-
   public static readonly DISABLE_CUSTOM_CONFIG_GENERATOR_ROUTE =
     process.env.DISABLE_CUSTOM_CONFIG_GENERATOR_ROUTE === 'true';
   public static readonly DETERMINISTIC_ADDON_ID = process.env
     .DETERMINISTIC_ADDON_ID
     ? process.env.DETERMINISTIC_ADDON_ID === 'true'
     : false;
+  public static readonly API_KEY = process.env.API_KEY ?? '';
   public static readonly TMDB_API_KEY = process.env.TMDB_API_KEY || '';
   public static readonly SHOW_DIE = process.env.SHOW_DIE
     ? process.env.SHOW_DIE === 'true'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validation for API keys in configuration, ensuring that an appropriate key is provided when required.
  - The configuration response now indicates whether an API key is necessary.
  - The setup interface conditionally displays an API key input field based on the server response, allowing users to enter their API key if needed.
  - Introduced a new property in the settings to retrieve the API key from environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->