### PR TITLE
fix(fronted): Allow negatives in overrides

### DIFF
--- a/packages/frontend/src/components/menu/filters/_components/synced-patterns.tsx
+++ b/packages/frontend/src/components/menu/filters/_components/synced-patterns.tsx
@@ -525,7 +525,10 @@ export function SyncedPatterns({
           {renderType === 'ranked' && (
             <NumberInput
               label="Custom Score"
-              value={regexEditing?.score ?? 0}
+              value={regexEditing?.score || 0}
+              min={-1_000_000}
+              max={1_000_000}
+              step={50}
               onValueChange={(score) =>
                 setRegexEditing((prev) => (prev ? { ...prev, score } : null))
               }
@@ -556,7 +559,7 @@ export function SyncedPatterns({
                   const entry = {
                     pattern: regexEditing.pattern,
                     name: regexEditing.name || undefined,
-                    score: regexEditing.score,
+                    score: regexEditing.score || 0,
                     originalName: regexEditing.originalName,
                     disabled:
                       regexEditing.disabled ?? existingOverride?.disabled,
@@ -597,7 +600,10 @@ export function SyncedPatterns({
           </p>
           <NumberInput
             label="Custom Score"
-            value={selEditing?.score ?? 0}
+            value={selEditing?.score || 0}
+            min={-1_000_000}
+            max={1_000_000}
+            step={50}
             onValueChange={(score) =>
               setSelEditing((prev) => (prev ? { ...prev, score } : null))
             }
@@ -629,7 +635,7 @@ export function SyncedPatterns({
                     idx >= 0 ? overrides[idx] : undefined;
                   const entry = {
                     expression: selEditing.expression,
-                    score: selEditing.score,
+                    score: selEditing.score || 0,
                     exprNames: selEditing.exprNames,
                     disabled: selEditing.disabled ?? existingOverride?.disabled,
                   };


### PR DESCRIPTION
Small fix to allow negatives in the overrides and also make sure that if no value gets entered, it defaults to zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardised numeric score field defaults to zero across pattern override modals, ensuring consistent and reliable value handling throughout the system.
  * Enhanced input validation for score input fields by introducing bounds checking and step increments to prevent invalid or out-of-range entries.
  * Improved control flow for handling undefined score values to guarantee proper data persistence in all override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->