### PR TITLE
fix(webstreamr): add missing emojis to message parser

### DIFF
--- a/packages/core/src/presets/webstreamr.ts
+++ b/packages/core/src/presets/webstreamr.ts
@@ -34,7 +34,7 @@ class WebStreamrStreamParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    const messageRegex = this.getRegexForTextAfterEmojis(['🐢', '🚦']);
+    const messageRegex = this.getRegexForTextAfterEmojis(['🐢', '🚦', '⚠️', '⏳', '❌']);
 
     let messages = [stream.description?.match(messageRegex)?.[1]];
     if (stream.name?.includes('external')) {


### PR DESCRIPTION
taken from https://github.com/webstreamr/webstreamr/blob/c14e1c008affd4ba5089ffa61aeade6b15c2dccc/src/error/index.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for extracting messages marked with additional emojis ('⚠️', '⏳', '❌') from stream descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->