### PR TITLE
feat: infer stream language from TMDB translations

### DIFF
--- a/packages/core/src/metadata/utils.ts
+++ b/packages/core/src/metadata/utils.ts
@@ -1,6 +1,14 @@
+export interface TitleWithLanguage {
+  title: string;
+  iso_639_1: string;
+  iso_3166_1?: string;
+  english_name: string;
+}
+
 export interface Metadata {
   title: string;
   titles?: string[];
+  titlesWithLanguages?: TitleWithLanguage[];
   year?: number;
   yearEnd?: number;
   releaseDate?: string;


### PR DESCRIPTION
- Compare unknown language streams against TMDB title translations
- Prioritize explicit language tags in filenames
- Handle multi-language and ambiguous titles appropriately
- Resolves #436 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata now includes language-tagged title information for improved multilingual content handling.
  * Automatic language detection system that infers stream languages from alternative titles when primary language data is unavailable, enhancing accuracy for international content.

* **Improvements**
  * Extended metadata architecture to support language-aware title associations throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->