### PR TITLE
Parse the elf-verified status from ElfHosted UsenetStreamer instances

### DIFF
--- a/packages/core/src/presets/usenetStreamer.ts
+++ b/packages/core/src/presets/usenetStreamer.ts
@@ -39,7 +39,7 @@ export class UsenetStreamerParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    const status = stream.description?.match(/(✅|⚠️|🚫)/g)?.[0];
+    const status = stream.description?.match(/(🧝|✅|⚠️|🚫)/g)?.[0];
     if (status) return `NZB Health: ${status}`;
   }
 


### PR DESCRIPTION
This PR simply adds the ability for the UsenetStreamer addon from the marketplace to parse the elf emoji returned by ElfHosted UsenetStreamer instances, indicating an internally elf-verified NZB/backbone/pubDate combo (*i.e. pre-checked and expected to be healthy*)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced health status detection for content sources with expanded indicator support. The parser now recognises additional status markers, improving the completeness of health information presented when managing your content library.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->