### PR TITLE
fix: add missing whitespace after proxy URL in the config page

### DIFF
--- a/packages/frontend/src/components/menu/proxy.tsx
+++ b/packages/frontend/src/components/menu/proxy.tsx
@@ -183,13 +183,13 @@ function Content() {
                     ? 'stremthru:8080'
                     : 'mediaflow-proxy:8888'
                   : 'mediaflow-proxy:8888'}
-                as the URL above but then using https://
+                 as the URL above but then using https://
                 {userData.proxy?.id
                   ? userData.proxy.id === 'stremthru'
                     ? 'stremthru.yourdomain.com'
                     : 'mediaflow-proxy.yourdomain.com'
                   : 'mediaflow-proxy.yourdomain.com'}
-                as the public URL.
+                 as the public URL.
               </p>
             </div>
           )}


### PR DESCRIPTION


Before:
<img width="421" height="43" alt="520416496-d791ef80-c658-4a38-ac35-cd613481d2f8" src="https://github.com/user-attachments/assets/260c18e6-04cb-4a06-aee5-6266f1af4acf" />


After:
<img width="421" height="43" alt="520416512-2d564f43-cd7e-45d4-a826-62310fd6eb2c" src="https://github.com/user-attachments/assets/4ecf9ad9-120c-456d-96b1-2a8eaea7c8bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->