### PR TITLE
fix(parser): extend 10bit regex to match hi10p (H.264 High 10 Profile)

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -79,7 +79,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     SCR: createRegex('((dvd|bd|web|hd)?[ .\\-_]?)?(scr(eener)?)'),
   },
   visualTags: {
-    '10bit': createRegex('10[ .\\-_]?bit'),
+    '10bit': createRegex('10[ .\\-_]?bit|hi10p'),
     'HDR10+': createRegex('hdr[ .\\-_]?10[ .\\-_]?(p(lus)?|[+])'),
     HDR10: createRegex('hdr[ .\\-_]?10(?![ .\\-_]?(?:\\+|p(lus)?))'),
     HDR: createRegex('hdr(?![ .\\-_]?10)(?![ .\\-_]?(?:\\+|p(lus)?))'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded video codec variant recognition to support the hi10p format in addition to existing codec detection patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->