### PR TITLE
fix: Stop overrides from mismatching in the backend

### DIFF
--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -227,13 +227,12 @@ export class SelAccess {
       // Match by extracted names vs stored exprNames
       if (o.exprNames && o.exprNames.length > 0) {
         const names = extractNamesFromExpression(expr.expression, false);
-        const legacyNames = extractNamesFromExpression(expr.expression, true);
         const matches = (list?: string[]) =>
           !!list &&
           list.length === o.exprNames!.length &&
           list.every((n, i) => n === o.exprNames![i]);
 
-        if (matches(names) || matches(legacyNames)) {
+        if (matches(names)) {
           return true;
         }
       }


### PR DESCRIPTION
The fallback was causing an issue where if you only had an override for web T1 and nothing else, anime web T1 would first check name matches, then fallback to legacy name matches where it would then incorrectly apply the override. This override does not show in the frontend, causing mismatched buggy behavior. I think just getting rid of the fallback is the cleanest and most bug free way to deal with this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined selector override matching to use exact-name criteria only, removing legacy name variant matching from override resolution and streamlining the matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->