### PR TITLE
fix: make bluray regex more robust

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -61,7 +61,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
   qualities: {
     'BluRay REMUX': createRegex('(bd|br|b|uhd)?remux'),
     BluRay: createRegex(
-      'blu[ .\\-_]?ray|((bd|br|b)[ .\\-_]?(rip|r)?)(?![ .\\-_]?remux)'
+      '(?<!remux.*)(blu[ .\\-_]?ray|((bd|br)[ .\\-_]?rip))(?!.*remux)'
     ),
     'WEB-DL': createRegex('web[ .\\-_]?(dl)?(?![ .\\-_]?(DLRip|cam))'),
     WEBRip: createRegex('web[ .\\-_]?rip'),


### PR DESCRIPTION
Accounts for titles that contain "remux" and any two letter false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved media quality detection to correctly distinguish BluRay REMUX from standard BluRay rips.
  - Prevented misclassification of releases containing “REMUX” as non-remux BluRay.
  - Enhanced accuracy of quality labels in parsing and display.

- Chores
  - Internal parsing rule tightened to reduce false positives in BluRay quality identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->