### PR TITLE
fix: prevent UHD in title from incorrectly classifying 1080p as 4K

### DIFF
--- a/packages/core/src/parser/file.ts
+++ b/packages/core/src/parser/file.ts
@@ -86,7 +86,9 @@ class FileParser {
       filename = filename.replace(parsed.title, '').trim();
       filename = filename.replace(/\s+/g, '.').replace(/^\.+|\.+$/g, '');
     }
-    const resolution = matchPattern(filename, PARSE_REGEX.resolutions);
+    const resolution =
+      matchPattern(filename, PARSE_REGEX.resolutions) ||
+      matchPattern(filename, PARSE_REGEX.alternativeResolutions);
     const quality = matchPattern(filename, PARSE_REGEX.qualities);
     const encode = matchPattern(filename, PARSE_REGEX.encodes);
     const audioChannels = matchMultiplePatterns(

--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -38,27 +38,33 @@ type PARSE_REGEX = {
   >;
   encodes: Omit<Record<(typeof constants.ENCODES)[number], RegExp>, 'Unknown'>;
   releaseGroup: RegExp;
+  alternativeResolutions: Partial<
+    Record<(typeof constants.RESOLUTIONS)[number], RegExp>
+  >;
 };
 
 export const PARSE_REGEX: PARSE_REGEX = {
   resolutions: {
     '2160p': createRegex(
-      '(bd|hd|m)?(4k|2160(p|i)?)|u(ltra)?[ .\\-_]?hd|3840\\s?x\\s?(\\d{4})'
+      '(bd|hd|m)?2160(p|i)?|4k[-_. ](?:u(ltra)?[ .\\-_]?hd|hevc|bd|(h|x)\\.?265)|(?:u(ltra)?[ .\\-_]?hd|hevc|bd|(h|x)\\.?265)[-_. ]4k|3840\\s?x\\s?(\\d{4})'
     ),
     '1440p': createRegex(
-      '(bd|hd|m)?(1440(p|i)?)|2k|w?q(uad)?[ .\\-_]?hd|2560\\s?x(\\d{4})'
+      '(bd|hd|m)?1440(p|i)?|2k|w?q(uad)?[ .\\-_]?hd|2560\\s?x(\\d{4})'
     ),
     '1080p': createRegex(
-      '(bd|hd|m)?(1080(p|i)?)|f(ull)?[ .\\-_]?hd|1920\\s?x\\s?(\\d{3,4})'
+      '(bd|hd|m)?1080(p|i)?|f(ull)?[ .\\-_]?hd|4kto1080p|1920\\s?x\\s?(\\d{3,4})'
     ),
-    '720p': createRegex(
-      '(bd|hd|m)?((720|800)(p|i)?)|hd|1280\\s?x\\s?(\\d{3,4})'
-    ),
-    '576p': createRegex('(bd|hd|m)?((576|534)(p|i)?)'),
-    '480p': createRegex('(bd|hd|m)?(480(p|i)?)|sd'),
-    '360p': createRegex('(bd|hd|m)?(360(p|i)?)'),
-    '240p': createRegex('(bd|hd|m)?((240|266)(p|i)?)'),
-    '144p': createRegex('(bd|hd|m)?(144(p|i)?)'),
+    '720p': createRegex('(bd|hd|m)?(720|800|960)(p|i)?|hd|1280\\s?x\\s?(\\d{3,4})'),
+    '576p': createRegex('(bd|hd|m)?(576|540|534)(p|i)?'),
+    '480p': createRegex('(bd|hd|m)?480(p|i)?|sd|640x480|848x480'),
+    '360p': createRegex('(bd|hd|m)?360(p|i)?'),
+    '240p': createRegex('(bd|hd|m)?(240|266)(p|i)?'),
+    '144p': createRegex('(bd|hd|m)?144(p|i)?'),
+  },
+  // Fallback patterns for resolution detection when no explicit resolution (1080p, 720p, etc.) is found.
+  // These patterns match standalone indicators like "UHD" or "4K" that typically imply 2160p content.
+  alternativeResolutions: {
+    '2160p': createRegex('u(ltra)?[ .\\-_]?hd|4k'),
   },
   qualities: {
     'BluRay REMUX': createRegex('(bd|br|b|uhd)?remux'),


### PR DESCRIPTION
## Problem

Releases that include "UHD" (Ultra HD Blu-ray source) in the title but explicitly specify 1080p resolution are being classified as 4K/2160p.

**Example that was misclassified:**
```
XYZ.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10.x265
```

This release clearly indicates **1080p** resolution but was classified as 4K.

**Community reports:** [Discord](https://discord.com/channels/1225024298490662974/1391478569607368924/1471628754517491825), [Discord](https://discord.com/channels/1225024298490662974/1379427701554679858/1450341789415374848), [Discord](https://discord.com/channels/1225024298490662974/1368861007203795045/1473251530949005383)

## Root cause

The 2160p resolution regex matched standalone `UHD` (or `u(ltra)?[ .\-_]?hd`) as a 4K indicator. In release names, "UHD" often refers to the **source format** (UHD Blu-ray disc) instead of the output resolution. A 1080p encode from a UHD Blu-ray source is still 1080p.

## Solution

1. **Remove standalone UHD** from the main 2160p resolution regex.
2. **Only treat UHD as 4K** when it appears together with 4K terms (e.g. `4K-UHD`, `UHD-4K`, `4K.HEVC`, `HEVC.4K`).
3. **Introduce `alternativeResolutions`** as a fallback for special cases such as `[4K]` tags.
4. **Refine resolution regexes** – remove ambiguous patterns and add explicit cases (e.g. `4kto1080p`, `960p`).

## Changes

- `packages/core/src/parser/regex.ts`: Adjusted 2160p regex, added `alternativeResolutions`, and refined other resolution patterns.
- `packages/core/src/parser/file.ts`: Resolution matching now uses `alternativeResolutions` when the primary patterns do not match.

## Expected behavior after fix

- `XYZ.UHD.BluRay.1080p.DD+Atmos.5.1.DoVi.HDR10.x265-SM737` → **1080p**
- `Movie.4K.UHD.BluRay.x265` → **2160p**
- Releases with explicit resolution (1080p, 720p, etc.) are now classified using that resolution.

## Regex Tests

- [Existing 4k Regex](https://regex101.com/r/YgvA0S/)
- [1080p Regex](https://regex101.com/r/FkoFg2/)
- [New 4k Regex](https://regex101.com/r/vdhuhK/)
- [Alternative Resolutions Regex](https://regex101.com/r/Pjd429/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Significantly expanded resolution detection capability with much broader pattern coverage across multiple media formats (4K, UHD, 1440p, 1080p, 720p, and standard definitions), now including enhanced style indicators and edge-case variations for improved accuracy
  * Introduced fallback resolution detection mechanism to enhance recognition of content that does not match primary detection patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->