### PR TITLE
fix(parser/regex): handle optional 'a' after ddp for audio channel patterns

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -113,13 +113,13 @@ export const PARSE_REGEX: PARSE_REGEX = {
   audioChannels: {
     '2.0': createRegex('(d(olby)?[ .\\-_]?d(igital)?)?2[ .\\-_]?0(ch)?'),
     '5.1': createRegex(
-      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+)?)?5[ .\\-_]?1(ch)?'
+      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?((p(lus)?|\\+)a?)?)?5[ .\\-_]?1(ch)?'
     ),
     '6.1': createRegex(
-      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+)?)?6[ .\\-_]?1(ch)?'
+      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?((p(lus)?|\\+)a?)?)?6[ .\\-_]?1(ch)?'
     ),
     '7.1': createRegex(
-      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?(p(lus)?|\\+)?)?7[ .\\-_]?1(ch)?'
+      '(d(olby)?[ .\\-_]?d(igital)?[ .\\-_]?((p(lus)?|\\+)a?)?)?7[ .\\-_]?1(ch)?'
     ),
   },
   encodes: {


### PR DESCRIPTION
**Issue:** Audio channel patterns were not matching ddpa5.1 formats
**Root Cause:** The regex pattern for audio channels didn't account for the optional 'a' in ddpa (Dolby Digital Plus Atmos) formats
**Solution:** Updated 5.1, 6.1, and 7.1 audio channel patterns to include ((p(lus)?|\+)a?)? instead of (p(lus)?|\+)? to support the optional 'a' suffix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced detection of 5.1, 6.1, and 7.1 Dolby Digital and Digital+ audio channel configurations for improved accuracy in media parsing and recognition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->