### PR TITLE
feat: allow disabling stream types

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -408,6 +408,11 @@ ALTERNATE_DESIGN=false
 # Disabling this means users cannot wrap your AIOStreams instance.
 # PROVIDE_STREAM_DATA=
 
+# --- Disabled Stream Types ---
+# Comma-separated list of stream types that should always be removed from responses.
+# Example: DISABLED_STREAM_TYPES=p2p,http,live
+# DISABLED_STREAM_TYPES=
+
 # --- Search API -----
 # Control whether to serve a search API for easier access to results through AIOStreams
 # at the /api/v1/search endpoint. 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -157,11 +157,15 @@ export class AIOStreams {
   ): Promise<
     AIOStreamsResponse<{
       streams: ParsedStream[];
-      statistics: { title: string; description: string }[];
+      statistics: { title: string; description: string; forced?: boolean }[];
     }>
   > {
     logger.info(`Handling stream request`, { type, id });
-    const statistics: { title: string; description: string }[] = [];
+    const statistics: {
+      title: string;
+      description: string;
+      forced?: boolean;
+    }[] = [];
     // get a list of all addons that support the stream resource with the given type and id.
     const supportedAddons = [];
     for (const [instanceId, addonResources] of Object.entries(
@@ -234,6 +238,36 @@ export class AIOStreams {
     let finalStreams = processResults.streams;
     const pipelineTimings = processResults.timings;
     errors.push(...processResults.errors);
+
+    // Force-remove disabled stream types (instance-level override, bypasses user config)
+    if (FeatureControl.disabledStreamTypes.size > 0) {
+      const removedByType = new Map<string, number>();
+      finalStreams = finalStreams.filter((stream) => {
+        if (FeatureControl.disabledStreamTypes.has(stream.type)) {
+          removedByType.set(
+            stream.type,
+            (removedByType.get(stream.type) ?? 0) + 1
+          );
+          return false;
+        }
+        return true;
+      });
+      if (removedByType.size > 0) {
+        const total = [...removedByType.values()].reduce((a, b) => a + b, 0);
+        const lines: string[] = [
+          `⚠️ The following stream types have been disabled by the instance owner.`,
+          `📌 Disabled Stream Types (${total})`,
+        ];
+        for (const [type, count] of removedByType.entries()) {
+          lines.push(`    • ${count}× ${type}`);
+        }
+        statistics.push({
+          title: '🚫 Removal Reasons',
+          description: lines.join('\n').trim(),
+          forced: true,
+        });
+      }
+    }
 
     // if this.userData.precacheNextEpisode is true, start a new thread to request the next episode, check if
     // all provider streams are uncached, and only if so, then send a request to the first uncached stream in the list.

--- a/packages/core/src/transformers/api.ts
+++ b/packages/core/src/transformers/api.ts
@@ -74,7 +74,7 @@ export class ApiTransformer {
   async transformStreams(
     response: AIOStreamsResponse<{
       streams: ParsedStream[];
-      statistics: { title: string; description: string }[];
+      statistics: { title: string; description: string; forced?: boolean }[];
     }>,
     requiredFields: SearchApiResultField[]
   ): Promise<SearchApiResponseData> {

--- a/packages/core/src/transformers/chilllink.ts
+++ b/packages/core/src/transformers/chilllink.ts
@@ -47,7 +47,7 @@ export class ChillLinkTransformer {
   async transformStreams(
     response: AIOStreamsResponse<{
       streams: ParsedStream[];
-      statistics: { title: string; description: string }[];
+      statistics: { title: string; description: string; forced?: boolean }[];
     }>,
     formatterContext: FormatterContext
   ): Promise<ChillLinkResponseData> {

--- a/packages/core/src/transformers/stremio.ts
+++ b/packages/core/src/transformers/stremio.ts
@@ -156,7 +156,7 @@ export class StremioTransformer {
   async transformStreams(
     response: AIOStreamsResponse<{
       streams: ParsedStream[];
-      statistics: { title: string; description: string }[];
+      statistics: { title: string; description: string; forced?: boolean }[];
     }>,
     formatterContext: FormatterContext,
     options?: { provideStreamData?: boolean; disableAutoplay?: boolean }
@@ -197,16 +197,31 @@ export class StremioTransformer {
       );
     }
 
+    const toStatisticStream = (statistic: { title: string; description: string }) => ({
+      name: statistic.title,
+      description: statistic.description,
+      externalUrl: 'https://github.com/Viren070/AIOStreams',
+      streamData: {
+        type: constants.STATISTIC_STREAM_TYPE,
+      },
+    });
+
+    const forcedStats = statistics.filter((s) => s.forced);
+    const userStats = statistics.filter((s) => !s.forced);
+
+    const position = this.userData.statistics?.position || 'bottom';
+
+    // Forced stats always surface regardless of user config, but respect position
+    if (forcedStats.length > 0) {
+      if (position === 'bottom') {
+        transformedStreams.push(...forcedStats.map(toStatisticStream));
+      } else {
+        transformedStreams.unshift(...forcedStats.map(toStatisticStream));
+      }
+    }
+
     if (this.userData.statistics?.enabled) {
-      let position = this.userData.statistics?.position || 'bottom';
-      let statisticStreams = statistics.map((statistic) => ({
-        name: statistic.title,
-        description: statistic.description,
-        externalUrl: 'https://github.com/Viren070/AIOStreams',
-        streamData: {
-          type: constants.STATISTIC_STREAM_TYPE,
-        },
-      }));
+      const statisticStreams = userStats.map(toStatisticStream);
       if (position === 'bottom') {
         transformedStreams.push(...statisticStreams);
       } else {

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -613,6 +613,10 @@ export const Env = cleanEnv(process.env, {
     default: undefined,
     desc: 'Comma separated list of disabled services in format of service:reason',
   }),
+  DISABLED_STREAM_TYPES: commaSeparated({
+    default: undefined,
+    desc: 'Comma separated list of stream types that should never be returned to clients (e.g., p2p,http,live).',
+  }),
   REGEX_FILTER_ACCESS: str({
     default: 'trusted',
     desc: 'Who can use regex filters',

--- a/packages/core/src/utils/feature.ts
+++ b/packages/core/src/utils/feature.ts
@@ -1,10 +1,11 @@
 import { Env } from './env.js';
+import { StreamType } from './constants.js';
 
 const DEFAULT_REASON = 'Disabled by owner of the instance';
 
 /**
  * Manages instance-level feature controls:
- *   - Disabled hosts, addons, and services
+ *   - Disabled hosts, addons, services, and stream types
  *   - Regex filter access level
  */
 export class FeatureControl {
@@ -39,6 +40,16 @@ export class FeatureControl {
       }
     }
     return map;
+  })();
+
+  public static readonly disabledStreamTypes: Set<StreamType> = (() => {
+    const set = new Set<StreamType>();
+    if (Env.DISABLED_STREAM_TYPES) {
+      for (const type of Env.DISABLED_STREAM_TYPES) {
+        set.add(type as StreamType);
+      }
+    }
+    return set;
   })();
 
   public static readonly regexFilterAccess: 'none' | 'trusted' | 'all' =

--- a/packages/core/src/utils/startup.ts
+++ b/packages/core/src/utils/startup.ts
@@ -356,11 +356,13 @@ const logStartupInfo = () => {
   const blockedHosts = parseBlockedItems(Env.DISABLED_HOSTS);
   const blockedAddons = parseBlockedItems(Env.DISABLED_ADDONS);
   const blockedServices = parseBlockedItems(Env.DISABLED_SERVICES);
+  const disabledStreamTypes = Env.DISABLED_STREAM_TYPES ?? [];
 
   if (
     blockedHosts.length > 0 ||
     blockedAddons.length > 0 ||
-    blockedServices.length > 0
+    blockedServices.length > 0 ||
+    disabledStreamTypes.length > 0
   ) {
     logSection('BLOCKED ITEMS', '🚫', () => {
       if (blockedHosts.length > 0) {
@@ -388,6 +390,12 @@ const logStartupInfo = () => {
         });
       } else {
         logKeyValue('Blocked Services:', '❌ None');
+      }
+
+      if (disabledStreamTypes.length > 0) {
+        logKeyValue('Disabled Stream Types:', disabledStreamTypes.join(', '));
+      } else {
+        logKeyValue('Disabled Stream Types:', '❌ None');
       }
     });
   }


### PR DESCRIPTION
We've implemented this on the ElfHosted instance as of 1 Jan 2026, allowing us to apply our new policy of disabling non-debrid streams (P2P, live, HTTP) on our public instances. I've tried to make it as consistent as possible with the existing `DISABLED_` options, and it adds a statistics entry if streams were disabled due to operator policy, like this:

<img width="377" height="257" alt="Monosnap Image 2026-01-01 11-57-53" src="https://github.com/user-attachments/assets/48152c17-0682-4e6c-8bf8-1946aa9ddba9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configuration to disable specific stream types via a comma‑separated list (e.g. p2p,http,live).
  * Disabled stream types are automatically filtered from results and a summary statistic is appended showing counts removed by type.
  * Support for "forced" statistics so certain summary entries always appear regardless of user settings.
  * Startup info now reports configured disabled stream types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->