### PR TITLE
[Formatter Feature] 1) Allow {...} to contain whitespace for readability 2) Allow nested conditionals within conditionals

### DIFF
--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -421,11 +421,11 @@ export const Env = cleanEnv(process.env, {
   }),
   // logging settings
   LOG_SENSITIVE_INFO: bool({
-    default: true,
+    default: false,
     desc: 'Log sensitive information',
   }),
   LOG_LEVEL: str({
-    default: 'debug',
+    default: 'info',
     desc: 'Log level for the addon',
     choices: ['info', 'debug', 'warn', 'error', 'verbose', 'silly', 'http'],
   }),
@@ -435,7 +435,7 @@ export const Env = cleanEnv(process.env, {
     choices: ['text', 'json'],
   }),
   LOG_TIMEZONE: str({
-    default: 'America/New_York',
+    default: 'UTC',
     desc: 'Timezone for log timestamps (e.g., America/New_York, Europe/London)',
   }),
   LOG_CACHE_STATS_INTERVAL: num({

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -421,11 +421,11 @@ export const Env = cleanEnv(process.env, {
   }),
   // logging settings
   LOG_SENSITIVE_INFO: bool({
-    default: false,
+    default: true,
     desc: 'Log sensitive information',
   }),
   LOG_LEVEL: str({
-    default: 'info',
+    default: 'debug',
     desc: 'Log level for the addon',
     choices: ['info', 'debug', 'warn', 'error', 'verbose', 'silly', 'http'],
   }),
@@ -435,7 +435,7 @@ export const Env = cleanEnv(process.env, {
     choices: ['text', 'json'],
   }),
   LOG_TIMEZONE: str({
-    default: 'UTC',
+    default: 'America/New_York',
     desc: 'Timezone for log timestamps (e.g., America/New_York, Europe/London)',
   }),
   LOG_CACHE_STATS_INTERVAL: num({


### PR DESCRIPTION
1) Allows whitespace in template definition between curly braces
- Matching manually rather than via regex for speed and customization ability (including this handy benefit!)
Example (all versions below work)

2) Allows for conditionals to contain full variables (i.e. `{variableType1.propertyName1::modifier1a:modifier1b::comparator1and2::variableType2.propertyName2::modifier2["{variableType3.propertyName3::modifier3["nested true"||"nested false"]"|""]}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for nested variables and modifiers in templates.
  - Case-insensitive matching for template keys.
  - New conditional and timezone/locale modifiers.
  - New newline and remove-line tokens for cleaner output.

- Performance
  - Faster template compilation with parallel processing for name/description.
  - More modular compilation for improved scalability.

- Bug Fixes
  - More consistent error handling during variable parsing.
  - Improved handling of duplicate keys and nested resolution.

- Refactor
  - Overhauled parsing and regex logic to enhance reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->