### PR TITLE
fix: Incorrect uuid or password when importing a config

### DIFF
--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -355,6 +355,8 @@ function Content() {
           );
           return;
         }
+        delete parsed.uuid;
+        delete parsed.trusted;
         setUserData((prev) => ({
           ...prev,
           ...applyMigrations(parsed),


### PR DESCRIPTION
When importing a backup config, it includes the uuid and trusted status that was in the config. When importing it could temporarily show you as a trusted user on the frontend, and the synced urls would show incorrect uuid or password, both of these would be fixed on a page reload + re-login. This fix deletes those fields on importing which would avoid the mismatch, and the need to refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed configuration import handling to prevent certain sensitive properties from being unintentionally reapplied during the import process, improving the reliability and security of imported user data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->