### PR TITLE
feat(frontend): persist user data to local storage

### DIFF
--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -1,14 +1,13 @@
 'use client';
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { TextInput } from '@/components/ui/text-input';
 import { useUserData } from '@/context/userData';
 import { UserConfigAPI } from '@/services/api';
 import { PageWrapper } from '@/components/shared/page-wrapper';
 import { Alert } from '@/components/ui/alert';
 import { SettingsCard } from '../shared/settings-card';
 import { toast } from 'sonner';
-import { CopyIcon, DownloadIcon, PlusIcon, UploadIcon } from 'lucide-react';
+import { DownloadIcon, UploadIcon, BrushCleaningIcon } from 'lucide-react';
 import { useStatus } from '@/context/status';
 import { BiCopy } from 'react-icons/bi';
 import { PageControls } from '../shared/page-controls';
@@ -43,6 +42,7 @@ function Content() {
   const {
     userData,
     setUserData,
+    clearUserData,
     uuid,
     setUuid,
     password,
@@ -311,6 +311,19 @@ function Content() {
         <div className="hidden lg:block lg:ml-auto">
           <PageControls />
         </div>
+      </div>
+
+      <div className="space-y-4 mt-6">
+        <SettingsCard title="Current Changes">
+          <Button
+            onClick={clearUserData}
+            intent="gray"
+            leftIcon={<BrushCleaningIcon />}
+            type="button"
+          >
+            Reset to Defaults
+          </Button>
+        </SettingsCard>
       </div>
 
       <div className="space-y-4 mt-6">

--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -1,13 +1,14 @@
 'use client';
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import { TextInput } from '@/components/ui/text-input';
 import { useUserData } from '@/context/userData';
 import { UserConfigAPI } from '@/services/api';
 import { PageWrapper } from '@/components/shared/page-wrapper';
 import { Alert } from '@/components/ui/alert';
 import { SettingsCard } from '../shared/settings-card';
 import { toast } from 'sonner';
-import { DownloadIcon, UploadIcon, BrushCleaningIcon } from 'lucide-react';
+import { CopyIcon, DownloadIcon, PlusIcon, UploadIcon } from 'lucide-react';
 import { useStatus } from '@/context/status';
 import { BiCopy } from 'react-icons/bi';
 import { PageControls } from '../shared/page-controls';
@@ -42,7 +43,6 @@ function Content() {
   const {
     userData,
     setUserData,
-    clearUserData,
     uuid,
     setUuid,
     password,
@@ -311,19 +311,6 @@ function Content() {
         <div className="hidden lg:block lg:ml-auto">
           <PageControls />
         </div>
-      </div>
-
-      <div className="space-y-4 mt-6">
-        <SettingsCard title="Current Changes">
-          <Button
-            onClick={clearUserData}
-            intent="gray"
-            leftIcon={<BrushCleaningIcon />}
-            type="button"
-          >
-            Reset to Defaults
-          </Button>
-        </SettingsCard>
       </div>
 
       <div className="space-y-4 mt-6">

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -7,6 +7,8 @@ import {
 } from '../../../core/src/utils/constants';
 import { useStatus } from './status';
 
+const USER_DATA_KEY = 'aiostreams-user-data';
+
 const DefaultUserData: UserData = {
   services: Object.values(SERVICE_DETAILS).map((service) => ({
     id: service.id,
@@ -68,12 +70,27 @@ const UserDataContext = React.createContext<UserDataContextType | undefined>(
 
 export function UserDataProvider({ children }: { children: React.ReactNode }) {
   const { status } = useStatus();
-  const [userData, setUserData] = React.useState<UserData>(DefaultUserData);
+
+  // Initialize userData from local storage or apply default
+  const [userData, setUserData] = React.useState<UserData>(() => {
+    try {
+      const stored = localStorage.getItem(USER_DATA_KEY);
+      return stored ? JSON.parse(stored) : DefaultUserData;
+    } catch {
+      return DefaultUserData;
+    }
+  });
+
   const [uuid, setUuid] = React.useState<string | null>(null);
   const [password, setPassword] = React.useState<string | null>(null);
   const [encryptedPassword, setEncryptedPassword] = React.useState<
     string | null
   >(null);
+
+  // Effect to persist userData to local storage
+  React.useEffect(() => {
+    localStorage.setItem(USER_DATA_KEY, JSON.stringify(userData));
+  }, [userData]);
 
   // Effect to apply forced and default values from status
   React.useEffect(() => {

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -56,6 +56,7 @@ const DefaultUserData: UserData = {
 interface UserDataContextType {
   userData: UserData;
   setUserData: (data: ((prev: UserData) => UserData | null) | null) => void;
+  clearUserData: () => void;
   uuid: string | null;
   setUuid: (uuid: string | null) => void;
   password: string | null;
@@ -160,11 +161,16 @@ export function UserDataProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const clearUserData = () => {
+    setUserData(DefaultUserData);
+  };
+
   return (
     <UserDataContext.Provider
       value={{
         userData,
         setUserData: safeSetUserData,
+        clearUserData,
         uuid,
         setUuid,
         password,

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -56,7 +56,6 @@ const DefaultUserData: UserData = {
 interface UserDataContextType {
   userData: UserData;
   setUserData: (data: ((prev: UserData) => UserData | null) | null) => void;
-  clearUserData: () => void;
   uuid: string | null;
   setUuid: (uuid: string | null) => void;
   password: string | null;
@@ -161,16 +160,11 @@ export function UserDataProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const clearUserData = () => {
-    setUserData(DefaultUserData);
-  };
-
   return (
     <UserDataContext.Provider
       value={{
         userData,
         setUserData: safeSetUserData,
-        clearUserData,
         uuid,
         setUuid,
         password,


### PR DESCRIPTION
Closes #352.

See issue above for context. Not sure if this is something you want, open to discuss :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Your settings and profile data are now saved on your device, so they persist across page reloads and when you reopen the app.
  - If previously saved data is unavailable or invalid, the app will safely fall back to default settings to ensure a smooth experience.
  - No changes to how you interact with the app or its visible controls; behaviour remains the same, with added persistence across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->