### PR TITLE
feat: disable stream cache for library add-ons

### DIFF
--- a/packages/core/src/wrapper.ts
+++ b/packages/core/src/wrapper.ts
@@ -213,7 +213,7 @@ export class Wrapper {
       { type, id },
       this.addon.timeout,
       validator,
-      Env.STREAM_CACHE_TTL != -1 ? streamsCache : undefined,
+      Env.STREAM_CACHE_TTL != -1 && !this.addon.library ? streamsCache : undefined,
       Env.STREAM_CACHE_TTL,
       this.preset.getCacheKey({
         resource: 'stream',


### PR DESCRIPTION
Closes https://github.com/Viren070/AIOStreams/issues/580

Simplest way of dealing with that, check proposed solutions there for possible alternatives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified stream caching behaviour for library addons to improve performance and resource management. Stream caching is now disabled for library addons, whilst remaining active for standard addons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->