### PR TITLE
fix: strict title matching for easynews++ is not passed through

### DIFF
--- a/packages/wrappers/src/easynewsPlusPlus.ts
+++ b/packages/wrappers/src/easynewsPlusPlus.ts
@@ -83,10 +83,10 @@ export async function getEasynewsPlusPlusStreams(
   if (!credentails || !credentails.username || !credentails.password) {
     throw new Error('Easynews credentials not found');
   }
-
   const easynewsPlusConfigString = getEasynewsPlusPlusConfigString(
     credentails.username,
-    credentails.password
+    credentails.password,
+    easynewsPlusOptions.strictTitleMatching
   );
 
   const easynews = new EasynewsPlusPlus(


### PR DESCRIPTION
Didn't work previously, now it does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for strict title matching in EasynewsPlusPlus streams configuration, allowing more precise control over search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->