### PR TITLE
change Comet default url to developers' own instance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -649,8 +649,8 @@ PRUNE_MAX_DAYS=-1
 
 # ----------- COMET ------------
 # This can also be set to a list of URLs which would show as options to users when configuring
-# e.g. COMET_URL='["https://comet.elfhosted.com", "https://comet.example.com"]'
-# COMET_URL=https://comet.elfhosted.com/
+# e.g. COMET_URL='["https://comet.feels.legal", "https://comet.example.com"]'
+# COMET_URL=https://comet.feels.legal/
 # DEFAULT_COMET_TIMEOUT=
 # Advanced: Override Comet hostname/port/protocol if COMET_URL is internal but needs to be public-facing.
 # Only uncomment and set if needed. Usually, leave these commented.

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -972,7 +972,7 @@ export const Env = cleanEnv(process.env, {
   }),
 
   COMET_URL: urlOrUrlList({
-    default: ['https://comet.elfhosted.com'],
+    default: ['https://comet.feels.legal'],
     desc: 'Comet URL',
   }),
   FORCE_COMET_HOSTNAME: host({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated COMET service endpoint configuration to point to a new default URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->