### PR TITLE
fix: Use episode runtime instead of series average

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -128,6 +128,7 @@ export interface ParseValue {
     runtime: number | null;
     genres: string[] | null;
     year: number | null;
+    episodeRuntime: number | null;
   };
   service?: {
     id: string | null;
@@ -175,6 +176,7 @@ export interface FormatterContext {
   yearEnd?: number;
   genres?: string[];
   runtime?: number;
+  episodeRuntime?: number;
   absoluteEpisode?: number;
   relativeAbsoluteEpisode?: number;
   originalLanguage?: string;
@@ -459,6 +461,7 @@ export abstract class BaseFormatter {
         queryType: this.formatterContext.queryType || null,
         title: this.formatterContext.title || null,
         runtime: this.formatterContext.runtime || null,
+        episodeRuntime: this.formatterContext.episodeRuntime || null,
         genres: this.formatterContext.genres || null,
         year: this.formatterContext.year || null,
       },

--- a/packages/core/src/metadata/tmdb.ts
+++ b/packages/core/src/metadata/tmdb.ts
@@ -128,6 +128,7 @@ const TVEpisodeDetailsSchema = z.object({
   overview: z.string().optional(),
   season_number: z.number(),
   still_path: z.string().nullable().optional(),
+  runtime: z.number().nullable().optional(),
 });
 
 const IdTypeMap: Partial<Record<IdType, TMDBIdType>> = {
@@ -440,11 +441,11 @@ export class TMDBMetadata {
     return data.results.flatMap((result) => result.release_dates);
   }
 
-  public async getEpisodeAirDate(
+  public async getEpisodeDetails(
     tmdbId: number,
     seasonNumber: number,
     episodeNumber: number
-  ): Promise<string | undefined> {
+  ): Promise<{ air_date?: string; runtime?: number } | undefined> {
     const url = new URL(
       API_BASE_URL +
         `/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`
@@ -461,7 +462,10 @@ export class TMDBMetadata {
     }
     const json = await response.json();
     const episodeData = TVEpisodeDetailsSchema.parse(json);
-    return episodeData.air_date ?? undefined;
+    return {
+      air_date: episodeData.air_date ?? undefined,
+      runtime: episodeData.runtime ?? undefined,
+    };
   }
 
   public async getNextEpisodeAirDate(


### PR DESCRIPTION
This change will allow bitrate calculation to use the episode runtime instead of the series average. If it can't get the episode runtime, it will fallback to average. I also added episodeRuntime to the formatting system since we now have this data. This will be useful for when premieres and finales are longer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for episode runtime metadata, enabling the system to retrieve and utilise episode-specific runtime information for optimised streaming quality selection.

* **Refactor**
  * Consolidated episode metadata handling for improved consistency and efficiency across the streaming pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->