### PR TITLE
Change MAX_EPISODE_SIZE to 70 GB

### DIFF
--- a/packages/utils/src/settings.ts
+++ b/packages/utils/src/settings.ts
@@ -79,7 +79,7 @@ export class Settings {
     : 161061273600; // 150GiB
   public static readonly MAX_EPISODE_SIZE = process.env.MAX_EPISODE_SIZE
     ? parseInt(process.env.MAX_EPISODE_SIZE)
-    : 16106127360; // 15GiB
+    : 75161927680; // 70GiB
   public static readonly MAX_TIMEOUT = process.env.MAX_TIMEOUT
     ? parseInt(process.env.MAX_TIMEOUT)
     : 50000;


### PR DESCRIPTION
Thanks Nhyira for the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the default maximum episode size limit from 15 GiB to 70 GiB when no environment variable is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->