### PR TITLE
feat: extend forceToTop feature for addons

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -119,6 +119,13 @@ export type Resource = z.infer<typeof ResourceSchema>;
 
 const ResourceList = z.array(ResourceSchema);
 
+const ForceToTopSchema = z.union([
+  z.boolean(),
+  z.enum(['streams', 'catalogs', 'both', 'none']),
+]);
+
+export type ForceToTopSetting = z.infer<typeof ForceToTopSchema>;
+
 const AddonSchema = z.object({
   instanceId: z.string().min(1).optional(), // uniquely identifies the addon in a given list of addons
   preset: z.object({
@@ -137,7 +144,7 @@ const AddonSchema = z.object({
   library: z.boolean().optional(),
   formatPassthrough: z.boolean().optional(),
   resultPassthrough: z.boolean().optional(),
-  forceToTop: z.boolean().optional(),
+  forceToTop: ForceToTopSchema.optional(),
   headers: z.record(z.string().min(1), z.string().min(1)).optional(),
   ip: z.union([z.ipv4(), z.ipv6()]).optional(),
 });

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -330,6 +330,7 @@ const MergedCatalog = z.object({
       'releaseDateDesc', // sort by release date (newest first)
     ])
     .optional(), // defaults to 'sequential' if not specified
+  forceToTop: z.boolean().optional(), // push this merged catalog above others when true
 });
 
 export type MergedCatalog = z.infer<typeof MergedCatalog>;

--- a/packages/core/src/presets/custom.ts
+++ b/packages/core/src/presets/custom.ts
@@ -3,6 +3,8 @@ import { Preset, baseOptions } from './preset.js';
 import { Env, RESOURCES } from '../utils/index.js';
 import { constants } from '../utils/index.js';
 
+type ForceToTopOption = 'streams' | 'catalogs' | 'both' | 'none';
+
 export class CustomPreset extends Preset {
   static override get METADATA() {
     const options: Option[] = [
@@ -100,10 +102,16 @@ export class CustomPreset extends Preset {
         id: 'forceToTop',
         name: 'Force to Top',
         description:
-          'Whether to force results from this addon to be pushed to the top of the stream list.',
-        type: 'boolean',
+          'Choose whether streams and/or catalogs from this addon should be pinned to the top.',
+        type: 'select',
         required: false,
-        default: false,
+        default: 'none',
+        options: [
+          { label: 'Neither', value: 'none' },
+          { label: 'Streams only', value: 'streams' },
+          { label: 'Catalogs only', value: 'catalogs' },
+          { label: 'Streams and catalogs', value: 'both' },
+        ],
       },
     ];
 
@@ -148,6 +156,8 @@ export class CustomPreset extends Preset {
     userData: UserData,
     options: Record<string, any>
   ): Addon {
+    const forceToTop = this.normalizeForceToTop(options.forceToTop);
+
     return {
       name: options.name || this.METADATA.NAME,
       manifestUrl: options.manifestUrl,
@@ -164,10 +174,28 @@ export class CustomPreset extends Preset {
       formatPassthrough:
         options.formatPassthrough ?? options.streamPassthrough ?? false,
       resultPassthrough: options.resultPassthrough ?? false,
-      forceToTop: options.forceToTop ?? false,
+      forceToTop,
       headers: {
         'User-Agent': this.METADATA.USER_AGENT,
       },
     };
+  }
+
+  private static normalizeForceToTop(
+    forceToTop: any
+  ): ForceToTopOption {
+    if (forceToTop === 'streams' || forceToTop === 'catalogs') {
+      return forceToTop;
+    }
+    if (forceToTop === 'both') {
+      return 'both';
+    }
+    if (forceToTop === 'none' || forceToTop === false || forceToTop === undefined) {
+      return 'none';
+    }
+    if (forceToTop === true) {
+      return 'streams';
+    }
+    return 'none';
   }
 }

--- a/packages/core/src/streams/sorter.ts
+++ b/packages/core/src/streams/sorter.ts
@@ -19,9 +19,11 @@ class StreamSorter {
     type: string
   ): Promise<ParsedStream[]> {
     const forcedToTopStreams = allStreams.filter(
-      (stream) => stream.addon.forceToTop
+      (stream) => StreamSorter.shouldForceStreamToTop(stream.addon.forceToTop)
     );
-    const streams = allStreams.filter((stream) => !stream.addon.forceToTop);
+    const streams = allStreams.filter(
+      (stream) => !StreamSorter.shouldForceStreamToTop(stream.addon.forceToTop)
+    );
 
     let primarySortCriteria = this.userData.sortCriteria.global;
     let cachedSortCriteria = this.userData.sortCriteria.cached;
@@ -133,6 +135,16 @@ class StreamSorter {
       } streams in ${getTimeTakenSincePoint(start)}`
     );
     return [...forcedToTopStreams, ...sortedStreams];
+  }
+
+  private static shouldForceStreamToTop(
+    forceToTop: ParsedStream['addon']['forceToTop']
+  ): boolean {
+    return (
+      forceToTop === true ||
+      forceToTop === 'streams' ||
+      forceToTop === 'both'
+    );
   }
 
   private dynamicSortKey(

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -898,6 +898,14 @@ function validateOption(
     }
     return value;
   }
+  if (
+    option.id === 'forceToTop' &&
+    option.type === 'select' &&
+    typeof value === 'boolean'
+  ) {
+    // Legacy boolean configs: true means streams-only, false means none
+    value = value ? 'streams' : 'none';
+  }
   if (option.type === 'multi-select') {
     if (!Array.isArray(value)) {
       throw new Error(

--- a/packages/frontend/src/components/menu/addons.tsx
+++ b/packages/frontend/src/components/menu/addons.tsx
@@ -1809,6 +1809,7 @@ function MergedCatalogsCard() {
   ]);
   const [mergeMethod, setMergeMethod] =
     useState<MergedCatalog['mergeMethod']>('sequential');
+  const [forceToTop, setForceToTop] = useState(false);
   const [catalogSearch, setCatalogSearch] = useState('');
   const [expandedAddons, setExpandedAddons] = useState<Set<string>>(new Set());
   const [pendingDeleteMergedCatalogId, setPendingDeleteMergedCatalogId] =
@@ -1922,6 +1923,7 @@ function MergedCatalogsCard() {
     setSelectedCatalogs([]);
     setDedupeMethods(['id']);
     setMergeMethod('sequential');
+    setForceToTop(false);
     setCatalogSearch('');
     setExpandedAddons(new Set());
     setModalOpen(true);
@@ -1934,6 +1936,7 @@ function MergedCatalogsCard() {
     setSelectedCatalogs(mergedCatalog.catalogIds);
     setDedupeMethods(mergedCatalog.deduplicationMethods ?? ['id']);
     setMergeMethod(mergedCatalog.mergeMethod ?? 'sequential');
+    setForceToTop(mergedCatalog.forceToTop ?? false);
     setCatalogSearch('');
     setExpandedAddons(new Set());
     setModalOpen(true);
@@ -1982,6 +1985,7 @@ function MergedCatalogsCard() {
                 deduplicationMethods:
                   dedupeMethods.length > 0 ? dedupeMethods : undefined,
                 mergeMethod: mergeMethod ?? 'sequential',
+                forceToTop,
               }
             : mc
         ),
@@ -2002,6 +2006,7 @@ function MergedCatalogsCard() {
             deduplicationMethods:
               dedupeMethods.length > 0 ? dedupeMethods : undefined,
             mergeMethod: mergeMethod ?? 'sequential',
+            forceToTop,
           },
         ],
       }));
@@ -2439,6 +2444,16 @@ function MergedCatalogsCard() {
               setMergeMethod(v as MergedCatalog['mergeMethod'])
             }
           />
+
+          <div className="flex items-center justify-between rounded-[--radius-md] border px-3 py-2">
+            <div>
+              <p className="text-sm font-medium">Force to Top</p>
+              <p className="text-xs text-[--muted]">
+                Pin this merged catalog above others in the catalog list.
+              </p>
+            </div>
+            <Switch value={forceToTop} onValueChange={setForceToTop} />
+          </div>
 
           {(mergeMethod === 'imdbRating' ||
             mergeMethod === 'releaseDateDesc' ||


### PR DESCRIPTION
- Updated schemas to allow forceToTop to accept multiple types: boolean, 'streams', 'catalogs', 'both', 'none'.
- Enhanced AIOStreams class to manage catalogs that should be forced to the top during resource fetching.
- Modified CustomPreset to provide a select option for forceToTop with appropriate labels.
- Updated StreamSorter to prioritize streams marked with forceToTop.
- Adjusted config validation to handle legacy boolean values for forceToTop.
- This is specifically useful for addons with dynamic catalogs like watchly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular force-to-top control: select none, streams, catalogues or both to promote items to the top.
  * UI option to mark merged catalogues as force-to-top and persist that setting.
  * Runtime normalization and legacy boolean compatibility for existing settings.

* **Behaviour**
  * Fetch/sort now places forced items ahead of others while preserving relative order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->