### PR TITLE
chore(presets/newznab): add ClubNZB

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -59,6 +59,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
             label: 'AnimeTosho',
             value: 'https://feed.animetosho.org/',
           },
+          { label: 'ClubNZB', value: 'https://clubnzb.com/' },
           { label: 'DOGnzb', value: 'https://api.dognzb.cr/' },
           { label: 'DrunkenSlug', value: 'https://drunkenslug.com/' },
           { label: 'Miatrix', value: 'https://www.miatrix.com' },


### PR DESCRIPTION
this is on the same level as nzbstars. it's a simple free indexer with no limits and no api key needed. they might be even returning the same results often tbh. thought that it might be interesting still for people who want to collect all of those

see https://www.sb-innovation.de/showthread.php?35674-API-Indexers-Table-(With-Tiers-and-Prices)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClubNZB provider support to the Newznab preset, enabling users to configure and use ClubNZB (https://clubnzb.com/) as a search source.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->