### PR TITLE
Make replace modifier able to replace with empty string

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -871,7 +871,7 @@ export abstract class BaseFormatter {
             new RegExp(`${findStartChar}\\s*,\\s*${findEndChar}`)
           );
 
-          if (!shouldBeUndefined && key && replaceKey)
+          if (!shouldBeUndefined && key && replaceKey !== undefined)
             return variable.replaceAll(key, replaceKey);
         }
         case mod.startsWith('truncate(') && mod.endsWith(')'): {


### PR DESCRIPTION
Makes ::replace('test','') work and remove 'test' from the string, replacing it with nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the string replace modifier to correctly handle replacement with empty strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->