### PR TITLE
fix(builtins): add year only for movies in debrid addons search

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -588,7 +588,7 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
         );
       }
     } else {
-      addQuery(`${titlePlaceholder}`);
+      addQuery(titlePlaceholder);
     }
     return queries;
   }


### PR DESCRIPTION
Closes https://github.com/Viren070/AIOStreams/issues/535

The refactor changes in https://github.com/Viren070/AIOStreams/commit/6306c7c33aee6b185940f37a0c929c40ddd19c94#diff-14bc75d775fcb724c01be16c389951782227dad14cb3dd47cf240e2f1284d0dcL139-L145 look like it was not adding the year for series before as fallback. based on that, I thought this is the simplest fix that avoids making this logic more complicated on any side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Year suffixes now appear only for movies when applicable.
  * Series preserve season/episode formatting when requested.
  * Non-movie/non-series items reliably show a base title placeholder to avoid missing or misleading tags.
  * Simplified title-year behaviour to ensure consistent display when year metadata is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->