### PR TITLE
chore(presets/webstreamr): enable multi by default, update provider list

### DIFF
--- a/packages/core/src/presets/webstreamr.ts
+++ b/packages/core/src/presets/webstreamr.ts
@@ -118,15 +118,15 @@ export class WebStreamrPreset extends Preset {
 
     const providers = [
       {
-        label: '🌐 Multi (VixSrc)',
+        label: '🌐 Multi (4KHDHub, VixSrc)',
         value: 'multi',
       },
       {
-        label: '🇺🇸 English (PrimeWire, VidSrc, VixSrc, XPrime)',
+        label: '🇺🇸 English (PrimeWire, Soaper, VidSrc, XPrime)',
         value: 'en',
       },
       {
-        label: '🇩🇪 German (KinoGer, MegaKino, MeineCloud, StreamKiste)',
+        label: '🇩🇪 German (Einschalten, KinoGer, MegaKino, MeineCloud, StreamKiste)',
         value: 'de',
       },
       {
@@ -160,7 +160,7 @@ export class WebStreamrPreset extends Preset {
         description: 'Select the providers to use',
         type: 'multi-select',
         options: providers,
-        default: ['en'],
+        default: ['multi', 'en'],
       },
       {
         id: 'includeExternalUrls',


### PR DESCRIPTION
multi is going to become very useful with the addition of 4KHDHub (https://github.com/webstreamr/webstreamr/releases/tag/v0.47.0) and should be considered to be enabled by default for users who just add that add-on without checking details. multi + en is also webstreamr's default config, see https://github.com/webstreamr/webstreamr/blob/v0.47.0/src/utils/config.ts#L5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default provider selection now includes Multi and English, offering broader results out of the box.
- Style
  - Updated provider labels in the preset to reflect current source names:
    - Multi now shows “4KHDHub, VixSrc”.
    - English now shows “PrimeWire, Soaper, VidSrc, XPrime”.
    - German now shows “Einschalten, KinoGer, MegaKino, MeineCloud, StreamKiste”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->