### PR TITLE
cleanTitle(): replace umlaut characters with ASCII equivalents

### DIFF
--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -84,7 +84,11 @@ export function normaliseTitle(title: string) {
 }
 
 export function cleanTitle(title: string) {
-  let cleaned = title.normalize('NFD');
+  const umlautMap: Record<string,string> = {
+    'Ä':'Ae','ä':'ae','Ö':'Oe','ö':'oe','Ü':'Ue','ü':'ue','ß':'ss'
+  };
+  // replace German umlauts with ASCII equivalents, then normalize to NFD
+  let cleaned = title.replace(/[ÄäÖöÜüß]/g, c => umlautMap[c]).normalize('NFD');
 
   for (const char of ['♪', '♫', '★', '☆', '♡', '♥', '-']) {
     cleaned = cleaned.replaceAll(char, ' ');


### PR DESCRIPTION
Update the cleanTitle() function in utils.ts to replace umlaut characters with their ASCII transliterations.
This is the most common naming convention on indexers so this is needed to get good results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced title processing to correctly handle German special characters and umlauts (Ä, ä, Ö, ö, Ü, ü) as well as the ß symbol by converting them to ASCII equivalents. This ensures consistent and reliable text normalisation across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->