### PR TITLE
fix(parser/regex): fix Atmos/DD+ audio tags

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -94,7 +94,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
   audioTags: {
     Atmos: createRegex('atmos|ddpa\\d?'),
     'DD+': createRegex(
-      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+|pa)(?:[ .\\-_]?(2[ .\\-_]?0|5[ .\\-_]?1|7[ .\\-_]?1))?)|e[ .\\-_]?ac[ .\\-_]?3'
+      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?((p(lus)?|\\+)a?)(?:[ .\\-_]?(2[ .\\-_]?0|5[ .\\-_]?1|7[ .\\-_]?1))?)|e[ .\\-_]?ac[ .\\-_]?3'
     ),
     DD: createRegex(
       '(d(olby)?[ .\\-_]?d(igital)?(?:[ .\\-_]?(5[ .\\-_]?1|7[ .\\-_]?1|2[ .\\-_]?0?))?)|(?<!e[ .\\-_]?)ac[ .\\-_]?3'


### PR DESCRIPTION
- Fix Atmos audio tag regex to include ddpa
- Fix DD+ audio tag regex to support optional 'a' suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Atmos and Dolby Digital Plus audio format variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->