### PR TITLE
feat(core/formatter): sort visual tags, audio tags, and audio channels by user pref

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -259,25 +259,7 @@ export abstract class BaseFormatter {
 
   protected convertStreamToParseValue(stream: ParsedStream): ParseValue {
     // Get original language from formatter context instead of from the stream's languages array hack
-    const resolvedOriginalLanguage = this.formatterContext.originalLanguage;
-    const languages = stream.parsedFile?.languages || null;
-    const subtitles = stream.parsedFile?.subtitles || null;
 
-    const rawUserLanguages = [
-      ...(this.userData.preferredLanguages || []),
-      ...(this.userData.requiredLanguages || []),
-      ...(this.userData.includedLanguages || []),
-    ];
-    const userSpecifiedLanguages = [
-      ...new Set(
-        rawUserLanguages.flatMap((lang) => {
-          if (lang === 'Original' && resolvedOriginalLanguage) {
-            return [resolvedOriginalLanguage];
-          }
-          return [lang];
-        })
-      ),
-    ];
     const getPaddedNumber = (number: number, length: number) =>
       number.toString().padStart(length, '0');
     const formattedSeasonString = stream.parsedFile?.seasons?.length
@@ -308,24 +290,49 @@ export abstract class BaseFormatter {
         : `E${getPaddedNumber(stream.parsedFile.folderEpisodes[0], 2)}-${getPaddedNumber(stream.parsedFile.folderEpisodes[stream.parsedFile.folderEpisodes.length - 1], 2)}`
       : undefined;
 
-    const buildLanguageVariants = (values: string[] | null) => {
-      const sortedValues = values
-        ? [...values].sort((a, b) => {
-            const aIndex = userSpecifiedLanguages.indexOf(a as any);
-            const bIndex = userSpecifiedLanguages.indexOf(b as any);
+    const getFieldValues = (field: string): string[] => {
+      // capitalise first letter
+      const key = field.charAt(0).toUpperCase() + field.slice(1);
+      return [
+        ...((this.userData[`preferred${key}` as keyof UserData] ||
+          []) as string[]),
+        ...((this.userData[`required${key}` as keyof UserData] ||
+          []) as string[]),
+        ...((this.userData[`included${key}` as keyof UserData] ||
+          []) as string[]),
+      ];
+    };
 
-            const aInUser = aIndex !== -1;
-            const bInUser = bIndex !== -1;
+    const sortByUserPreference = <T extends string>(
+      items: T[] | undefined,
+      userPrefs: string[]
+    ): T[] | null => {
+      if (!items) return null;
+      if (!userPrefs.length) return items;
+      return [...items].sort((a, b) => {
+        const aIndex = userPrefs.indexOf(a);
+        const bIndex = userPrefs.indexOf(b);
+        const aInPrefs = aIndex !== -1;
+        const bInPrefs = bIndex !== -1;
+        if (aInPrefs && bInPrefs) {
+          return aIndex - bIndex;
+        }
+        return aInPrefs ? -1 : bInPrefs ? 1 : 0;
+      });
+    };
 
-            return aInUser && bInUser
-              ? aIndex - bIndex
-              : aInUser
-                ? -1
-                : bInUser
-                  ? 1
-                  : values.indexOf(a) - values.indexOf(b);
-          })
-        : null;
+    const userSpecifiedLanguages = [
+      ...new Set(
+        getFieldValues('languages').map((lang) =>
+          lang === 'Original' && this.formatterContext.originalLanguage
+            ? this.formatterContext.originalLanguage
+            : lang
+        )
+      ),
+    ];
+
+    const buildLanguageVariants = (values: string[] | undefined) => {
+      const sortedValues = sortByUserPreference(values, userSpecifiedLanguages);
 
       const userValues = sortedValues
         ? sortedValues.filter((value) =>
@@ -333,57 +340,50 @@ export abstract class BaseFormatter {
           )
         : null;
 
-      const emojis = sortedValues
-        ? sortedValues
-            .map((value) => languageToEmoji(value) || value)
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
+      const applyModifiers = (
+        list: string[] | null,
+        ...modifiers: Array<(value: string) => string | undefined>
+      ): string[] | null => {
+        if (!list) return null;
 
-      const userEmojis = userValues
-        ? userValues
-            .map((value) => languageToEmoji(value) || value)
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
+        const modified = list.map((value) =>
+          modifiers.reduce<string | undefined>(
+            (acc, modifier) =>
+              acc !== undefined ? (modifier(acc) ?? acc) : undefined,
+            value
+          )
+        );
 
-      const codes = sortedValues
-        ? sortedValues
-            .map((value) => languageToCode(value) || value.toUpperCase())
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
-
-      const userCodes = userValues
-        ? userValues
-            .map((value) => languageToCode(value) || value.toUpperCase())
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
-
-      const smallCodes = sortedValues
-        ? sortedValues
-            .map((value) => languageToCode(value) || value)
-            .filter((value, index, self) => self.indexOf(value) === index)
-            .map((value) => makeSmall(value))
-        : null;
-
-      const userSmallCodes = userValues
-        ? userValues
-            .map((value) => languageToCode(value) || value)
-            .filter((value, index, self) => self.indexOf(value) === index)
-            .map((value) => makeSmall(value))
-        : null;
-
-      const usEmojis = sortedValues
-        ? sortedValues
-            .map((value) => languageToEmoji(value) || value)
-            .map((emoji) => emoji.replace('🇬🇧', '🇺🇸🦅'))
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
-
-      const userUsEmojis = userValues
-        ? userValues
-            .map((value) => languageToEmoji(value) || value)
-            .map((emoji) => emoji.replace('🇬🇧', '🇺🇸🦅'))
-            .filter((value, index, self) => self.indexOf(value) === index)
-        : null;
+        return [...new Set(modified.filter(Boolean) as string[])];
+      };
+      const emojis = applyModifiers(sortedValues, languageToEmoji);
+      const userEmojis = applyModifiers(userValues, languageToEmoji);
+      const codes = applyModifiers(
+        sortedValues,
+        (value) => languageToCode(value) || value.toUpperCase()
+      );
+      const userCodes = applyModifiers(
+        userValues,
+        (value) => languageToCode(value) || value.toUpperCase()
+      );
+      const smallCodes = applyModifiers(
+        sortedValues,
+        languageToCode,
+        makeSmall
+      );
+      const userSmallCodes = applyModifiers(
+        userValues,
+        languageToCode,
+        makeSmall
+      );
+      const usEmojis = applyModifiers(sortedValues, languageToEmoji, (emoji) =>
+        emoji.replace('🇬🇧', '🇺🇸🦅')
+      );
+      const userUsEmojis = applyModifiers(
+        userValues,
+        languageToEmoji,
+        (emoji) => emoji.replace('🇬🇧', '🇺🇸🦅')
+      );
 
       return {
         sortedValues,
@@ -399,8 +399,24 @@ export abstract class BaseFormatter {
       };
     };
 
-    const languageVariants = buildLanguageVariants(languages);
-    const subtitleVariants = buildLanguageVariants(subtitles);
+    const languageVariants = buildLanguageVariants(
+      stream.parsedFile?.languages
+    );
+    const subtitleVariants = buildLanguageVariants(
+      stream.parsedFile?.subtitles
+    );
+    const sortedAudioChannels = sortByUserPreference(
+      stream.parsedFile?.audioChannels,
+      getFieldValues('audioChannels')
+    );
+    const sortedAudioTags = sortByUserPreference(
+      stream.parsedFile?.audioTags,
+      getFieldValues('audioTags')
+    );
+    const sortedVisualTags = sortByUserPreference(
+      stream.parsedFile?.visualTags,
+      getFieldValues('visualTags')
+    );
 
     const formattedAge = stream.age ? formatHours(stream.age) : null;
     const parseValue: ParseValue = {
@@ -436,8 +452,8 @@ export abstract class BaseFormatter {
         uSmallSubtitleCodes: subtitleVariants.userSmallCodes,
         wedontknowwhatakilometeris: languageVariants.usEmojis,
         uWedontknowwhatakilometeris: languageVariants.userUsEmojis,
-        visualTags: stream.parsedFile?.visualTags || null,
-        audioTags: stream.parsedFile?.audioTags || null,
+        visualTags: sortedVisualTags,
+        audioTags: sortedAudioTags,
         releaseGroup: stream.parsedFile?.releaseGroup || null,
         regexMatched:
           stream.regexMatched?.name || stream.rankedRegexesMatched?.[0] || null,
@@ -462,7 +478,7 @@ export abstract class BaseFormatter {
               )
             : null,
         encode: stream.parsedFile?.encode || null,
-        audioChannels: stream.parsedFile?.audioChannels || null,
+        audioChannels: sortedAudioChannels || null,
         indexer: stream.indexer || null,
         seeders: stream.torrent?.seeders ?? null,
         private: stream.torrent?.private ?? false,


### PR DESCRIPTION
Refactor language sorting into a reusable generic sortByUserPreference function and apply the same preference-based ordering to visualTags, audioTags, and audioChannels. Build deduplicated user-specified lists (preferred/required/included) for each category and use them when sorting parsedFile values, falling back to original order or null when appropriate. This ensures user-preferred items are prioritized in formatted output without changing null handling semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Prioritises user-specified language preferences (including original-language) when showing language and subtitle options.
  * Deduplicates and consolidates language variants for clearer choices.
  * Better sorts visual tags, audio tags and audio channels to reflect user preferences.
  * More consistent prioritisation across languages, subtitles and multimedia metadata for a clearer user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->