### PR TITLE
feat: integrate AIOratings as a poster service

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -547,7 +547,9 @@ export const UserDataSchema = z.object({
   rpdbApiKey: z.string().optional(),
   // rpdbUseRedirectApi: z.boolean().optional(),
   topPosterApiKey: z.string().optional(),
-  posterService: z.enum(['rpdb', 'top-poster', 'none']).optional(),
+  aioratingsApiKey: z.string().optional(),
+  aioratingsProfileId: z.string().optional(),
+  posterService: z.enum(['rpdb', 'top-poster', 'aioratings', 'none']).optional(),
   usePosterRedirectApi: z.boolean().optional(),
   usePosterServiceForMeta: z.boolean().optional(),
   formatter: Formatter,
@@ -1230,6 +1232,11 @@ export const TopPosterIsValidResponse = z.object({
   valid: z.boolean(),
 });
 export type TopPosterIsValidResponse = z.infer<typeof TopPosterIsValidResponse>;
+
+export const AIOratingsIsValidResponse = z.object({
+  valid: z.boolean(),
+});
+export type AIOratingsIsValidResponse = z.infer<typeof AIOratingsIsValidResponse>;
 
 export const TemplateSchema = z.object({
   metadata: z.object({

--- a/packages/core/src/utils/aioratings.ts
+++ b/packages/core/src/utils/aioratings.ts
@@ -1,0 +1,179 @@
+import { Cache } from './cache.js';
+import { makeRequest } from './http.js';
+import { AIOratingsIsValidResponse } from '../db/schemas.js';
+import { Env } from './env.js';
+import { IdParser } from './id-parser.js';
+import { AnimeDatabase } from './anime-database.js';
+
+const apiKeyValidationCache = Cache.getInstance<string, boolean>(
+  'aioratingsApiKey'
+);
+const posterCheckCache = Cache.getInstance<string, string>('aioratingsCheck');
+
+export class AIOratings {
+  private readonly apiKey: string;
+  private readonly profileId: string;
+  constructor(apiKey: string, profileId: string = 'default') {
+    this.apiKey = apiKey.trim();
+    if (!this.apiKey) {
+      throw new Error('AIOratings API key is not set');
+    }
+    this.profileId = profileId.trim() || 'default';
+  }
+
+  public async validateApiKey(): Promise<boolean> {
+    const cached = await apiKeyValidationCache.get(this.apiKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let response;
+    try {
+      response = await makeRequest(
+        `${Env.AIORATINGS_API_URL}/api/${this.apiKey}/isValid`,
+        {
+          timeout: 10000,
+          ignoreRecursion: true,
+        }
+      );
+    } catch (error: any) {
+      throw new Error(
+        `Failed to connect to AIOratings API: ${error.message}`
+      );
+    }
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('Invalid AIOratings API key');
+      } else if (response.status === 429) {
+        throw new Error('AIOratings API rate limit exceeded');
+      } else {
+        throw new Error(
+          `AIOratings API returned an unexpected status: ${response.status} - ${response.statusText}`
+        );
+      }
+    }
+
+    let data;
+    try {
+      data = AIOratingsIsValidResponse.parse(await response.json());
+    } catch (error: any) {
+      throw new Error(
+        `AIOratings API returned malformed JSON: ${error.message}`
+      );
+    }
+
+    if (!data.valid) {
+      throw new Error('Invalid AIOratings API key');
+    }
+
+    apiKeyValidationCache.set(
+      this.apiKey,
+      data.valid,
+      Env.RPDB_API_KEY_VALIDITY_CACHE_TTL
+    );
+    return data.valid;
+  }
+
+  private parseId(
+    type: string,
+    id: string
+  ): { idType: 'tmdb' | 'imdb'; idValue: string } | null {
+    const parsedId = IdParser.parse(id, type);
+    if (!parsedId) return null;
+
+    let idType: 'tmdb' | 'imdb' | null = null;
+    let idValue: string | null = null;
+
+    switch (parsedId.type) {
+      case 'imdbId':
+        idType = 'imdb';
+        idValue = parsedId.value.toString();
+        break;
+      case 'themoviedbId': {
+        idType = 'tmdb';
+        // aioratings uses 'tv' not 'series'
+        const tmdbType = type === 'series' ? 'tv' : type;
+        idValue = `${tmdbType}-${parsedId.value}`;
+        break;
+      }
+      case 'thetvdbId': {
+        // aioratings doesn't support tvdb, fall through to AnimeDatabase
+        const entry = AnimeDatabase.getInstance().getEntryById(
+          'thetvdbId',
+          parsedId.value
+        );
+        if (!entry) return null;
+
+        if (entry.mappings?.imdbId) {
+          idType = 'imdb';
+          idValue = entry.mappings.imdbId.toString();
+        } else if (entry.mappings?.themoviedbId) {
+          idType = 'tmdb';
+          const tmdbType = type === 'series' ? 'tv' : type;
+          idValue = `${tmdbType}-${entry.mappings.themoviedbId}`;
+        } else {
+          return null;
+        }
+        break;
+      }
+      default: {
+        // Try to map unsupported id types via AnimeDatabase
+        const entry = AnimeDatabase.getInstance().getEntryById(
+          parsedId.type,
+          parsedId.value
+        );
+        if (!entry) return null;
+
+        if (entry.mappings?.imdbId) {
+          idType = 'imdb';
+          idValue = entry.mappings.imdbId.toString();
+        } else if (entry.mappings?.themoviedbId) {
+          idType = 'tmdb';
+          const tmdbType = type === 'series' ? 'tv' : type;
+          idValue = `${tmdbType}-${entry.mappings.themoviedbId}`;
+        } else {
+          return null;
+        }
+        break;
+      }
+    }
+    if (!idType || !idValue) return null;
+    return { idType, idValue };
+  }
+
+  public async getPosterUrl(
+    type: string,
+    id: string,
+    checkExists: boolean = true
+  ): Promise<string | null> {
+    const parsed = this.parseId(type, id);
+    if (!parsed) return null;
+    const { idType, idValue } = parsed;
+
+    const cacheKey = `${type}-${id}-${this.apiKey}-${this.profileId}`;
+    const cached = await posterCheckCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const posterUrl = `${Env.AIORATINGS_API_URL}/api/${this.apiKey}/${idType}/${this.profileId}/${idValue}.jpg`;
+    if (!checkExists) {
+      return posterUrl;
+    }
+    try {
+      const response = await makeRequest(posterUrl, {
+        method: 'HEAD',
+        timeout: 3000,
+        ignoreRecursion: true,
+      });
+      if (!response.ok) {
+        return null;
+      }
+    } catch (error) {
+      return null;
+    }
+    posterCheckCache.set(cacheKey, posterUrl, 24 * 60 * 60);
+    return posterUrl;
+  }
+}

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -19,6 +19,7 @@ import {
   Env,
   maskSensitiveInfo,
   RPDB,
+  AIOratings,
   FeatureControl,
   RegexAccess,
   compileRegex,
@@ -480,6 +481,21 @@ export async function validateConfig(
         throw new Error(`Invalid RPDB API key: ${error}`);
       }
       logger.warn(`Invalid RPDB API key: ${error}`);
+    }
+  }
+
+  if (config.aioratingsApiKey) {
+    try {
+      const aioratings = new AIOratings(
+        config.aioratingsApiKey,
+        config.aioratingsProfileId || 'default'
+      );
+      await aioratings.validateApiKey();
+    } catch (error) {
+      if (!options?.skipErrorsFromAddonsOrProxies) {
+        throw new Error(`Invalid AIOratings API key: ${error}`);
+      }
+      logger.warn(`Invalid AIOratings API key: ${error}`);
     }
   }
 

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -729,7 +729,9 @@ const TOP_LEVEL_OPTION_DETAILS: Record<
   | 'tmdbAccessToken'
   | 'rpdbApiKey'
   | 'tvdbApiKey'
-  | 'topPosterApiKey',
+  | 'topPosterApiKey'
+  | 'aioratingsApiKey'
+  | 'aioratingsProfileId',
   {
     name: string;
     description: string;
@@ -759,6 +761,16 @@ const TOP_LEVEL_OPTION_DETAILS: Record<
     name: 'TVDB API Key',
     description:
       'Sign up for a free API Key at [TVDB](https://www.thetvdb.com/api-information) and then get it from your [dashboard](https://www.thetvdb.com/dashboard/account/apikeys).',
+  },
+  aioratingsApiKey: {
+    name: 'AIOratings API Key',
+    description:
+      'Get your API key from [here](https://aioratings.com) for custom posters with ratings.',
+  },
+  aioratingsProfileId: {
+    name: 'AIOratings Profile ID',
+    description:
+      'Use "default" for the default profile, or enter a custom profile UUID from your AIOratings dashboard.',
   },
 };
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -727,6 +727,10 @@ export const Env = cleanEnv(process.env, {
     default: 604800, // 7 days
     desc: 'Cache TTL for RPDB API key validity',
   }),
+  AIORATINGS_API_URL: str({
+    default: 'https://apiv2.aioratings.com',
+    desc: 'Base URL for the AIOratings API',
+  }),
 
   PRECACHE_NEXT_EPISODE_MIN_INTERVAL: num({
     default: 86400, // 24 hours

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,6 +17,7 @@ export * from './startup.js';
 export * from './extras.js';
 export * from './rpdb.js';
 export * from './top-poster.js';
+export * from './aioratings.js';
 export * from './distributed-lock.js';
 export * from './id-parser.js';
 export * from './anime-database.js';

--- a/packages/frontend/src/components/menu/services.tsx
+++ b/packages/frontend/src/components/menu/services.tsx
@@ -311,12 +311,13 @@ function Content() {
             { label: 'None', value: 'none' },
             { label: 'RPDB', value: 'rpdb' },
             { label: 'Top Poster', value: 'top-poster' },
+            { label: 'AIOratings', value: 'aioratings' },
           ]}
           value={userData.posterService || 'rpdb'}
           onValueChange={(v) => {
             setUserData((prev) => ({
               ...prev,
-              posterService: v as 'rpdb' | 'top-poster' | 'none',
+              posterService: v as 'rpdb' | 'top-poster' | 'aioratings' | 'none',
             }));
           }}
           defaultValue="rpdb"
@@ -374,6 +375,61 @@ function Content() {
             }}
           />
         )}
+        {userData.posterService === 'aioratings' && (
+          <>
+            <PasswordInput
+              autoComplete="new-password"
+              label="AIOratings API Key"
+              help={
+                <span>
+                  Get your API Key from{' '}
+                  <a
+                    href="https://aioratings.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[--brand] hover:underline"
+                  >
+                    here
+                  </a>
+                </span>
+              }
+              value={userData.aioratingsApiKey}
+              onValueChange={(v) => {
+                setUserData((prev) => ({
+                  ...prev,
+                  aioratingsApiKey: v,
+                }));
+              }}
+            />
+            <TextInput
+              label="AIOratings Profile ID"
+              help={
+                <span>
+                  Custom profiles are a premium feature that lets you design
+                  your own poster layout. Premium users can map their API key
+                  and default posters dynamically from the{' '}
+                  <a
+                    href="https://aioratings.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[--brand] hover:underline"
+                  >
+                    AIOratings website
+                  </a>
+                  . Free users can leave this as &quot;default&quot;.
+                </span>
+              }
+              value={userData.aioratingsProfileId || 'default'}
+              placeholder="default"
+              onValueChange={(v) => {
+                setUserData((prev) => ({
+                  ...prev,
+                  aioratingsProfileId: v,
+                }));
+              }}
+            />
+          </>
+        )}
 
         <Switch
           label="Use Poster Service for Library/Continue Watching"
@@ -387,7 +443,9 @@ function Content() {
           }}
           disabled={
             userData.posterService === 'none' ||
-            (!userData.rpdbApiKey && !userData.topPosterApiKey)
+            (!userData.rpdbApiKey &&
+              !userData.topPosterApiKey &&
+              !userData.aioratingsApiKey)
           }
           help={
             <span>
@@ -403,7 +461,9 @@ function Content() {
           side="right"
           disabled={
             userData.posterService === 'none' ||
-            (!userData.rpdbApiKey && !userData.topPosterApiKey)
+            (!userData.rpdbApiKey &&
+              !userData.topPosterApiKey &&
+              !userData.aioratingsApiKey)
           }
           help={
             <span>

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -7,6 +7,7 @@ import {
   catalogApi,
   rpdbApi,
   topPosterApi,
+  aioratingsApi,
   gdriveApi,
   debridApi,
   searchApi,
@@ -101,6 +102,7 @@ apiRouter.use('/format', formatApi);
 apiRouter.use('/catalogs', catalogApi);
 apiRouter.use('/rpdb', rpdbApi);
 apiRouter.use('/top-poster', topPosterApi);
+apiRouter.use('/aioratings', aioratingsApi);
 apiRouter.use('/oauth/exchange/gdrive', gdriveApi);
 apiRouter.use('/debrid', debridApi);
 if (Env.ENABLE_SEARCH_API) {

--- a/packages/server/src/routes/api/aioratings.ts
+++ b/packages/server/src/routes/api/aioratings.ts
@@ -1,0 +1,66 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  APIError,
+  constants,
+  createLogger,
+  formatZodError,
+  AIOratings,
+} from '@aiostreams/core';
+import { createResponse } from '../../utils/responses.js';
+import { z } from 'zod';
+
+const router: Router = Router();
+const logger = createLogger('server');
+
+const searchParams = z.object({
+  id: z.string(),
+  type: z.string(),
+  fallback: z.string().optional(),
+  apiKey: z.string(),
+  profileId: z.string().optional(),
+});
+
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { success, data, error } = searchParams.safeParse(req.query);
+    if (!success) {
+      res.status(400).json(
+        createResponse({
+          success: false,
+          detail: 'Invalid request',
+          error: {
+            code: constants.ErrorCode.BAD_REQUEST,
+            message: formatZodError(error),
+          },
+        })
+      );
+      return;
+    }
+    const { id, type, fallback, apiKey, profileId } = data;
+    const aioratings = new AIOratings(apiKey, profileId || 'default');
+    let posterUrl: string | null = await aioratings.getPosterUrl(type, id);
+
+    posterUrl = posterUrl || fallback || null;
+
+    if (!posterUrl) {
+      res.status(404).json(
+        createResponse({
+          success: false,
+          detail: 'Not found',
+        })
+      );
+      return;
+    }
+    res.redirect(301, posterUrl!);
+  } catch (error: any) {
+    next(
+      new APIError(
+        constants.ErrorCode.INTERNAL_SERVER_ERROR,
+        undefined,
+        error.message
+      )
+    );
+  }
+});
+
+export default router;

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -5,6 +5,7 @@ export { default as formatApi } from './format.js';
 export { default as catalogApi } from './catalog.js';
 export { default as rpdbApi } from './rpdb.js';
 export { default as topPosterApi } from './top-poster.js';
+export { default as aioratingsApi } from './aioratings.js';
 export { default as gdriveApi } from './gdrive.js';
 export { default as debridApi } from './debrid.js';
 export { default as searchApi } from './search.js';


### PR DESCRIPTION
Add AIOratings alongside RPDB and Top Poster as a selectable poster service. AIOratings supports custom poster profiles with configurable rating overlays via imdb and tmdb IDs (with series→tv conversion and tvdb fallback through AnimeDatabase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AIOratings as a new poster service provider option. Users can now select AIOratings from the poster service dropdown and configure their API credentials via new AIOratings API Key and Profile ID fields in settings. This expands available poster source options alongside existing providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->