### PR TITLE
Fixed a typo in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -91,7 +91,7 @@ DEFAULT_COMET_TIMOUT=
 # i.e. you would set these to the public URL of the comet instance
 FORCE_COMET_HOSTNAME=
 FORCE_COMET_PORT=
-FORCE_COMOT_PROTOCOL=
+FORCE_COMET_PROTOCOL=
 # -------------------------------------
 
 # ----------- MEDIAFUSION ------------


### PR DESCRIPTION
Comet was spelled as comot in the .env.sample file in the FORCE_COMET_PROTOCOL variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the naming of an environment variable to ensure the Comet service protocol is referenced accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->