### PR TITLE
feat(strm): implement STRM output feature with user-agent handling

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -625,6 +625,13 @@ export const UserDataSchema = z.object({
   externalDownloads: z.boolean().optional(),
   cacheAndPlay: CacheAndPlaySchema.optional(),
 
+  strmOutput: z
+    .object({
+      mode: z.enum(['disabled', 'always', 'userAgent']).optional(),
+      userAgents: z.array(z.string().min(1)).optional(),
+    })
+    .optional(),
+
   autoRemoveDownloads: z.boolean().optional(),
 });
 

--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -189,7 +189,10 @@ export class StreamContext {
       this.userData.excludedStreamExpressions?.length ||
       this.userData.requiredStreamExpressions?.length ||
       this.userData.includedStreamExpressions?.length ||
-      (this.userData.precacheNextEpisode && this.type === 'series');
+      (this.userData.precacheNextEpisode && this.type === 'series') ||
+      // STRM output needs metadata for filename generation (title, year, tmdbId)
+      (this.userData.strmOutput?.mode &&
+        this.userData.strmOutput.mode !== 'disabled');
 
     if (!needsMetadata || !this.parsedId) {
       this._metadataFetched = true;

--- a/packages/frontend/src/components/menu/miscellaneous.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous.tsx
@@ -449,6 +449,69 @@ function Content() {
           </SettingsCard>
         )}
         {mode === 'pro' && (
+          <SettingsCard
+            title="STRM Output"
+            description={
+              <div className="space-y-2">
+                <p>
+                  When enabled, stream URLs are routed through a gate endpoint.
+                  If the player&apos;s User-Agent matches, a .strm file is
+                  served instead of a direct link.
+                </p>
+                <Alert intent="info-basic">
+                  <p className="text-sm">
+                    In &quot;User-Agent Dependent&quot; mode, non-matching
+                    clients are transparently redirected to the direct stream
+                    URL.
+                  </p>
+                </Alert>
+              </div>
+            }
+          >
+            <Select
+              label="Mode"
+              options={[
+                { label: 'Disabled', value: 'disabled' },
+                { label: 'Always', value: 'always' },
+                { label: 'User-Agent Dependent', value: 'userAgent' },
+              ]}
+              value={userData.strmOutput?.mode || 'disabled'}
+              onValueChange={(value) => {
+                setUserData((prev) => ({
+                  ...prev,
+                  strmOutput: {
+                    ...prev.strmOutput,
+                    mode: value as 'disabled' | 'always' | 'userAgent',
+                  },
+                }));
+              }}
+            />
+            {userData.strmOutput?.mode === 'userAgent' && (
+              <TextInput
+                label="User Agents"
+                help="Comma-separated list of User-Agent substrings to match (case-insensitive). If the player's User-Agent contains any of these, a .strm file is served."
+                placeholder="e.g., Infuse, VLC, mpv"
+                value={(userData.strmOutput?.userAgents ?? ['Infuse']).join(
+                  ', '
+                )}
+                onValueChange={(value) => {
+                  const agents = value
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                  setUserData((prev) => ({
+                    ...prev,
+                    strmOutput: {
+                      ...prev.strmOutput,
+                      userAgents: agents.length > 0 ? agents : undefined,
+                    },
+                  }));
+                }}
+              />
+            )}
+          </SettingsCard>
+        )}
+        {mode === 'pro' && (
           <SettingsCard title="Hide Errors">
             <Switch
               label="Hide Errors"

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -14,6 +14,7 @@ import {
   proxyApi,
   templatesApi,
   syncApi,
+  strmApi,
 } from './routes/api/index.js';
 import {
   configure,
@@ -110,6 +111,7 @@ apiRouter.use('/anime', animeApi);
 apiRouter.use('/proxy', proxyApi);
 apiRouter.use('/templates', templatesApi);
 apiRouter.use('/sync', syncApi);
+apiRouter.use('/strm-gate', strmApi);
 app.use(`/api/v${constants.API_VERSION}`, apiRouter);
 
 // Stremio Routes

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -12,3 +12,4 @@ export { default as animeApi } from './anime.js';
 export { default as proxyApi } from './proxy.js';
 export { default as templatesApi } from './templates.js';
 export { default as syncApi } from './sync.js';
+export { default as strmApi } from './strm.js';

--- a/packages/server/src/routes/api/strm.ts
+++ b/packages/server/src/routes/api/strm.ts
@@ -1,0 +1,80 @@
+import { Router, Request, Response } from 'express';
+import { createLogger, decryptString } from '@aiostreams/core';
+
+const logger = createLogger('strm-gate');
+const router: Router = Router();
+
+interface StrmGatePayload {
+  url: string;
+  mode: 'always' | 'userAgent';
+  userAgents: string[];
+}
+
+router.get('/:data/:filename', (req: Request, res: Response) => {
+  try {
+    const { data, filename } = req.params;
+
+    // Decrypt the payload
+    const decrypted = decryptString(data);
+    if (!decrypted.success || !decrypted.data) {
+      logger.error('Failed to decrypt STRM gate data');
+      res.status(400).send('Invalid request');
+      return;
+    }
+
+    let payload: StrmGatePayload;
+    try {
+      payload = JSON.parse(decrypted.data);
+    } catch {
+      logger.error('Failed to parse STRM gate payload');
+      res.status(400).send('Invalid request');
+      return;
+    }
+
+    if (!payload.url || !payload.mode) {
+      logger.error('Missing required fields in STRM gate payload');
+      res.status(400).send('Invalid request');
+      return;
+    }
+
+    // Determine if we should serve a .strm file or redirect
+    let serveStrm = false;
+
+    if (payload.mode === 'always') {
+      serveStrm = true;
+    } else if (payload.mode === 'userAgent') {
+      const clientUserAgent = (req.headers['user-agent'] || '').toLowerCase();
+      const userAgents = payload.userAgents || ['Infuse'];
+      serveStrm = userAgents.some((ua) =>
+        clientUserAgent.includes(ua.toLowerCase())
+      );
+    }
+
+    if (serveStrm) {
+      // Serve the .strm file
+      const strmFilename = filename.endsWith('.strm')
+        ? filename
+        : `${filename}.strm`;
+
+      logger.info(`Serving STRM file: ${strmFilename}`);
+
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${strmFilename}"`
+      );
+      res.status(200).send(payload.url);
+    } else {
+      // Redirect to the actual stream URL
+      logger.debug('STRM gate: User-Agent did not match, redirecting');
+      res.redirect(302, payload.url);
+    }
+  } catch (error) {
+    logger.error(
+      `STRM gate error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+    res.status(500).send('Internal server error');
+  }
+});
+
+export default router;

--- a/packages/server/src/routes/stremio/stream.ts
+++ b/packages/server/src/routes/stremio/stream.ts
@@ -7,6 +7,8 @@ import {
   StremioTransformer,
   Cache,
   IdParser,
+  constants,
+  encryptString,
 } from '@aiostreams/core';
 import { stremioStreamRateLimiter } from '../../middlewares/ratelimit.js';
 
@@ -15,6 +17,87 @@ const router: Router = Router();
 const logger = createLogger('server');
 
 router.use(stremioStreamRateLimiter);
+
+/**
+ * Convert a string to Title Case (capitalize first letter of each word).
+ */
+function toTitleCase(str: string): string {
+  return str.replace(
+    /\w\S*/g,
+    (word) => word.charAt(0).toUpperCase() + word.slice(1)
+  );
+}
+
+/**
+ * Generate the STRM filename from metadata.
+ */
+function generateStrmFilename(
+  metadata: { title?: string; year?: number } | undefined,
+  parsedId: {
+    type: string;
+    value: string | number;
+    season?: string;
+    episode?: string;
+  } | null,
+  type: string
+): string {
+  // Build the base name from metadata title or fallback, with Title Case
+  let baseName = toTitleCase(metadata?.title || 'Unknown');
+
+  // Add year for movies
+  if (metadata?.year) {
+    baseName += ` (${metadata.year})`;
+  }
+
+  // Add season/episode for series
+  if (type === 'series' && parsedId?.season && parsedId?.episode) {
+    const season = String(parsedId.season).padStart(2, '0');
+    const episode = String(parsedId.episode).padStart(2, '0');
+    baseName += ` S${season}E${episode}`;
+  }
+
+  return `${baseName}.strm`;
+}
+
+/**
+ * Wrap stream URLs through the STRM gate endpoint.
+ * The gate will decide at request time (based on User-Agent) whether to serve
+ * a .strm file or redirect to the actual stream URL.
+ * The URL looks identical to a normal API call - the .strm filename is only
+ * used in the Content-Disposition header when the gate serves the file.
+ */
+function wrapStreamsWithStrmGate(
+  result: AIOStreamResponse,
+  strmFilename: string,
+  strmMode: 'always' | 'userAgent',
+  userAgents: string[]
+): AIOStreamResponse {
+  const wrappedStreams = result.streams.map((stream) => {
+    // Only wrap streams that have an HTTP url
+    if (!stream.url) {
+      return stream;
+    }
+
+    const payload = JSON.stringify({
+      url: stream.url,
+      mode: strmMode,
+      userAgents,
+    });
+
+    const encrypted = encryptString(payload);
+    if (!encrypted.success || !encrypted.data) {
+      logger.warn('Failed to encrypt STRM gate payload, keeping original URL');
+      return stream;
+    }
+
+    return {
+      ...stream,
+      url: `${Env.BASE_URL}/api/v${constants.API_VERSION}/strm-gate/${encrypted.data}/${encodeURIComponent(strmFilename)}`,
+    };
+  });
+
+  return { ...result, streams: wrappedStreams };
+}
 
 router.get(
   '/:type/:id.json',
@@ -56,15 +139,36 @@ router.get(
         throw new Error('Stream context not available');
       }
 
-      res
-        .status(200)
-        .json(
-          await transformer.transformStreams(
-            response,
-            streamContext.toFormatterContext(response.data.streams),
-            { provideStreamData, disableAutoplay }
-          )
+      let result = await transformer.transformStreams(
+        response,
+        streamContext.toFormatterContext(response.data.streams),
+        { provideStreamData, disableAutoplay }
+      );
+
+      // STRM Gate wrapping: wrap stream URLs through the gate endpoint
+      const strmConfig = req.userData.strmOutput;
+      if (strmConfig?.mode && strmConfig.mode !== 'disabled') {
+        const metadata = await streamContext.getMetadata();
+        const strmFilename = generateStrmFilename(
+          metadata,
+          streamContext.parsedId,
+          type
         );
+        const userAgents = strmConfig.userAgents ?? ['Infuse'];
+
+        result = wrapStreamsWithStrmGate(
+          result,
+          strmFilename,
+          strmConfig.mode as 'always' | 'userAgent',
+          userAgents
+        );
+
+        logger.info(
+          `Wrapped ${result.streams.filter((s) => s.url?.includes('/strm-gate/')).length} streams with STRM gate (mode: ${strmConfig.mode}, filename: ${strmFilename})`
+        );
+      }
+
+      res.status(200).json(result);
     } catch (error) {
       let errorMessage =
         error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## STRM Output Support (Infuse / Third-Party Player Compatibility)

### Summary

Adds a new "STRM Output" feature that allows AIOStreams to serve `.strm` files instead of direct stream links when accessed by specific media players (like [Infuse](https://firecore.com/infuse)). This enables seamless integration with players that use `.strm` files for library management and metadata matching.

### How It Works

When enabled, all HTTP stream URLs are routed through a new **STRM Gate** endpoint (`/api/v1/strm-gate/`). This endpoint acts as a transparent intermediary:

1. **Stremio** requests streams normally and receives the JSON response with gate URLs
2. When a player opens a stream URL, the gate checks the player's `User-Agent` header
3. **If the User-Agent matches** (e.g., contains "Infuse"): the gate serves a `.strm` text file containing the actual (potentially proxied) video URL, with a proper `Content-Disposition` filename
4. **If the User-Agent does not match**: the gate performs a transparent `302 redirect` to the actual stream URL — behavior is identical to before

```
Stremio → Gate URL → 302 redirect → Video URL (normal playback)
Infuse  → Gate URL → .strm file   → Video URL (Infuse reads it)
```

### STRM Filename

The `.strm` filename follows media player conventions for metadata matching:
- **Movies**: `Title (Year).strm` (e.g., `Inception (2010).strm`)
- **Series**: `Title (Year) S01E02.strm` (e.g., `Breaking Bad (2008) S01E01.strm`)

The filename is derived from TMDB metadata (title, year) with proper Title Case formatting.

### Configuration

A new **"STRM Output"** settings card is available in the **Miscellaneous** section (Pro mode):

| Option | Description |
|--------|-------------|
| **Disabled** | No STRM processing (default) |
| **Always** | Always serve `.strm` files regardless of User-Agent |
| **User-Agent Dependent** | Serve `.strm` only when the player's User-Agent matches configured strings |

When "User-Agent Dependent" is selected, users can specify a comma-separated list of User-Agent substrings to match (case-insensitive). Default: `Infuse`.

<img width="1786" height="242" alt="image" src="https://github.com/user-attachments/assets/786720df-de3d-4c5b-ada7-6d6136c47277" />

<img width="1787" height="246" alt="image" src="https://github.com/user-attachments/assets/123ba3e6-e09b-4104-9d15-a1c62ced2bd3" />

<img width="1774" height="342" alt="image" src="https://github.com/user-attachments/assets/2f889ea4-b748-4f4a-97c8-4fcb7aea14aa" />


### Changes

#### New Files
- `packages/server/src/routes/api/strm.ts` — STRM Gate endpoint that decrypts the payload, checks User-Agent, and either serves a `.strm` file or redirects

#### Modified Files
- `packages/core/src/db/schemas.ts` — Added `strmOutput` config schema (`mode`, `userAgents`)
- `packages/core/src/streams/context.ts` — Metadata fetch is triggered when STRM output is active (needed for filename generation)
- `packages/server/src/routes/stremio/stream.ts` — Post-processing logic to wrap stream URLs through the STRM gate, with filename generation from metadata
- `packages/server/src/routes/api/index.ts` — Export new STRM route
- `packages/server/src/app.ts` — Register `/strm-gate` API route
- `packages/frontend/src/components/menu/miscellaneous.tsx` — New "STRM Output" settings card with Mode select and User Agents input

### Notes

- Only streams with HTTP URLs are wrapped (P2P/torrent, YouTube, external URLs are not affected)
- Proxied stream URLs are preserved — the `.strm` file contains the already-proxied URL
- The encrypted gate payload uses the same `encryptString`/`decryptString` mechanism as the built-in proxy
- No breaking changes — the feature is disabled by default

### References

- [Infuse STRM Files documentation](https://support.firecore.com/hc/en-us/articles/30038115451799-STRM-Files)
- [Infuse Metadata 101 (file naming conventions)](https://support.firecore.com/hc/fr/articles/215090947-M%C3%A9tadonn%C3%A9es-101)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added STRM Output settings for Pro mode users with configurable streaming modes
  * Implemented User-Agent dependent streaming to serve .strm files or redirect based on device type
  * Extended metadata fetching to support STRM output configurations
  * Added new API endpoint for STRM gate functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->