### PR TITLE
feat: Add truncate(N) modifier to formatter

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -690,6 +690,18 @@ export abstract class BaseFormatter {
           if (!shouldBeUndefined && key && replaceKey)
             return variable.replaceAll(key, replaceKey);
         }
+        case mod.startsWith('truncate(') && mod.endsWith(')'):
+          {
+            // Extract N from truncate(N)
+            const inside = _mod.substring('truncate('.length, _mod.length - 1);
+            const n = parseInt(inside, 10);
+            if (!isNaN(n) && n >= 0) {
+              if (variable.length > n) {
+                return variable.slice(0, n) + '…';
+              }
+              return variable;
+            }
+          }
       }
     }
 
@@ -902,6 +914,7 @@ class ModifierConstants {
     'replace(".*?"\\s*?,\\s*?\".*?\")': null,
     "join('.*?')": null,
     'join(".*?")': null,
+    'truncate(\\d+)': null,
     '$.*?': null,
     '^.*?': null,
     '~.*?': null,


### PR DESCRIPTION
Adds a new ::truncate(N) modifier to the formatter, which truncates a string to N characters and appends a single-character ellipsis (…) to help prevent long strings from cutting off other important information in the Stremio Web UI.

Closes #450  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new truncate modifier for string formatting. When applied with a numeric parameter, it limits strings to a specified character count and appends an ellipsis (…) if the text exceeds the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->