### PR TITLE
fix(debrid): only add torrent via URL if it was downloaded before

### DIFF
--- a/packages/core/src/debrid/stremthru.ts
+++ b/packages/core/src/debrid/stremthru.ts
@@ -278,7 +278,11 @@ export class StremThruInterface implements DebridService {
     }
 
     let magnetDownload: DebridDownload;
-    if (playbackInfo.downloadUrl && Env.BUILTIN_DEBRID_USE_TORRENT_DOWNLOAD_URL) {
+    if (
+      playbackInfo.private !== undefined && // make sure the torrent was downloaded before
+      playbackInfo.downloadUrl &&
+      Env.BUILTIN_DEBRID_USE_TORRENT_DOWNLOAD_URL
+    ) {
       logger.debug(
         `Adding torrent to ${this.serviceName} for ${playbackInfo.downloadUrl}`
       );


### PR DESCRIPTION
leads to preferring using magnet only when both magnet and URL are got. yes, this is currently kind of a dirty workaround because I didn't come up with a better way of figuring out here if we got the hash directly or if it was parsed from the downloaded file without modifying the data structures too much. maybe there are better solutions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced torrent download handling to validate prerequisites before attempting torrent-based downloads, ensuring more reliable operation with automatic fallback to alternative download methods when conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->