### PR TITLE
fix: improve regex parser

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -92,7 +92,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
   audioTags: {
     Atmos: createRegex('atmos'),
     'DD+': createRegex(
-      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+)(?:[ .\\-_]?(5[ .\\-_]?1|7[ .\\-_]?1))?)|e[ .\\-_]?ac[ .\\-_]?3'
+      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+)(?:[ .\\-_]?(2[ .\\-_]?0|5[ .\\-_]?1|7[ .\\-_]?1))?)|e[ .\\-_]?ac[ .\\-_]?3'
     ),
     DD: createRegex(
       '(d(olby)?[ .\\-_]?d(igital)?(?:[ .\\-_]?(5[ .\\-_]?1|7[ .\\-_]?1|2[ .\\-_]?0?))?)|(?<!e[ .\\-_]?)ac[ .\\-_]?3'
@@ -180,5 +180,5 @@ export const PARSE_REGEX: PARSE_REGEX = {
     Latino: createLanguageRegex('latino|lat'),
   },
   releaseGroup:
-    /-[. ]?(?!\d+$|S\d+|\d+x|ep?\d+|[^[]+]$)([^\-. []+[^\-. [)\]\d][^\-. [)\]]*)(?:\[[\w.-]+])?(?=\)|\.\w{2,4}$|$)/i,
+    /-[. ]?(?!\d+$|S\d+|\d+x|ep?\d+|[^[]+]$)([^\-. []+[^\-. [)\]\d][^\-. [)\]]*)(?:\[[\w.-]+])?(?=\)|[.-]+\w{2,4}$|$)/i,
 };

--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -63,7 +63,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     BluRay: createRegex(
       '(?<!remux.*)(blu[ .\\-_]?ray|((bd|br)[ .\\-_]?rip))(?!.*remux)'
     ),
-    'WEB-DL': createRegex('web[ .\\-_]?(dl)?(?![ .\\-_]?(DLRip|cam))'),
+    'WEB-DL': createRegex('web[ .\\-_]?(dl)?(?![ .\\-_]?(rip|DLRip|cam))'),
     WEBRip: createRegex('web[ .\\-_]?rip'),
     HDRip: createRegex('hd[ .\\-_]?rip|web[ .\\-_]?dl[ .\\-_]?rip'),
     'HC HD-Rip': createRegex('hc|hd[ .\\-_]?rip'),
@@ -130,7 +130,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     'Dual Audio': createLanguageRegex(
       'dual[ .\\-_]?(audio|lang(uage)?|flac|ac3|aac2?)'
     ),
-    Dubbed: createLanguageRegex('dub(bed)?'),
+    Dubbed: createLanguageRegex('dub(s|bed|bing)?'),
     English: createLanguageRegex('english|eng'),
     Japanese: createLanguageRegex('japanese|jap|jpn'),
     Chinese: createLanguageRegex('chinese|chi'),


### PR DESCRIPTION
Addresses the following cases:
- https://regex101.com/r/utF2Qs/1 - WEB-DL
- https://regex101.com/r/Ce1EDR/1 - Dubbed
- https://regex101.com/r/C3R1rB/1 - Group Name
- https://regex101.com/r/QrXQsm/1 - DDP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quality detection so WEB-DL variants aren’t mislabelled when small “rip” variants appear in names.
  - Enhanced audio detection to recognise 2.0 DD+ labels in addition to existing bitrates.
  - Broadened language parsing to catch more dubbed variants (e.g., dubs, dubbing).
  - Relaxed trailing-group parsing to better handle varied filename suffix formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->