### PR TITLE
[Bugfix-#355] Update Conditional check to properly typecheck

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -551,17 +551,20 @@ export abstract class BaseFormatter {
         
         // PREFIX
         else if (isPrefix) {
+          // get the longest prefix match
           const modPrefix = Object.keys(conditionalModifiers.prefix).sort((a, b) => b.length - a.length).find(key => mod.startsWith(key))!!;
           
+          // Pre-process string value and check to allow for intuitive comparisons
           const stringValue = value.toString().toLowerCase();
           let stringCheck = mod.substring(modPrefix.length).toLowerCase();
-          // remove spaces/tabs/newlines from stringCheck if they aren't in stringValue
+          // remove whitespace from stringCheck if it isn't in stringValue
           stringCheck = !/\s/.test(stringValue) ? stringCheck.replace(/\s/g, '') : stringCheck;
           
-          const [numericValue, numericCheck] = [Number(value), Number(stringCheck)]
-          // use numeric comparison if possible, otherwise use string (value, check) params
-          const [paramValue, paramCheck] = ["<", "<=", ">", ">="].includes(modPrefix) && 
-            !isNaN(numericValue) && !isNaN(numericCheck) ? [numericValue, numericCheck] : [stringValue, stringCheck]
+          const isNumericComparison = ["<", "<=", ">", ">="].includes(modPrefix) && 
+            !Number.isNaN(Number(stringValue)) && !Number.isNaN(Number(stringCheck));
+          const [paramValue, paramCheck] = isNumericComparison 
+            ? [Number(stringValue), Number(stringCheck)] 
+            : [stringValue, stringCheck];
           
           conditional = conditionalModifiers.prefix[modPrefix as keyof typeof conditionalModifiers.prefix](
             paramValue as any, 

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -211,7 +211,7 @@ export const conditionalModifiers = {
     'exists': (value: any) => {
       // Handle null, undefined, empty strings, empty arrays
       if (value === undefined || value === null) return false;
-      if (typeof value === 'string') return (value.trim().length > 0 && value != 'null' && value != 'undefined');
+      if (typeof value === 'string') return (value.replace(/ /g, '').length > 0);
       if (Array.isArray(value)) return value.length > 0;
       // For other types (numbers, booleans, objects), consider them as "existing"
       return true;
@@ -539,7 +539,15 @@ export abstract class BaseFormatter {
       // try to coerce true/false value from modifier
       let conditional: boolean | undefined;
       try {
-        if (isExact) {
+
+        // PRE-CHECK(s) -- skip resolving conditional modifier if value DNE, defaulting to false conditional
+        if (!conditionalModifiers.exact.exists(value)) {
+          console.log("FORCING FALSE CONDITIONAL")
+          conditional = false;
+        }
+        
+        // EXACT
+        else if (isExact) {
           const modAsKey = mod as keyof typeof conditionalModifiers.exact;
           conditional = conditionalModifiers.exact[modAsKey](value);
         }

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -560,7 +560,7 @@ export abstract class BaseFormatter {
           // remove whitespace from stringCheck if it isn't in stringValue
           stringCheck = !/\s/.test(stringValue) ? stringCheck.replace(/\s/g, '') : stringCheck;
           
-          const isNumericComparison = ["<", "<=", ">", ">="].includes(modPrefix) && 
+          const isNumericComparison = ["<", "<=", ">", ">=", "="].includes(modPrefix) && 
             !Number.isNaN(Number(stringValue)) && !Number.isNaN(Number(stringCheck));
           const [paramValue, paramCheck] = isNumericComparison 
             ? [Number(stringValue), Number(stringCheck)] 

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -211,7 +211,7 @@ export const conditionalModifiers = {
     'exists': (value: any) => {
       // Handle null, undefined, empty strings, empty arrays
       if (value === undefined || value === null) return false;
-      if (typeof value === 'string') return /\S/.test(value);
+      if (typeof value === 'string') return /\S/.test(value); // has at least one non-whitespace character
       if (Array.isArray(value)) return value.length > 0;
       // For other types (numbers, booleans, objects), consider them as "existing"
       return true;

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -211,7 +211,7 @@ export const conditionalModifiers = {
     'exists': (value: any) => {
       // Handle null, undefined, empty strings, empty arrays
       if (value === undefined || value === null) return false;
-      if (typeof value === 'string') return value.replace(/ /g, '').length > 0;
+      if (typeof value === 'string') return /\S/.test(value);
       if (Array.isArray(value)) return value.length > 0;
       // For other types (numbers, booleans, objects), consider them as "existing"
       return true;
@@ -417,7 +417,6 @@ export abstract class BaseFormatter {
     const variable = `(?<variableName>${validVariables.join('|')})\\.(?<propertyName>${validProperties.join('|')})`;
 
     // Dynamically build the `modifier` regex pattern from modifier keys
-    // Sort by length (longest first) to ensure more specific patterns match before shorter ones
     const validModifiers = Object.keys(modifiers)
       .map(key => key.replace(/[\(\)\'\"\$\^\~\=\>\<]/g, '\\$&'));
     
@@ -556,8 +555,8 @@ export abstract class BaseFormatter {
           
           const stringValue = value.toString().toLowerCase();
           let stringCheck = mod.substring(modPrefix.length).toLowerCase();
-          // remove spaces from stringCheck if spaces aren't in stringValue
-          stringCheck = !stringValue.includes(' ') ? stringCheck.replace(/ /g, '') : stringCheck;
+          // remove spaces/tabs/newlines from stringCheck if they aren't in stringValue
+          stringCheck = !/\s/.test(stringValue) ? stringCheck.replace(/\s/g, '') : stringCheck;
           
           const [numericValue, numericCheck] = [Number(value), Number(stringCheck)]
           // use numeric comparison if possible, otherwise use string (value, check) params

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -542,7 +542,6 @@ export abstract class BaseFormatter {
 
         // PRE-CHECK(s) -- skip resolving conditional modifier if value DNE, defaulting to false conditional
         if (!conditionalModifiers.exact.exists(value)) {
-          console.log("FORCING FALSE CONDITIONAL")
           conditional = false;
         }
         

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -419,8 +419,7 @@ export abstract class BaseFormatter {
     // Dynamically build the `modifier` regex pattern from modifier keys
     // Sort by length (longest first) to ensure more specific patterns match before shorter ones
     const validModifiers = Object.keys(modifiers)
-      .map(key => key.replace(/[\(\)\'\"\$\^\~\=\>\<]/g, '\\$&'))
-      .sort((a, b) => b.length - a.length); // Sort by length, longest first
+      .map(key => key.replace(/[\(\)\'\"\$\^\~\=\>\<]/g, '\\$&'));
     
     const modifier = `::(?<mod>${validModifiers.join('|')})`;
     
@@ -553,7 +552,7 @@ export abstract class BaseFormatter {
         
         // PREFIX
         else if (isPrefix) {
-          const modPrefix = Object.keys(conditionalModifiers.prefix).find(key => mod.startsWith(key))!!;
+          const modPrefix = Object.keys(conditionalModifiers.prefix).sort((a, b) => b.length - a.length).find(key => mod.startsWith(key))!!;
           
           var checkKey = mod.substring(modPrefix.length).toLowerCase();
           // remove spaces from checkKey if spaces aren't in value

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -211,7 +211,7 @@ export const conditionalModifiers = {
     'exists': (value: any) => {
       // Handle null, undefined, empty strings, empty arrays
       if (value === undefined || value === null) return false;
-      if (typeof value === 'string') return (value.replace(/ /g, '').length > 0);
+      if (typeof value === 'string') return value.replace(/ /g, '').length > 0;
       if (Array.isArray(value)) return value.length > 0;
       // For other types (numbers, booleans, objects), consider them as "existing"
       return true;
@@ -219,14 +219,14 @@ export const conditionalModifiers = {
   },
 
   prefix: {
-    '$': (value: any, check: any) => value.toLowerCase().startsWith(check.toLowerCase()),
-    '^': (value: any, check: any) => value.toLowerCase().endsWith(check.toLowerCase()),
-    '~': (value: any, check: any) => value.includes(check),
-    '=': (value: any, check: any) => value == check,
-    '>=': (value: any, check: any) => value >= check,
-    '>': (value: any, check: any) => value > check,
-    '<=': (value: any, check: any) => value <= check,
-    '<': (value: any, check: any) => value < check,
+    '$': (value: string, check: string) => value.startsWith(check),
+    '^': (value: string, check: string) => value.endsWith(check),
+    '~': (value: string, check: string) => value.includes(check),
+    '=': (value: string, check: string) => value == check,
+    '>=': (value: string, check: string) => value >= check,
+    '>': (value: string, check: string) => value > check,
+    '<=': (value: string, check: string) => value <= check,
+    '<': (value: string, check: string) => value < check,
   },
 }
 
@@ -491,7 +491,7 @@ export abstract class BaseFormatter {
           str,
           this.modifier(
             matches.groups.mod,
-            property as unknown,
+            property as any,
             matches.groups.mod_tzlocale ?? "",
             matches.groups.mod_check_true ?? "",
             matches.groups.mod_check_false ?? "",
@@ -520,7 +520,7 @@ export abstract class BaseFormatter {
 
   protected modifier(
     mod: string,
-    value: unknown,
+    value: any,
     tzlocale?: string,
     check_true?: string,
     check_false?: string,
@@ -553,16 +553,14 @@ export abstract class BaseFormatter {
         
         // PREFIX
         else if (isPrefix) {
-          for (let key of Object.keys(conditionalModifiers.prefix)) {
-            if (mod.startsWith(key)) {
-              var checkKey = mod.substring(key.length);
-              if (typeof value !== 'string' || !value.includes(' ')) {
-                checkKey = checkKey.replace(/ /g, '');
-              }
-              conditional = conditionalModifiers.prefix[key as keyof typeof conditionalModifiers.prefix](value, checkKey);
-              break;
-            }
+          const modPrefix = Object.keys(conditionalModifiers.prefix).find(key => mod.startsWith(key))!!;
+          
+          var checkKey = mod.substring(modPrefix.length).toLowerCase();
+          // remove spaces from checkKey if spaces aren't in value
+          if (typeof value !== 'string' || !value.includes(' ')) {
+            checkKey = checkKey.replace(/ /g, '');
           }
+          conditional = conditionalModifiers.prefix[modPrefix as keyof typeof conditionalModifiers.prefix](value.toString().toLowerCase(), checkKey);
         }
       } catch (error) {
         conditional = false;

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -560,13 +560,13 @@ export abstract class BaseFormatter {
           // remove whitespace from stringCheck if it isn't in stringValue
           stringCheck = !/\s/.test(stringValue) ? stringCheck.replace(/\s/g, '') : stringCheck;
           
-          // parse check as if it's a number (123,456 -> 123456)
-          const parsedNumericCheck = Number(stringCheck.replace(/,\s/g, ''));
+          // parse value/check as if they're numbers (123,456 -> 123456)
+          const [parsedNumericValue, parsedNumericCheck] = [Number(stringValue.replace(/,\s/g, '')), Number(stringCheck.replace(/,\s/g, ''))];
           const isNumericComparison = ["<", "<=", ">", ">=", "="].includes(modPrefix) && 
-            !isNaN(Number(stringValue)) && !isNaN(parsedNumericCheck);
+            !isNaN(parsedNumericValue) && !isNaN(parsedNumericCheck);
           
           conditional = conditionalModifiers.prefix[modPrefix as keyof typeof conditionalModifiers.prefix](
-            isNumericComparison ? Number(stringValue) as any : stringValue, 
+            isNumericComparison ? parsedNumericValue as any : stringValue, 
             isNumericComparison ? parsedNumericCheck as any : stringCheck,
           );
         }

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -560,15 +560,14 @@ export abstract class BaseFormatter {
           // remove whitespace from stringCheck if it isn't in stringValue
           stringCheck = !/\s/.test(stringValue) ? stringCheck.replace(/\s/g, '') : stringCheck;
           
+          // parse check as if it's a number (123,456 -> 123456)
+          const parsedNumericCheck = Number(stringCheck.replace(/,\s/g, ''));
           const isNumericComparison = ["<", "<=", ">", ">=", "="].includes(modPrefix) && 
-            !Number.isNaN(Number(stringValue)) && !Number.isNaN(Number(stringCheck));
-          const [paramValue, paramCheck] = isNumericComparison 
-            ? [Number(stringValue), Number(stringCheck)] 
-            : [stringValue, stringCheck];
+            !isNaN(Number(stringValue)) && !isNaN(parsedNumericCheck);
           
           conditional = conditionalModifiers.prefix[modPrefix as keyof typeof conditionalModifiers.prefix](
-            paramValue as any, 
-            paramCheck as any
+            isNumericComparison ? Number(stringValue) as any : stringValue, 
+            isNumericComparison ? parsedNumericCheck as any : stringCheck,
           );
         }
       } catch (error) {


### PR DESCRIPTION
Conditionals have been failing due to
- Improperly configured .toString / .toLowerCase / etc (forcing only human input `check` to be lower but not `value`)
- Improperly configured comparison operators for numeric types (causing issues like "2" < "12" to be false when we'd actually want it to be 2 < 12, true)

Updating with proper types and updating logic a bit to cover corner cases that caused this to fail.
Closes https://github.com/Viren070/AIOStreams/issues/355

<img width="495" height="958" alt="image" src="https://github.com/user-attachments/assets/d0ad376b-2f67-460e-a761-1b09001bc7f5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate conditional evaluation with explicit numeric comparisons when values are numeric.
  * Resolved inconsistent whitespace checks; presence detection now uses non-whitespace tests.
  * Conditional branches now receive richer parsing context, improving resolution of true/false branches.

* **Refactor**
  * Comparisons are now case-sensitive by default, improving strictness.
  * Prefix-selection and pattern-generation order changed — may alter matching in some edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->