### PR TITLE
feat: add toggle all on/off button for addons

### DIFF
--- a/packages/frontend/src/components/menu/addons.tsx
+++ b/packages/frontend/src/components/menu/addons.tsx
@@ -378,6 +378,24 @@ function Content() {
             <SettingsCard
               title="My Addons"
               description="Edit, remove, and reorder your installed addons. If you reorder your addons, you will have to refresh the catalogs if you have made any changes, and also reinstall the addon."
+              action={
+                <Switch
+                  id="toggle-addons"
+                  label="Toggle all"
+                  labelClass="text-sm"
+                  containerClass="gap-1"
+                  value={userData.presets.every((preset) => preset.enabled)}
+                  onValueChange={(val) =>
+                    setUserData((prev) => ({
+                      ...prev,
+                      presets: prev.presets.map((p) => ({
+                        ...p,
+                        enabled: val,
+                      })),
+                    }))
+                  }
+                />
+              }
             >
               <DndContext
                 modifiers={[restrictToVerticalAxis]}


### PR DESCRIPTION
Wasn't sure the best UI/UX to go with for this, so it can be changed if needed.

Current implementation has a single button and is easy to understand:
<img width="759" height="150" alt="image" src="https://github.com/user-attachments/assets/7c669996-d01e-41fa-b93b-784555e4cee5" />

Another idea is separate buttons which looks cleaner but is less intuitive:
<img width="696" height="143" alt="image" src="https://github.com/user-attachments/assets/32684648-711e-4878-b5bc-8e276f09ab47" />

Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Toggle all" switch to the My Addons settings, enabling users to quickly enable or disable all presets simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->