### PR TITLE
Feat: Add the ability to see the formatter output as a preview 

### DIFF
--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -284,7 +284,7 @@ export default function Configure() {
   const fetchWithTimeout = async (
     url: string,
     options: RequestInit | undefined,
-    timeoutMs = 3000
+    timeoutMs = 30000
   ) => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -1082,7 +1082,7 @@ export default function Configure() {
             <div className={styles.settingDescription}>
               <h2 style={{ padding: '5px' }}>Formatter</h2>
               <p style={{ padding: '5px' }}>
-                Change how your stream results are f.
+                Change how your stream results are f
                 <span
                   onClick={() => {
                     if (formatterOptions.includes('imposter')) {

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -1082,7 +1082,7 @@ export default function Configure() {
             <div className={styles.settingDescription}>
               <h2 style={{ padding: '5px' }}>Formatter</h2>
               <p style={{ padding: '5px' }}>
-                Change how your stream results are formatted.
+                Change how your stream results are f.
                 <span
                   onClick={() => {
                     if (formatterOptions.includes('imposter')) {

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -1098,7 +1098,7 @@ export default function Configure() {
                 >
                   ◌
                 </span>
-                rmatted
+                rmatted.
               </p>
             </div>
             <div className={styles.settingInput}>

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -1098,6 +1098,7 @@ export default function Configure() {
                 >
                   ◌
                 </span>
+                rmatted
               </p>
             </div>
             <div className={styles.settingInput}>

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -40,6 +40,7 @@ import CredentialInput from '@/components/CredentialInput';
 import CreateableSelect from '@/components/CreateableSelect';
 import MultiSelect from '@/components/MutliSelect';
 import InstallWindow from '@/components/InstallWindow';
+import FormatterPreview from '@/components/FormatterPreview';
 
 const version = addonPackage.version;
 
@@ -283,7 +284,7 @@ export default function Configure() {
   const fetchWithTimeout = async (
     url: string,
     options: RequestInit | undefined,
-    timeoutMs = 30000
+    timeoutMs = 5000
   ) => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -1081,7 +1082,7 @@ export default function Configure() {
             <div className={styles.settingDescription}>
               <h2 style={{ padding: '5px' }}>Formatter</h2>
               <p style={{ padding: '5px' }}>
-                Change how your stream results are f
+                Change how your stream results are formatted.
                 <span
                   onClick={() => {
                     if (formatterOptions.includes('imposter')) {
@@ -1097,7 +1098,6 @@ export default function Configure() {
                 >
                   ◌
                 </span>
-                rmatted.
               </p>
             </div>
             <div className={styles.settingInput}>
@@ -1113,6 +1113,7 @@ export default function Configure() {
               </select>
             </div>
           </div>
+          <FormatterPreview formatter={formatter || 'gdrive'} />
         </div>
 
         <div className={styles.section}>

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -284,7 +284,7 @@ export default function Configure() {
   const fetchWithTimeout = async (
     url: string,
     options: RequestInit | undefined,
-    timeoutMs = 5000
+    timeoutMs = 3000
   ) => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/packages/frontend/src/components/FormatterPreview.module.css
+++ b/packages/frontend/src/components/FormatterPreview.module.css
@@ -1,0 +1,28 @@
+.previewContainer {
+  background-color: #121212;
+  border-radius: 6px;
+  padding: 15px;
+  margin-top: 15px;
+  border: 1px solid #333333;
+  transition: all 0.3s ease;
+}
+
+
+
+.streamPreview {
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.streamName {
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 10px;
+  color: #ffffff;
+}
+
+.streamDescription {
+  font-size: 14px;
+  color: #dddddd;
+}

--- a/packages/frontend/src/components/FormatterPreview.tsx
+++ b/packages/frontend/src/components/FormatterPreview.tsx
@@ -26,11 +26,10 @@ const FormatterPreview: React.FC<FormatterPreviewProps> = ({
     size: 62500000000, // 58.2 GB
     duration: 9120, // 2h 32m
     provider: {
-      id: 'rd',
+      id: 'realdebrid',
       cached: true
     },
     torrent: {
-      infoHash: 'abc123',
       seeders: 125
     },
     indexers: 'RARBG',

--- a/packages/frontend/src/components/FormatterPreview.tsx
+++ b/packages/frontend/src/components/FormatterPreview.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styles from './FormatterPreview.module.css';
+import { ParsedStream } from '@aiostreams/types';
+import { gdriveFormat, torrentioFormat, torboxFormat } from '@aiostreams/formatters';
+
+interface FormatterPreviewProps {
+  formatter: string;
+}
+
+const FormatterPreview: React.FC<FormatterPreviewProps> = ({
+  formatter
+}) => {
+  // Create a sample stream for preview
+  const sampleStream: ParsedStream = {
+    addon: {
+      id: 'aiostreams',
+      name: 'AIOStreams'
+    },
+    resolution: '4K',
+    quality: 'BluRay',
+    encode: 'HEVC',
+    visualTags: ['HDR', 'DV'],
+    audioTags: ['Atmos', 'TrueHD'],
+    languages: ['English', 'Spanish', 'French'],
+    filename: 'Movie.Title.2023.2160p.BluRay.HEVC.DV.TrueHD.Atmos.7.1-GROUP',
+    size: 62500000000, // 58.2 GB
+    duration: 9120, // 2h 32m
+    provider: {
+      id: 'rd',
+      cached: true
+    },
+    torrent: {
+      infoHash: 'abc123',
+      seeders: 125
+    },
+    indexers: 'RARBG',
+    type: 'debrid'
+  };
+
+  const getFormatterExample = () => {
+    switch (formatter) {
+      case 'gdrive':
+        return gdriveFormat(sampleStream, false);
+      case 'gdrive-minimalistic':
+        return gdriveFormat(sampleStream, true);
+      case 'torrentio':
+        return torrentioFormat(sampleStream);
+      case 'torbox':
+        return torboxFormat(sampleStream);
+      case 'imposter':
+        return {
+          name: 'ಞ AIOStreams 4K ಞ',
+          description: 'ಞ Sus: Very ಞ\nಞ Vented: Yes ಞ\nಞ Tasks: None ಞ\nಞ Crewmates: 0 ಞ',
+        };
+      default:
+        return gdriveFormat(sampleStream, false);
+    }
+  };
+
+  const example = getFormatterExample();
+
+  return (
+    <div className={styles.previewContainer}>
+      <div className={styles.streamPreview}>
+        <div className={styles.streamName}>{example.name}</div>
+        <div className={styles.streamDescription}>{example.description}</div>
+      </div>
+    </div>
+  );
+};
+
+export default FormatterPreview;


### PR DESCRIPTION
## Added Formatter Preview Feature

### New Feature
- Added a new formatter preview component that shows how different formatters will display streams
- Preview appears automatically below the formatter dropdown
- Uses real formatter functions to show accurate formatting examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a preview section for formatters, allowing users to see how stream results will be displayed based on the selected formatter.
- **Improvements**
	- Enhanced the description text for the formatter setting to improve clarity.
- **Style**
	- Added new styles to provide a visually distinct and readable preview area for formatter output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->