### PR TITLE
Revert "fix: Change default for BUILTIN_DEBRID_USE_TORRENT_DOWNLOAD_URL to false temporarily"

### DIFF
--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1849,7 +1849,7 @@ export const Env = cleanEnv(process.env, {
     desc: 'Builtin Debrid NZB list cache TTL',
   }),
   BUILTIN_DEBRID_USE_TORRENT_DOWNLOAD_URL: bool({
-    default: false,
+    default: true,
     desc: 'Use torrent URLs instead of magnets for better private tracker integration',
   }),
   BUILTIN_DEBRID_METADATA_STORE: str({


### PR DESCRIPTION
This reverts commit 2b38bf45c3a216899e1dd07c5ff00f45bc276dc8.

fine after https://github.com/Viren070/AIOStreams/pull/678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated default setting for built-in Debrid functionality to use torrent download URLs instead of magnet links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->