### PR TITLE
feat: Stale while revalidate

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -382,6 +382,12 @@ SEL_SYNC_ACCESS=trusted
 # Default: 86400 (24 hours)
 # WHITELISTED_SYNC_REFRESH_INTERVAL=86400
 
+# --- Sync URL Stale Tolerance ---
+# How long stale patterns/expressions from sync URLs can be served if refresh fails.
+# Value in seconds. Set to 0 to disable.
+# Default: 604800 (7 days)
+# WHITELISTED_SYNC_STALE_TOLERANCE=604800
+
 # --- Aliased Configurations (Vanity URLs) ---
 # Create shorter, memorable installation URLs.
 # Format: aliasName1:uuid1:encryptedPassword1,aliasName2:uuid2:encryptedPassword2

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -802,6 +802,10 @@ export const Env = cleanEnv(process.env, {
     default: undefined,
     desc: 'Refresh interval for synced URLs (regex and SEL) in seconds. Falls back to ALLOWED_REGEX_PATTERNS_URLS_REFRESH_INTERVAL (converted from ms to s). Default: 86400 (24h).',
   }),
+  WHITELISTED_SYNC_STALE_TOLERANCE: num({
+    default: 604800,
+    desc: 'Stale tolerance for synced URLs in seconds. Extends cache TTL beyond refresh interval. Default: 604800 (7 days).',
+  }),
   WHITELISTED_SEL_URLS: json<string[]>({
     default: undefined,
     desc: 'Whitelisted stream expression (SEL) sync URLs (JSON array of URL strings). Non-trusted users can only sync from these URLs.',

--- a/packages/core/src/utils/regex-access.ts
+++ b/packages/core/src/utils/regex-access.ts
@@ -53,10 +53,13 @@ export class RegexAccess {
         Env.WHITELISTED_SYNC_REFRESH_INTERVAL ??
         Math.floor(Env.ALLOWED_REGEX_PATTERNS_URLS_REFRESH_INTERVAL / 1000);
 
+      const staleTolerance = Env.WHITELISTED_SYNC_STALE_TOLERANCE;
+
       this._instance = new SyncManager<RegexPatternItem>({
         cacheKey: 'regex-patterns',
         maxCacheSize: 100,
         refreshInterval,
+        staleTolerance,
         configuredUrls,
         itemSchema: RegexPatternSchema,
         itemKey: (item) => item.pattern,

--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -45,10 +45,13 @@ export class SelAccess {
           (Env.ALLOWED_REGEX_PATTERNS_URLS_REFRESH_INTERVAL ?? 86400000) / 1000
         );
 
+      const staleTolerance = Env.WHITELISTED_SYNC_STALE_TOLERANCE;
+
       this._instance = new SyncManager<StreamExpressionItem>({
         cacheKey: 'sel-expressions',
         maxCacheSize: 100,
         refreshInterval,
+        staleTolerance,
         configuredUrls,
         itemSchema: StreamExpressionSchema,
         itemKey: (item) => item.expression,

--- a/packages/core/src/utils/sync.ts
+++ b/packages/core/src/utils/sync.ts
@@ -16,6 +16,8 @@ export interface SyncManagerConfig {
   maxCacheSize: number;
   /** Refresh interval in seconds (0 = no refresh) */
   refreshInterval: number;
+  /** Stale tolerance in seconds (0 = disabled) */
+  staleTolerance: number;
   /** Statically configured URLs from env vars */
   configuredUrls: string[];
   /** Zod schema to validate items fetched from URLs */
@@ -113,7 +115,7 @@ export class SyncManager<T extends Record<string, any>> {
 
     const items = await this._fetchWithRetry(url);
     if (items.length > 0) {
-      await this.cache.set(url, { items }, this.config.refreshInterval);
+      await this.cache.set(url, { items }, this.config.refreshInterval + this.config.staleTolerance);
     }
     return items;
   }
@@ -126,7 +128,7 @@ export class SyncManager<T extends Record<string, any>> {
     try {
       const items = await this._fetchWithRetry(url);
       if (items.length > 0) {
-        await this.cache.set(url, { items }, this.config.refreshInterval);
+        await this.cache.set(url, { items }, this.config.refreshInterval + this.config.staleTolerance);
       }
       return { url, items };
     } catch (error: any) {
@@ -264,7 +266,7 @@ export class SyncManager<T extends Record<string, any>> {
         this._fetchWithRetry(url)
           .then((items) => {
             if (items.length > 0) {
-              this.cache.set(url, { items }, this.config.refreshInterval);
+              this.cache.set(url, { items }, this.config.refreshInterval + this.config.staleTolerance);
             }
             return items;
           })


### PR DESCRIPTION
Since we are going to be relying more on external URL fetches, I implemented stale while revalidate. If the URL fetch ever fails, it will continue using the old cache for a configurable amount in the env. This will be useful if github ever has downtime, or some urls change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable stale tolerance for synced content sources. When automatic refresh of patterns or expressions fails, cached data can now be served for an extended period before expiring. Default grace period: 7 days; disable by setting tolerance to 0 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->