### PR TITLE
fix(presets/stremthru-torz): use correct default timeout env variable

### DIFF
--- a/packages/core/src/presets/stremthruTorz.ts
+++ b/packages/core/src/presets/stremthruTorz.ts
@@ -54,7 +54,7 @@ export class StremthruTorzPreset extends StremThruPreset {
       ...baseOptions(
         'StremThru Torz',
         supportedResources,
-        Env.DEFAULT_STREMTHRU_STORE_TIMEOUT,
+        Env.DEFAULT_STREMTHRU_TORZ_TIMEOUT,
         Env.STREMTHRU_TORZ_URL
       ),
       {


### PR DESCRIPTION
just a drive-by PR since I noticed the seemingly wrong env var in use here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default timeout configuration for the StremthruTorz preset to ensure consistent timeout handling across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->