### PR TITLE
fix(debrid): exclude private torrents from auto-removal

### DIFF
--- a/packages/core/src/builtins/utils/debrid.ts
+++ b/packages/core/src/builtins/utils/debrid.ts
@@ -307,6 +307,7 @@ export async function processTorrentsForP2P(
           {
             id: 'p2p',
             name: torrent.title,
+            private: torrent.private,
             size: torrent.size,
             status: 'downloaded',
             files: torrent.files,

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -89,6 +89,7 @@ export interface DebridDownload {
   library?: boolean;
   hash?: string;
   name?: string;
+  private?: boolean;
   size?: number;
   status:
     | 'cached'

--- a/packages/core/src/debrid/stremthru.ts
+++ b/packages/core/src/debrid/stremthru.ts
@@ -186,6 +186,7 @@ export class StremThruInterface implements DebridService {
         id: result.data.id,
         status: result.data.status,
         hash: result.data.hash,
+        private: result.data.private,
         size: result.data.files.reduce((acc, file) => acc + file.size, 0),
         files: result.data.files.map((file) => ({
           name: file.name,
@@ -414,7 +415,7 @@ export class StremThruInterface implements DebridService {
       true
     );
 
-    if (autoRemoveDownloads && magnetDownload.id) {
+    if (autoRemoveDownloads && magnetDownload.id && !magnetDownload.private) {
       this.removeMagnet(magnetDownload.id.toString()).catch((err) => {
         logger.warn(
           `Failed to cleanup magnet ${magnetDownload.id} after resolve: ${err.message}`

--- a/packages/frontend/src/components/menu/miscellaneous.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous.tsx
@@ -344,14 +344,14 @@ function Content() {
               <div className="space-y-2">
                 <p>
                   When enabled, AIOStreams will automatically remove the
-                  magnet/NZB from your debrid dashboard after generating a
+                  torrent/NZB from your debrid dashboard after generating a
                   playback link. This prevents watched items from cluttering
                   your debrid service&apos;s library.
                 </p>
                 <Alert intent="info-basic">
                   <p className="text-sm">
                     This feature only works for built-in addons and supported
-                    debrid services.
+                    debrid services. Private torrents will not be removed.
                   </p>
                 </Alert>
               </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Torrent downloads now include a privacy flag so private torrents are tracked and preserved from automatic removal.
  * Privacy status is propagated across download handling to keep behaviour consistent for private content.

* **UI Updates**
  * Settings text changed from “magnet/NZB” to “torrent/NZB” and now clarifies that private torrents will not be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->