### PR TITLE
fix: overlapping snippets modal

### DIFF
--- a/packages/frontend/src/components/menu/formatter.tsx
+++ b/packages/frontend/src/components/menu/formatter.tsx
@@ -568,23 +568,23 @@ function SnippetsButton() {
           {SNIPPETS.map((snippet, idx) => (
             <div
               key={idx}
-              className="flex items-center justify-between border rounded-md p-3 bg-gray-900 border-gray-800"
+              className="flex flex-col sm:flex-row sm:items-center sm:justify-between border rounded-md p-3 bg-gray-900 border-gray-800 gap-3"
             >
               <div>
                 <div className="font-semibold text-base mb-1">
                   {snippet.name}
                 </div>
-                <div className="text-sm text-muted-foreground mb-1">
+                <div className="text-sm text-muted-foreground mb-1 break-words">
                   {snippet.description}
                 </div>
-                <div className="font-mono text-xs bg-gray-800 rounded px-2 py-1 inline-block">
+                <div className="font-mono text-xs bg-gray-800 rounded px-2 py-1 inline-block break-all">
                   {snippet.value}
                 </div>
               </div>
               <Button
                 size="sm"
                 intent="primary-outline"
-                className="ml-4"
+                className="sm:ml-4 flex-shrink-0"
                 onClick={async () => {
                   if (!navigator.clipboard) {
                     toast.error(


### PR DESCRIPTION
On Firefox the snippets modal was overlapping

My solution changes the behavior to break-all and not only words. Breaking on words is nicer to look at but unfortunately not responsive when using the formatter syntax that doesn't contain many spaces.

Before:
![image](https://github.com/user-attachments/assets/18750c99-c09a-4937-9eca-30651e4605f1)

After:
![image](https://github.com/user-attachments/assets/fa17a09c-8efd-454b-b725-ea858930b7bd)

