### PR TITLE
fix: Fix bitrate when stream.age is present

### DIFF
--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -135,7 +135,6 @@ class StreamParser {
     parsedStream.indexer = this.getIndexer(stream, parsedStream);
     parsedStream.service = this.getService(stream, parsedStream);
     parsedStream.duration = this.getDuration(stream, parsedStream);
-    parsedStream.bitrate = this.getBitrate(stream, parsedStream);
     parsedStream.type = this.getStreamType(
       stream,
       parsedStream.service,
@@ -143,6 +142,7 @@ class StreamParser {
     );
     parsedStream.library = this.getInLibrary(stream, parsedStream);
     parsedStream.age = this.getAge(stream, parsedStream);
+    parsedStream.bitrate = this.getBitrate(stream, parsedStream);
     parsedStream.message = this.getMessage(stream, parsedStream);
 
     parsedStream.parsedFile = this.getParsedFile(stream, parsedStream);


### PR DESCRIPTION
When stream.age was present, bitrate was getting calculated with it instead of duration. The most simple fix was just moving when bitrate gets calculated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered bitrate calculation logic within the stream parser to optimise code flow execution order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->