### PR TITLE
fix(builtins): only set private flag if torrent was parsed

### DIFF
--- a/packages/core/src/builtins/torbox-search/source-handlers.ts
+++ b/packages/core/src/builtins/torbox-search/source-handlers.ts
@@ -346,7 +346,6 @@ export class TorrentSourceHandler extends SourceHandler {
         return {
           ...torrent,
           type: 'torrent',
-          private: false,
         };
       }),
       this.services,

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -127,7 +127,7 @@ const BaseFileInfoSchema = z.object({
 const TorrentInfoSchema = BaseFileInfoSchema.extend({
   downloadUrl: z.string().optional(),
   hash: z.string(),
-  private: z.boolean().default(false),
+  private: z.boolean().optional(),
   sources: z.array(z.string()),
   type: z.literal('torrent'),
 });

--- a/packages/core/src/debrid/torbox.ts
+++ b/packages/core/src/debrid/torbox.ts
@@ -61,7 +61,6 @@ export class TorboxDebridService implements DebridService {
       });
       logger.debug(`Removed usenet download ${nzbId} from Torbox`);
     } catch (error: any) {
-
       throw new DebridError(
         `Failed to remove usenet download: ${error.message}`,
         {

--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -54,7 +54,7 @@ export interface Torrent extends BaseFile {
   hash: string;
   files?: DebridFile[];
   // magnet?: string;
-  private: boolean;
+  private?: boolean;
 }
 
 export interface UnprocessedTorrent extends BaseFile {

--- a/packages/core/src/utils/torrent.ts
+++ b/packages/core/src/utils/torrent.ts
@@ -19,7 +19,7 @@ interface TorrentMetadata {
   hash: string;
   files: DebridFile[];
   sources: string[];
-  private: boolean;
+  private?: boolean;
 }
 
 export class TorrentClient {
@@ -49,7 +49,6 @@ export class TorrentClient {
         hash: torrent.hash,
         files: [], // Empty files array since we don't need metadata
         sources: torrent.sources || [],
-        private: false,
       };
     }
 
@@ -113,7 +112,6 @@ export class TorrentClient {
           hash: torrent.hash,
           files: [],
           sources: torrent.sources || [],
-          private: false,
         };
       }
       return undefined;
@@ -163,7 +161,7 @@ export class TorrentClient {
           hash,
         }
       );
-      metadata = { hash, files: [], sources, private: false };
+      metadata = { hash, files: [], sources };
     } else if (response.ok) {
       const bytes = await response.arrayBuffer();
 


### PR DESCRIPTION
follow-up for https://github.com/Viren070/AIOStreams/pull/644

simplifies setting the flag slightly and makes sure to not assume `false` by default when we actually don't know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the torrent private field optional throughout the debrid system and related components. Torrent metadata objects can now omit this field when not explicitly specified, rather than always including a default value. Improves code flexibility and clarity with minor error handling cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->