### PR TITLE
Fix: Update DefaultUserData

### DIFF
--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -234,6 +234,39 @@ const DefaultUserData: UserData = {
     uncached: 'per_service',
     p2p: 'single_result',
   },
+  autoPlay: {
+    enabled: true,
+    method: 'matchingFile',
+    attributes: ['resolution', 'quality', 'releaseGroup'],
+  },
+  cacheAndPlay: {
+    enabled: false,
+    streamTypes: ['usenet'],
+  },
+  statistics: {
+    enabled: false,
+    position: 'bottom',
+    statsToShow: ['addon', 'filter'],
+  },
+  digitalReleaseFilter: {
+    enabled: false,
+    tolerance: 0,
+    requestTypes: [],
+    addons: [],
+  },
+  ageRangeTypes: ['usenet'],
+  seasonEpisodeMatching: {
+    addons: [],
+    requestTypes: [],
+  },
+  yearMatching: {
+    addons: [],
+    requestTypes: [],
+  },
+  titleMatching: {
+    addons: [],
+    requestTypes: [],
+  },
 };
 
 interface UserDataContextType {


### PR DESCRIPTION
When using my diff viewer on PR #648, I noticed that if you created a new user without doing anything else, turn on show changes, and then simply view some of the pages, it would show some stuff being added. I realized that this came from DefaultUserData not having some fields. While I could include this fix under PR #648, I am trying to avoid scope creep and this does technically affect more things than just the diff viewer.

<img width="495" height="739" alt="Screenshot 2026-01-27 at 12 31 28 PM" src="https://github.com/user-attachments/assets/8c1fbdc8-70fe-46af-84f7-ca9d10065c26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended user configuration options including autoPlay settings, cache and play functionality, playback statistics, digital release filtering, age range preferences, and enhanced matching capabilities for seasons, episodes, years, and titles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->