### PR TITLE
feat: Add regex-based stream sorting with API key protection

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -740,6 +740,29 @@ export class AIOStreams {
           (resolution) => resolution[b.resolution]
         )
       );
+    } else if (field === 'regexSort') {
+      if (!this.config.regexSortPattern) return 0;
+      
+      try {
+        const regex = new RegExp(this.config.regexSortPattern);
+        const aMatch = a.filename ? regex.exec(a.filename) : null;
+        const bMatch = b.filename ? regex.exec(b.filename) : null;
+        
+        // If both match or both don't match, they are equal
+        if ((aMatch && bMatch) || (!aMatch && !bMatch)) return 0;
+        
+        // If one matches and the other doesn't, use direction to determine order
+        const direction = this.config.sortBy.find((sort) => Object.keys(sort)[0] === 'regexSort')?.direction;
+        if (direction === 'asc') {
+          // In ascending order, matching files come last
+          return aMatch ? 1 : -1;
+        } else {
+          // In descending order, matching files come first
+          return aMatch ? -1 : 1;
+        }
+      } catch (e) {
+        return 0;
+      }
     } else if (field === 'cached') {
       let aCanbeCached = a.provider;
       let bCanbeCached = b.provider;

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -745,8 +745,8 @@ export class AIOStreams {
       
       try {
         const regex = new RegExp(this.config.regexSortPattern);
-        const aMatch = a.filename ? regex.exec(a.filename) : null;
-        const bMatch = b.filename ? regex.exec(b.filename) : null;
+        const aMatch = a.filename ? regex.test(a.filename) : false;
+        const bMatch = b.filename ? regex.test(b.filename) : false;
         
         // If both match or both don't match, they are equal
         if ((aMatch && bMatch) || (!aMatch && !bMatch)) return 0;

--- a/packages/addon/src/config.ts
+++ b/packages/addon/src/config.ts
@@ -465,5 +465,25 @@ export function validateConfig(
     }
   }
 
+  if (config.regexSortPattern) {
+    if (!config.apiKey) {
+      return createResponse(
+        false,
+        'missingApiKey',
+        'Regex sorting requires an API key to be set'
+      );
+    }
+
+    try {
+      new RegExp(config.regexSortPattern);
+    } catch (e) {
+      return createResponse(
+        false,
+        'invalidRegexSortPattern',
+        'Invalid regex sort pattern'
+      );
+    }
+  }
+
   return createResponse(true, null, null);
 }

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -556,6 +556,7 @@ export default function Configure() {
         })) || []
       );
       setRegexFilters(decodedConfig.regexFilters || {});
+      setRegexSortPattern(decodedConfig.regexSortPattern || '');
 
       setServices(loadValidServices(decodedConfig.services));
       setMaxMovieSize(

--- a/packages/frontend/src/app/configure/page.tsx
+++ b/packages/frontend/src/app/configure/page.tsx
@@ -118,6 +118,7 @@ const defaultSortCriteria: SortBy[] = [
   { quality: false },
   { seeders: false, direction: 'desc' },
   { addon: false },
+  { regexSort: false, direction: 'desc' },
 ];
 
 const defaultResolutions: Resolution[] = [
@@ -219,6 +220,7 @@ export default function Configure() {
     excludePattern?: string;
     includePattern?: string;
   }>({});
+  const [regexSortPattern, setRegexSortPattern] = useState<string>('');
 
   useEffect(() => {
     // get config from the server
@@ -284,6 +286,7 @@ export default function Configure() {
         excludePattern: regexFilters.excludePattern || undefined,
         includePattern: regexFilters.includePattern || undefined
       } : undefined,
+      regexSortPattern: regexSortPattern,
     };
     return config;
   };
@@ -1064,6 +1067,27 @@ export default function Configure() {
           </div>
         )}
 
+        {showApiKeyInput && (
+          <div className={styles.section}>
+            <h2 style={{ padding: '5px' }}>Regex Sort Pattern</h2>
+            <p style={{ padding: '5px' }}>
+              Enter a regex pattern to sort streams. This will sort streams based on whether their filename matches the pattern. Matching files will come first in descending order, and last in ascending order.
+            </p>
+            {/* <div className={styles.settingInput}> */}
+            <input
+              type="text"
+              value={regexSortPattern}
+              onChange={(e) => setRegexSortPattern(e.target.value)}
+              placeholder="Example: \b(3L|BiZKiT|BLURANiUM)"
+              style={{
+                width: '97.5%',
+                padding: '5px',
+                marginLeft: '5px',
+              }}
+              className={styles.input}
+            />
+          </div>
+        )}
         <div className={styles.section}>
           <div className={styles.slidersSetting}>
             <div>

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -181,6 +181,7 @@ export interface Config {
     enabled: boolean;
     credentials: { [key: string]: string };
   }[];
+  regexSortPattern?: string;
 }
 
 interface BaseOptionDetail {


### PR DESCRIPTION
## Description
This PR introduces a new regex-based sorting feature for streams, allowing users to sort streams based on filename pattern matching. The feature is only available to those who have set an API key in .env

## Key Changes
- Added new `regexSort` field to sorting configuration
- Added regex sort configuration in the configure page
- Added validation for regex pattern syntax

## Technical Details
- The sorting is implemented in the `compareByField` method
- Supports both ascending and descending order for matched files
- Regex pattern validation is performed during config validation
- Frontend includes a new input field for regex pattern when API key is set

## Usage
To use the regex sorting:
1. Set an API key in the configuration
2. Enter a valid regex pattern in the "Regex Sort Pattern" field
3. Enable regex sorting in the sort criteria
4. Choose the desired sort direction (ascending/descending), default is descending

## Example
A regex pattern like `\b(3L|BiZKiT|BLURANiUM)` can be used to prioritize streams from specific release groups.

## Security
- Regex sorting requires an API key to be set
- Invalid regex patterns are caught and handled gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new sorting option that allows streams to be sorted based on whether their filenames match a user-defined regular expression pattern.
  - Added a configuration field and UI input for specifying a regex pattern for sorting.
- **Bug Fixes**
  - Improved validation to ensure the regex pattern is valid and that an API key is set when using this sorting feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->