### PR TITLE
fix(debrid): limit torbox magnet checks to 2 per user at any given time

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   },
   "engines": {
     "node": ">=24.0.0"
+  },
+  "dependencies": {
+    "lru-cache": "^11.2.6"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "expr-eval": "^2.0.2",
     "fetch-socks": "^1.3.2",
     "fuzzball": "^2.2.3",
+    "lru-cache": "^11.2.6",
     "moment-timezone": "^0.5.48",
     "p-limit": "^7.3.0",
     "parse-torrent": "^11.0.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      lru-cache:
+        specifier: ^11.2.6
+        version: 11.2.6
     devDependencies:
       cross-env:
         specifier: ^7.0.3
@@ -56,6 +60,9 @@ importers:
       fuzzball:
         specifier: ^2.2.3
         version: 2.2.3
+      lru-cache:
+        specifier: ^11.2.6
+        version: 11.2.6
       moment-timezone:
         specifier: ^0.5.48
         version: 0.5.48
@@ -3141,7 +3148,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3601,6 +3608,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -8440,6 +8451,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.2.6: {}
 
   lru-cache@6.0.0:
     dependencies:


### PR DESCRIPTION
this is a simple and stupid workaround to avoid hitting the 5/s limits with the current aiostreams design. it seems to work quite well on my local system and should still leave room for wrapped add-ons doing their own availability checks.

in case this gets merged - something similar will be needed for nzb checks too I suppose. I only have a single indexer and don't experience problems there though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Added lru-cache dependency to manage cached controls and improve stability.

* **Performance Improvements**
  * Improved magnet validation by introducing per-account concurrency limits, reducing request spikes and improving overall responsiveness and resource efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->