### PR TITLE
Fix URL formatting for Tabula Rasa

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -43,7 +43,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
           { label: 'SceneNZBs', value: 'https://scenenzbs.com' },
           {
             label: 'Tabula Rasa',
-            value: 'https://www.tabula-rasa.pw/api/v1/  ',
+            value: 'https://www.tabula-rasa.pw/api/v1/',
           },
           {
             label: 'TorBox Search',


### PR DESCRIPTION
Extra space in the URL was causing the addon to query https://www.tabula-rasa.pw/api/v1/%20%20/ , resulting in "Could not get capabilities: 404 - Not Found " error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected a minor formatting issue in preset configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->