### PR TITLE
fix(debrid): capitalize TV category name for Usenet streams

### DIFF
--- a/packages/core/src/debrid/usenet-stream-base.ts
+++ b/packages/core/src/debrid/usenet-stream-base.ts
@@ -728,7 +728,7 @@ export abstract class UsenetStreamService implements DebridService {
       nzbUrl: maskSensitiveInfo(nzb),
     });
 
-    const category = metadata?.season || metadata?.episode ? 'Tv' : 'Movies';
+    const category = metadata?.season || metadata?.episode ? 'TV' : 'Movies';
     const expectedFolderName = this.getExpectedFolderName(playbackInfo);
 
     // Check if content already exists at the expected path


### PR DESCRIPTION
Changes category name for series in UsenetStreamService from "Tv" to "TV" to ensure consistency with standard Newznab category naming. 
This corrects the folder naming on NzbDAV to ensure content from AIOStreams and other tools like NZBHydra2 all end up in the same "content/TV" folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content category classification for television shows to ensure accurate categorisation of Usenet streams.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->