### PR TITLE
fix: More unique override names

### DIFF
--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -1343,3 +1343,22 @@ export function extractNamesFromExpression(
   }
   return names.length > 0 ? names : undefined;
 }
+
+/**
+ * Extracts ALL names from comments in a stream expression, including #-prefixed ones.
+ * This makes each expression's name set naturally unique for override tracking.
+ * @param expression The stream expression to extract names from
+ * @returns Array of extracted names, or undefined if none found
+ */
+export function extractAllNamesFromExpression(
+  expression: string
+): string[] | undefined {
+  const regex = /\/\*\s*(.*?)\s*\*\//g;
+  const names: string[] = [];
+  let match;
+  while ((match = regex.exec(expression)) !== null) {
+    const content = match[1];
+    names.push(content.startsWith('#') ? content.slice(1).trim() : content);
+  }
+  return names.length > 0 ? names : undefined;
+}

--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { UserData } from '../db/schemas.js';
 import { Env } from './env.js';
 import { SyncManager, type SyncOverride, type FetchResult } from './sync.js';
-import { extractNamesFromExpression } from '../parser/streamExpression.js';
+import { extractAllNamesFromExpression } from '../parser/streamExpression.js';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('core');
@@ -212,7 +212,7 @@ export class SelAccess {
 
       // Match by extracted names vs stored exprNames
       if (o.exprNames && o.exprNames.length > 0) {
-        const names = extractNamesFromExpression(expr.expression);
+        const names = extractAllNamesFromExpression(expr.expression);
         if (
           names &&
           names.length === o.exprNames.length &&

--- a/packages/frontend/src/components/menu/filters/_components/synced-patterns.tsx
+++ b/packages/frontend/src/components/menu/filters/_components/synced-patterns.tsx
@@ -30,18 +30,16 @@ import {
 // Helpers
 
 /**
- * Extract names from C-style block comments in a SEL expression.
- * Names are comments that don't start with `#`.
+ * Extract ALL names from block comments, including #-prefixed ones.
+ * Used for override tracking to make each expression's name unique.
  */
-function extractNamesFromExpression(expression: string): string[] | undefined {
+function extractAllNamesFromExpression(expression: string): string[] | undefined {
   const regex = /\/\*\s*(.*?)\s*\*\//g;
   const names: string[] = [];
   let match;
   while ((match = regex.exec(expression)) !== null) {
     const content = match[1];
-    if (!content.startsWith('#')) {
-      names.push(content);
-    }
+    names.push(content.startsWith('#') ? content.slice(1).trim() : content);
   }
   return names.length > 0 ? names : undefined;
 }
@@ -162,7 +160,7 @@ export function SyncedPatterns({
 
         // For SEL items, extract names from expression comments
         const extractedNames = isSel
-          ? extractNamesFromExpression(patternStr)
+          ? extractAllNamesFromExpression(patternStr)
           : undefined;
 
         const matchesOverride = (o: any) => {


### PR DESCRIPTION
This should make the ranked stream expression names that are used for the override more unique without losing any of the functionality of tracking pattern changes.

This should also have no affect on {stream.seMatched} in the formatter, it will still properly ignore comments with the #.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Improved extraction of names from stream expressions to include previously filtered patterns, enhancing pattern matching and synchronisation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->