### PR TITLE
fix(parser): replace German umlauts with ASCII equivalents in normaliseTitle

### DIFF
--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -3,6 +3,16 @@ import { createLogger } from '../utils/index.js';
 
 const logger = createLogger('parser');
 
+const umlautMap: Record<string, string> = {
+  Ä: 'Ae',
+  ä: 'ae',
+  Ö: 'Oe',
+  ö: 'oe',
+  Ü: 'Ue',
+  ü: 'ue',
+  ß: 'ss',
+};
+
 export function titleMatch(
   parsedTitle: string,
   titles: string[],
@@ -76,6 +86,7 @@ export function preprocessTitle(
 
 export function normaliseTitle(title: string) {
   return title
+    .replace(/[ÄäÖöÜüß]/g, (c) => umlautMap[c])
     .replace(/&/g, 'and')
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
@@ -84,15 +95,6 @@ export function normaliseTitle(title: string) {
 }
 
 export function cleanTitle(title: string) {
-  const umlautMap: Record<string, string> = {
-    Ä: 'Ae',
-    ä: 'ae',
-    Ö: 'Oe',
-    ö: 'oe',
-    Ü: 'Ue',
-    ü: 'ue',
-    ß: 'ss',
-  };
   // replace German umlauts with ASCII equivalents, then normalize to NFD
   let cleaned = title
     .replace(/[ÄäÖöÜüß]/g, (c) => umlautMap[c])


### PR DESCRIPTION
Updates normaliseTitle() to expand German umlauts before normalization. This aligns the behavior with cleanTitle() to ensure consistency between search queries and result matching.

Previously, normaliseTitle() simply stripped diacritics (e.g. ä -> a), while cleanTitle() was updated to expand them (ä -> ae) in PR #481, causing valid search results (which mostly use the expanded form) to be filtered out during strict title matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of German special characters (umlauts and ß) during title normalisation, ensuring consistent conversion and reliable text processing across the app.

* **Chores**
  * Internal cleanup to centralise character mapping for more predictable behaviour without changing public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->