### PR TITLE
Fix label casing and add VixSrc entry to nuivo streams

### DIFF
--- a/packages/core/src/presets/nuviostreams.ts
+++ b/packages/core/src/presets/nuviostreams.ts
@@ -113,11 +113,15 @@ export class NuvioStreamsPreset extends Preset {
       },
       {
         value: 'vidzee',
-        label: 'Vidzee',
+        label: 'VidZee',
       },
       {
         value: 'vidsrc',
-        label: 'Vidsrc',
+        label: 'VidSrc',
+      },
+      {
+        value: 'vixsrc',
+        label: 'VixSrc',
       },
       {
         value: 'mp4hydra',


### PR DESCRIPTION
Corrected the casing of labels for VidZee and VidSrc, and added a new entry for VixSrc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider label capitalisations for improved consistency.

* **New Features**
  * Added a new provider option to the available streaming services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->