### PR TITLE
fix(formatter): remove trailing whitespace before truncating

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -700,7 +700,9 @@ export abstract class BaseFormatter {
           const n = parseInt(inside, 10);
           if (!isNaN(n) && n >= 0) {
             if (variable.length > n) {
-              return variable.slice(0, n) + '…';
+              // Truncate to N characters and remove trailing whitespace
+              const truncated = variable.slice(0, n).replace(/\s+$/, '');
+              return truncated + '…';
             }
             return variable;
           }


### PR DESCRIPTION
Removes trailing whitespace from truncated strings before appending ellipsis to improve visual formatting

Example:
- "Chainsaw Man - The …" -> "Chainsaw Man - The…"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation to remove trailing whitespace before the ellipsis character, ensuring cleaner and more professional text formatting when text is truncated to a specified length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->