### PR TITLE
fix(debrid): lowercase movies category name for Usenet streams

### DIFF
--- a/packages/core/src/debrid/usenet-stream-base.ts
+++ b/packages/core/src/debrid/usenet-stream-base.ts
@@ -728,7 +728,7 @@ export abstract class UsenetStreamService implements DebridService {
       nzbUrl: maskSensitiveInfo(nzb),
     });
 
-    const category = metadata?.season || metadata?.episode ? 'TV' : 'Movies';
+    const category = metadata?.season || metadata?.episode ? 'TV' : 'movies';
     const expectedFolderName = this.getExpectedFolderName(playbackInfo);
 
     // Check if content already exists at the expected path


### PR DESCRIPTION
fix(debrid): lowercase movies category name for Usenet streams

almost the same as #538 but for movies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardised content category naming convention in Usenet stream processing to ensure consistent categorisation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->