### PR TITLE
chore(frontend): replace "magnet" with "torrent" in auto remove downloads

### DIFF
--- a/packages/frontend/src/components/menu/miscellaneous.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous.tsx
@@ -344,7 +344,7 @@ function Content() {
               <div className="space-y-2">
                 <p>
                   When enabled, AIOStreams will automatically remove the
-                  magnet/NZB from your debrid dashboard after generating a
+                  torrent/NZB from your debrid dashboard after generating a
                   playback link. This prevents watched items from cluttering
                   your debrid service&apos;s library.
                 </p>


### PR DESCRIPTION
To be a bit clearer that this is not limited to magnets and will affect e.g. private torrents added without magnets as well. but most likely it only confused me with magnet/torrent internal info..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description text for the Auto remove Downloads feature to accurately reflect "torrent/NZB" instead of "magnet/NZB".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->