### PR TITLE
feat(core): add FETCH_TRAKT_ALIASES env var to toggle Trakt alias fetching

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -225,6 +225,7 @@ TMDB_ACCESS_TOKEN=
 TMDB_API_KEY=
 
 # Provide a trakt client ID for authorised requests to get trakt aliases.
+FETCH_TRAKT_ALIASES=true
 TRAKT_CLIENT_ID=
 
 # Configure API keys for debrid services and others you plan to use.

--- a/packages/core/src/metadata/service.ts
+++ b/packages/core/src/metadata/service.ts
@@ -5,7 +5,7 @@ import { getTraktAliases } from './trakt.js';
 import { IMDBMetadata } from './imdb.js';
 import { createLogger, getTimeTakenSincePoint } from '../utils/logger.js';
 import { TYPES } from '../utils/constants.js';
-import { AnimeDatabase, IdParser, ParsedId } from '../utils/index.js';
+import { AnimeDatabase, IdParser, ParsedId, Env } from '../utils/index.js';
 import { withRetry } from '../utils/general.js';
 import { Meta } from '../db/schemas.js';
 import { TVDBMetadata } from './tvdb.js';
@@ -122,7 +122,7 @@ export class MetadataService {
             }
 
             // Trakt aliases
-            if (imdbId) {
+            if (imdbId && Env.FETCH_TRAKT_ALIASES) {
               promises.push(getTraktAliases(id));
             } else {
               promises.push(Promise.resolve(undefined));

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -430,6 +430,10 @@ export const Env = cleanEnv(process.env, {
     default: undefined,
     desc: 'Trakt Client ID. Used for fetching Trakt aliases.',
   }),
+  FETCH_TRAKT_ALIASES: bool({
+    default: true,
+    desc: 'Fetch Trakt aliases. Defaults to true.',
+  }),
   PROVIDE_STREAM_DATA: boolOrList<boolean | string[] | undefined>({
     default: undefined,
     desc: 'Provide stream data to the client in stream responses. Required for users to wrap this addon within another AIOStreams instance.',


### PR DESCRIPTION
Adds a new environment variable 'FETCH_TRAKT_ALIASES' (default: 'true') to allow users to toggle fetching of Trakt aliases during metadata retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control Trakt alias fetching, enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->