### PR TITLE
Change sootio default url to developers' own instance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -698,7 +698,7 @@ PRUNE_MAX_DAYS=-1
 # FORCE_STREMTHRU_TORZ_PROTOCOL=
 
 # --------- Sootio ---------
-# SOOTIO_URL=https://sootio.elfhosted.com
+# SOOTIO_URL=https://sooti.info
 # DEFAULT_SOOTIO_TIMEOUT=
 
 # --------- EASYNEWS+ ADDON ---------

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1307,7 +1307,7 @@ export const Env = cleanEnv(process.env, {
   }),
 
   SOOTIO_URL: urlOrUrlList({
-    default: ['https://sootio.elfhosted.com'],
+    default: ['https://sooti.info'],
     desc: 'Sootio URL',
   }),
   DEFAULT_SOOTIO_TIMEOUT: num({


### PR DESCRIPTION
[Elfhosted Sootio](https://sootio-has-moved-out.elfhosted.com/) instance has been deprecated in favor of the developers own instance: https://sooti.info/

<img width="364" height="436" alt="firefox_JMGuodhMVA" src="https://github.com/user-attachments/assets/dcb503a1-e171-4c92-ac7e-fc3a39cfe7c1" />

I have tested the functionality to the new instance by changing the URL. Everything works as expected:

<img width="519" height="947" alt="firefox_9T7yf4mJAC" src="https://github.com/user-attachments/assets/bb702519-3ab8-4397-8c92-a070cfee11a1" />

This change will fix the default Sootio addon to use the correct URL.
