### PR TITLE
feat: whitelist regex and SEL sync URLs by GitHub username

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -364,6 +364,10 @@ REGEX_FILTER_ACCESS=trusted
 # Supports markdown format for links and code only (i.e. [linktext](link) and `code`)
 # WHITELISTED_REGEX_PATTERNS_DESCRIPTION=
 
+# GitHub usernames: regex sync URLs starting with https://raw.githubusercontent.com/<username>/ are whitelisted.
+# Example: ["Vidhin05"]
+# WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES=
+
 # --- SEL (Stream Expression Language) Sync Access ---
 # Controls who can use SEL sync URLs.
 # 'all': Anyone can sync from any URL.
@@ -375,6 +379,10 @@ SEL_SYNC_ACCESS=trusted
 # Non-trusted users can only sync from these URLs when SEL_SYNC_ACCESS is 'trusted'.
 # Example: ["https://example.com/sel-expressions.json"]
 # WHITELISTED_SEL_URLS=
+
+# GitHub usernames: SEL sync URLs starting with https://raw.githubusercontent.com/<username>/ are whitelisted.
+# Example: ["Vidhin05", "Tam-Taro"]
+# WHITELISTED_SEL_URLS_GITHUB_USERNAMES=
 
 # --- Sync URL Refresh Interval ---
 # How often patterns/expressions from sync URLs (regex and SEL) will be refreshed.

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -25,6 +25,7 @@ import {
   constants,
   SelAccess,
 } from './index.js';
+import { isWhitelistedGithubRawUrl } from './general.js';
 import { z, ZodError } from 'zod';
 import {
   ExitConditionEvaluator,
@@ -854,7 +855,11 @@ function validateSyncedRegexUrls(
 
   if (isUnrestricted) return;
 
-  const allowedUrls = Env.ALLOWED_REGEX_PATTERNS_URLS || [];
+  const allowedUrls =
+    Env.WHITELISTED_REGEX_PATTERNS_URLS ??
+    Env.ALLOWED_REGEX_PATTERNS_URLS ??
+    [];
+  const githubUsernames = Env.WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES || [];
   const urlsToCheck = [
     ...(config.syncedIncludedRegexUrls || []),
     ...(config.syncedExcludedRegexUrls || []),
@@ -862,7 +867,10 @@ function validateSyncedRegexUrls(
     ...(config.syncedPreferredRegexUrls || []),
   ];
 
-  const invalidUrls = urlsToCheck.filter((url) => !allowedUrls.includes(url));
+  const invalidUrls = urlsToCheck.filter(
+    (url) =>
+      !(allowedUrls.includes(url) || isWhitelistedGithubRawUrl(url, githubUsernames))
+  );
 
   if (invalidUrls.length > 0) {
     if (!skipErrors) {
@@ -881,6 +889,7 @@ function validateSyncedSelUrls(config: UserData, skipErrors: boolean = false) {
   if (isUnrestricted) return;
 
   const allowedUrls = Env.WHITELISTED_SEL_URLS || [];
+  const githubUsernames = Env.WHITELISTED_SEL_URLS_GITHUB_USERNAMES || [];
   const urlsToCheck = [
     ...(config.syncedIncludedStreamExpressionUrls || []),
     ...(config.syncedExcludedStreamExpressionUrls || []),
@@ -889,7 +898,10 @@ function validateSyncedSelUrls(config: UserData, skipErrors: boolean = false) {
     ...(config.syncedRankedStreamExpressionUrls || []),
   ];
 
-  const invalidUrls = urlsToCheck.filter((url) => !allowedUrls.includes(url));
+  const invalidUrls = urlsToCheck.filter(
+    (url) =>
+      !(allowedUrls.includes(url) || isWhitelistedGithubRawUrl(url, githubUsernames))
+  );
 
   if (invalidUrls.length > 0) {
     if (!skipErrors) {

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -798,6 +798,10 @@ export const Env = cleanEnv(process.env, {
     default: undefined,
     desc: 'Description of the whitelisted regex patterns. Falls back to ALLOWED_REGEX_PATTERNS_DESCRIPTION.',
   }),
+  WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES: json<string[]>({
+    default: [],
+    desc: 'GitHub usernames; regex sync URLs starting with https://raw.githubusercontent.com/<username>/ are whitelisted.',
+  }),
   WHITELISTED_SYNC_REFRESH_INTERVAL: num({
     default: undefined,
     desc: 'Refresh interval for synced URLs (regex and SEL) in seconds. Falls back to ALLOWED_REGEX_PATTERNS_URLS_REFRESH_INTERVAL (converted from ms to s). Default: 86400 (24h).',
@@ -805,6 +809,10 @@ export const Env = cleanEnv(process.env, {
   WHITELISTED_SEL_URLS: json<string[]>({
     default: undefined,
     desc: 'Whitelisted stream expression (SEL) sync URLs (JSON array of URL strings). Non-trusted users can only sync from these URLs.',
+  }),
+  WHITELISTED_SEL_URLS_GITHUB_USERNAMES: json<string[]>({
+    default: [],
+    desc: 'GitHub usernames; SEL sync URLs starting with https://raw.githubusercontent.com/<username>/ are whitelisted.',
   }),
   SEL_SYNC_ACCESS: str({
     default: 'trusted',

--- a/packages/core/src/utils/general.ts
+++ b/packages/core/src/utils/general.ts
@@ -5,6 +5,26 @@ import { parseConnectionURI } from '../db/utils.js';
 import { Env } from './env.js';
 const logger = createLogger('utils-general');
 
+const GITHUB_RAW_URL_PREFIX = 'https://raw.githubusercontent.com/';
+
+/**
+ * Returns true if url is a raw GitHub URL whose owner (first path segment) is in usernames.
+ * Used to whitelist regex/SEL sync URLs by GitHub username.
+ */
+export function isWhitelistedGithubRawUrl(
+  url: string,
+  usernames: string[]
+): boolean {
+  if (!usernames?.length || typeof url !== 'string') return false;
+  if (!url.startsWith(GITHUB_RAW_URL_PREFIX)) return false;
+  const rest = url.slice(GITHUB_RAW_URL_PREFIX.length);
+  const slash = rest.indexOf('/');
+  const owner = slash === -1 ? rest : rest.slice(0, slash);
+  const ownerLower = owner.toLowerCase();
+  const whitelistLower = new Set(usernames.map((u) => u.toLowerCase()));
+  return whitelistLower.has(ownerLower);
+}
+
 export function getDataFolder(): string {
   const databaseURI = parseConnectionURI(Env.DATABASE_URI);
   if (databaseURI.dialect === 'sqlite') {

--- a/packages/core/src/utils/regex-access.ts
+++ b/packages/core/src/utils/regex-access.ts
@@ -3,6 +3,7 @@ import { UserData } from '../db/schemas.js';
 import { Env } from './env.js';
 import { SyncManager, type SyncOverride, type FetchResult } from './sync.js';
 import { createLogger } from './logger.js';
+import { isWhitelistedGithubRawUrl } from './general.js';
 
 const logger = createLogger('core');
 
@@ -170,7 +171,13 @@ export class RegexAccess {
 
     if (isUnrestricted) return urls;
 
-    return urls.filter((url) => this.manager.allowedUrls.includes(url));
+    const githubUsernames =
+      Env.WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES || [];
+    return urls.filter(
+      (url) =>
+        this.manager.allowedUrls.includes(url) ||
+        isWhitelistedGithubRawUrl(url, githubUsernames)
+    );
   }
 
   /**

--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -4,6 +4,7 @@ import { Env } from './env.js';
 import { SyncManager, type SyncOverride, type FetchResult } from './sync.js';
 import { extractNamesFromExpression } from '../parser/streamExpression.js';
 import { createLogger } from './logger.js';
+import { isWhitelistedGithubRawUrl } from './general.js';
 
 const logger = createLogger('core');
 
@@ -85,8 +86,13 @@ export class SelAccess {
 
     if (isUnrestricted) return urls;
 
-    // Non-trusted users can only use whitelisted SEL URLs
-    return urls.filter((url) => this.manager.allowedUrls.includes(url));
+    // Non-trusted users can only use whitelisted SEL URLs or raw GitHub URLs from whitelisted usernames
+    const githubUsernames = Env.WHITELISTED_SEL_URLS_GITHUB_USERNAMES || [];
+    return urls.filter(
+      (url) =>
+        this.manager.allowedUrls.includes(url) ||
+        isWhitelistedGithubRawUrl(url, githubUsernames)
+    );
   }
 
   /**


### PR DESCRIPTION
## Add GitHub username whitelist for regex and SEL sync

### Summary

Adds two environment variables so community admins can whitelist trusted GitHub usernames instead of individual raw URLs for regex and SEL sync.

### New environment variables

- **`WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES`** — whitelists `https://raw.githubusercontent.com/<username>/` URLs for regex sync
- **`WHITELISTED_SEL_URLS_GITHUB_USERNAMES`** — whitelists `https://raw.githubusercontent.com/<username>/` URLs for SEL (Stream Expression Language) sync

### Behavior

Provide a list of GitHub usernames. Any URL whose path starts with `https://raw.githubusercontent.com/<username>/` is treated as whitelisted for the corresponding sync type. This lets you trust entire user/organization namespaces instead of maintaining long lists of raw URLs.

### Example

```bash
WHITELISTED_REGEX_PATTERNS_URLS_GITHUB_USERNAMES=["Vidhin05"]
WHITELISTED_SEL_URLS_GITHUB_USERNAMES=["Vidhin05", "Tam-Taro"]
```

This whitelists all raw URLs under `https://raw.githubusercontent.com/Vidhin05/` for regex and SEL sync; and `https://raw.githubusercontent.com/Tam-Taro/` for SEL sync respectively.

### Benefits

- **Simpler config** — whitelist usernames instead of many URLs
- **Easier updates** — new files or repos under a username are automatically allowed
- **Same security model** — only explicitly listed usernames are whitelisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub username-based whitelisting for synchronised content URLs (regex patterns and selector/SEL URLs).
  * Administrators can whitelist content from specific GitHub user repositories for automatic acceptance.
  * New configuration option to expose an optional sync refresh interval for whitelisted syncs.
  * Environment-configurable whitelisting with safe defaults and explanatory examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->