### PR TITLE
improved german language detection + prevent false positives + improved overall result

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -141,7 +141,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     Portuguese: createLanguageRegex('portuguese|por'),
     Spanish: createLanguageRegex('spanish|spa|esp'),
     French: createLanguageRegex('french|fra|fr|vf|vff|vfi|vf2|vfq|truefrench'),
-    German: createLanguageRegex('deu(tsch)?|ger(man)?'),
+    German: (new RegExp(`(?<![^\\s\\[(_\\-.,])((GER(MAN)?|(Ger|ger)(man)?|DE(U)?|(Deu|deu)(tsch)?|DEUTSCH)(?![ .\\-_]?sub(title)?s?))(?=[\\s\\)\\]_.\\-,]|$)`)),
     Italian: createLanguageRegex('italian|ita'),
     Korean: createLanguageRegex('korean|kor'),
     Hindi: createLanguageRegex('hindi|hin'),


### PR DESCRIPTION
in Portuguese and Spanish the 'de' is used as a preposition like 'from/of'  ...

 (which is in a lot of movie/episode titles)

 ... so the filter would find those as well 😦
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of German language tags for greater accuracy when parsing text, ensuring more reliable identification across different formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->