### PR TITLE
chore(stremthru): add torrent filename as display name to magnet

### DIFF
--- a/packages/core/src/debrid/stremthru.ts
+++ b/packages/core/src/debrid/stremthru.ts
@@ -258,6 +258,9 @@ export class StremThruInterface implements DebridService {
     const cachedLink = await StremThruInterface.playbackLinkCache.get(cacheKey);
 
     let magnet = `magnet:?xt=urn:btih:${hash}`;
+    if (playbackInfo.filename) {
+      magnet += `&dn=${playbackInfo.filename}`;
+    }
     if (playbackInfo.sources.length > 0) {
       magnet += `&tr=${playbackInfo.sources.join('&tr=')}`;
     }


### PR DESCRIPTION
avoids entries in e.g. torbox showing only the hash as e.g.

<img width="535" height="152" alt="image" src="https://github.com/user-attachments/assets/e65e4795-3d80-4201-833a-f1ce8c18d4bc" />


https://en.wikipedia.org/wiki/Magnet_URI_scheme#Format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced streaming media identification with improved display metadata handling for better playback compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->