### PR TITLE
Fix: Skip bitrate calculation for incorrect metadata

### DIFF
--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -315,38 +315,6 @@ class StreamFilterer {
           );
         }
 
-        // checks for metadata mismatches
-        if (
-          type === 'series' &&
-          requestedMetadata?.seasons &&
-          stream.parsedFile?.seasons?.length
-        ) {
-          const metadataSeasons = requestedMetadata.seasons;
-
-          for (const seasonNum of stream.parsedFile.seasons) {
-            const seasonData = metadataSeasons.find(
-              (s) => s.season_number === seasonNum
-            );
-
-            if (
-              seasonData &&
-              parsedId?.episode &&
-              parsedId?.season &&
-              seasonNum === Number(parsedId.season)
-            ) {
-              const episodeNum = Number(parsedId.episode);
-              if (episodeNum > seasonData.episode_count) {
-                logger.debug(
-                  `Skipping bitrate calculation for stream ${stream.filename}: Episode ${episodeNum} exceeds Season ${seasonNum} count (${seasonData.episode_count})`,
-                  { stream, seasonData }
-                );
-                doBitrateCalculation = false;
-                break;
-              }
-            }
-          }
-        }
-
         if (
           (stream.bitrate === undefined || !Number.isFinite(stream.bitrate)) &&
           requestedMetadata?.runtime &&


### PR DESCRIPTION
When metadata is incorrect (has a placeholder runtime of 1), or there is a mismatch between seasons and episodes, skip the bitrate calculation.

This primarily happening when users are using AIOM for metadata, but are not setting their TVDB key in AIOS settings. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bitrate calculation now skips special releases (Season 0) to prevent incorrect adjustments.
  * Added clearer debug logging when bitrate computation is bypassed for inapplicable episodes, reducing misleading diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->