### PR TITLE
fix: regex defaults handling and add case-insensitive matching

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -58,10 +58,10 @@ export class AIOStreams {
     this.config = {
       ...config,
       regexFilters: {
-        excludePattern: config.regexFilters?.excludePattern ?? Settings.DEFAULT_REGEX_EXCLUDE_PATTERN,
-        includePattern: config.regexFilters?.includePattern ?? Settings.DEFAULT_REGEX_INCLUDE_PATTERN
+        excludePattern: config.regexFilters?.excludePattern || Settings.DEFAULT_REGEX_EXCLUDE_PATTERN,
+        includePattern: config.regexFilters?.includePattern || Settings.DEFAULT_REGEX_INCLUDE_PATTERN
       },
-      regexSortPatterns: config.regexSortPatterns ?? Settings.DEFAULT_REGEX_SORT_PATTERNS
+      regexSortPatterns: config.regexSortPatterns || Settings.DEFAULT_REGEX_SORT_PATTERNS
     };
 
     // Pre-compile regex patterns if they exist
@@ -70,14 +70,14 @@ export class AIOStreams {
         .split(/\s+/)
         .filter(Boolean);
       this.preCompiledRegexSortPatterns = regexSortPatterns.map(
-        (pattern) => new RegExp(pattern)
+        (pattern) => new RegExp(pattern, 'i')
       );
     }
     if(this.config?.regexFilters?.includePattern) {
-      this.preCompiledRegexFilterIncludePattern = new RegExp(this.config?.regexFilters?.includePattern);
+      this.preCompiledRegexFilterIncludePattern = new RegExp(this.config?.regexFilters?.includePattern, 'i');
     }
     if(this.config?.regexFilters?.excludePattern) {
-      this.preCompiledRegexFilterExcludePattern = new RegExp(this.config?.regexFilters?.excludePattern);
+      this.preCompiledRegexFilterExcludePattern = new RegExp(this.config?.regexFilters?.excludePattern, 'i');
     }
   }
 


### PR DESCRIPTION
This PR addresses two important issues with regex pattern handling in the AIOStreams addon:

1. **Fixed Default Pattern Handling**
   - Changed the nullish coalescing operator (`??`) to logical OR (`||`) for regex pattern defaults
   - This ensures that empty strings or falsy values from environment variables are properly handled
   - Affects `excludePattern`, `includePattern`, and `regexSortPatterns` configurations

2. **Added Case-Insensitive Matching**
   - Made all regex patterns case-insensitive by default by adding the 'i' flag
   - This improves user experience by making pattern matching more flexible
   - Applied to:
     - Sort patterns
     - Include filter patterns
     - Exclude filter patterns

These changes make the pattern matching more robust and user-friendly while maintaining backward compatibility with existing configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated default assignment logic for regex filters and sort patterns.
	- Made all regex filters and sort patterns case-insensitive for improved matching consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->