### PR TITLE
refactor(debrid): better separation of torrent and usenet services

### DIFF
--- a/packages/core/src/builtins/utils/debrid.ts
+++ b/packages/core/src/builtins/utils/debrid.ts
@@ -17,6 +17,8 @@ import {
   isTitleWrong,
   DebridDownload,
   isNotVideoFile,
+  isTorrentDebridService,
+  isUsenetDebridService,
 } from '../../debrid/index.js';
 import { parseTorrentTitle, ParsedResult } from '@viren070/parse-torrent-title';
 import { preprocessTitle } from '../../parser/utils.js';
@@ -119,6 +121,9 @@ async function processTorrentsForDebridService(
     service.credential,
     clientIp
   );
+  if (!isTorrentDebridService(debridService)) {
+    throw new Error(`Service ${service.id} does not support torrent`);
+  }
 
   const results: TorrentWithSelectedFile[] = [];
 
@@ -403,8 +408,7 @@ async function processNZBsForDebridService(
     service.credential,
     clientIp
   );
-
-  if (!debridService.supportsUsenet || !debridService.checkNzbs) {
+  if (!isUsenetDebridService(debridService)) {
     throw new Error(`Service ${service.id} does not support usenet`);
   }
 

--- a/packages/core/src/debrid/easynews.ts
+++ b/packages/core/src/debrid/easynews.ts
@@ -1,9 +1,9 @@
 import {
   DebridDownload,
   DebridError,
-  DebridService,
   DebridServiceConfig,
   PlaybackInfo,
+  UsenetDebridService,
 } from './base.js';
 import {
   Cache,
@@ -23,7 +23,7 @@ const EasynewsAuthSchema = z.object({
   password: z.string(),
 });
 
-export class EasynewsService implements DebridService {
+export class EasynewsService implements UsenetDebridService {
   readonly serviceName: ServiceId = 'easynews';
   readonly serviceLogger = logger;
 
@@ -32,29 +32,11 @@ export class EasynewsService implements DebridService {
     'easynews:link'
   );
 
-  supportsUsenet: boolean = true;
-
   constructor(private readonly config: DebridServiceConfig) {
     const auth = EasynewsAuthSchema.parse(
       JSON.parse(Buffer.from(config.token, 'base64').toString())
     );
     this.auth = auth;
-  }
-
-  checkMagnets(magnets: string[], sid?: string): Promise<DebridDownload[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  listMagnets(): Promise<DebridDownload[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  addMagnet(magnet: string): Promise<DebridDownload> {
-    throw new Error('Method not implemented.');
-  }
-
-  addTorrent(torrent: string): Promise<DebridDownload> {
-    throw new Error('Method not implemented.');
   }
 
   async checkNzbs(
@@ -151,9 +133,5 @@ export class EasynewsService implements DebridService {
       Env.BUILTIN_DEBRID_PLAYBACK_LINK_CACHE_TTL
     );
     return finalUrl;
-  }
-
-  generateTorrentLink(link: string, clientIp?: string): Promise<string> {
-    throw new Error('Method not implemented.');
   }
 }

--- a/packages/core/src/debrid/stremio-nntp.ts
+++ b/packages/core/src/debrid/stremio-nntp.ts
@@ -1,43 +1,25 @@
 import {
   DebridDownload,
-  DebridService,
   DebridServiceConfig,
   PlaybackInfo,
+  UsenetDebridService,
 } from './base.js';
 import { ServiceId, createLogger, fromUrlSafeBase64 } from '../utils/index.js';
 import { NNTPServers, NNTPServersSchema } from '../db/schemas.js';
 
 const logger = createLogger('stremio-nntp');
 
-export class StremioNNTPService implements DebridService {
+export class StremioNNTPService implements UsenetDebridService {
   readonly serviceName: ServiceId = 'stremio_nntp';
   readonly serviceLogger = logger;
 
   private servers: NNTPServers;
-
-  supportsUsenet: boolean = true;
 
   constructor(config: DebridServiceConfig) {
     const parsedConfig = NNTPServersSchema.parse(
       JSON.parse(Buffer.from(config.token, 'base64').toString())
     );
     this.servers = parsedConfig;
-  }
-
-  checkMagnets(magnets: string[], sid?: string): Promise<DebridDownload[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  listMagnets(): Promise<DebridDownload[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  addMagnet(magnet: string): Promise<DebridDownload> {
-    throw new Error('Method not implemented.');
-  }
-
-  addTorrent(torrent: string): Promise<DebridDownload> {
-    throw new Error('Method not implemented.');
   }
 
   async checkNzbs(
@@ -60,10 +42,6 @@ export class StremioNNTPService implements DebridService {
     filename: string,
     cacheAndPlay: boolean
   ): Promise<string | undefined> {
-    throw new Error('Method not implemented.');
-  }
-
-  generateTorrentLink(link: string, clientIp?: string): Promise<string> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/core/src/debrid/stremthru.ts
+++ b/packages/core/src/debrid/stremthru.ts
@@ -9,11 +9,11 @@ import {
 } from '../utils/index.js';
 import { selectFileInTorrentOrNZB, Torrent } from './utils.js';
 import {
-  DebridService,
   DebridServiceConfig,
   DebridDownload,
   PlaybackInfo,
   DebridError,
+  TorrentDebridService,
 } from './base.js';
 import { StremThruServiceId } from '../presets/stremthru.js';
 import { parseTorrentTitle, ParsedResult } from '@viren070/parse-torrent-title';
@@ -32,7 +32,7 @@ function convertStremThruError(error: StremThruError): DebridError {
   });
 }
 
-export class StremThruInterface implements DebridService {
+export class StremThruInterface implements TorrentDebridService {
   private readonly stremthru: StremThru;
   private static playbackLinkCache = Cache.getInstance<string, string | null>(
     'st:link'
@@ -41,7 +41,6 @@ export class StremThruInterface implements DebridService {
     'st:instant-check'
   );
 
-  readonly supportsUsenet = false;
   readonly serviceName: ServiceId;
 
   constructor(

--- a/packages/core/src/debrid/usenet-stream-base.ts
+++ b/packages/core/src/debrid/usenet-stream-base.ts
@@ -11,12 +11,12 @@ import {
 } from '../utils/index.js';
 import { isVideoFile, selectFileInTorrentOrNZB } from './utils.js';
 import {
-  DebridService,
   DebridServiceConfig,
   DebridDownload,
   PlaybackInfo,
   DebridError,
   DebridFile,
+  UsenetDebridService,
 } from './base.js';
 import { ParsedResult, parseTorrentTitle } from '@viren070/parse-torrent-title';
 import z, { ZodError } from 'zod';
@@ -417,7 +417,7 @@ enum Category {
  * These services accept NZBs via a SABnzbd-compatible API and stream content
  * directly from usenet providers via WebDAV, rather than downloading to disk.
  */
-export abstract class UsenetStreamService implements DebridService {
+export abstract class UsenetStreamService implements UsenetDebridService {
   protected readonly webdavClient: WebDAVClient;
   protected readonly api: SABnzbdApi;
   protected static resolveCache = Cache.getInstance<
@@ -428,7 +428,6 @@ export abstract class UsenetStreamService implements DebridService {
     'usenet-stream:library'
   );
 
-  readonly supportsUsenet = true;
   abstract readonly serviceName: ServiceId;
 
   protected readonly auth: UsenetStreamServiceConfig;
@@ -567,32 +566,6 @@ export abstract class UsenetStreamService implements DebridService {
     }
 
     return { files: allFiles, depth: currentDepth };
-  }
-
-  public async listMagnets(): Promise<DebridDownload[]> {
-    throw new Error('Unsupported operation');
-  }
-
-  public async checkMagnets(
-    magnets: string[],
-    sid?: string
-  ): Promise<DebridDownload[]> {
-    throw new Error('Unsupported operation');
-  }
-
-  public async addMagnet(magnet: string): Promise<DebridDownload> {
-    throw new Error('Unsupported operation');
-  }
-
-  public async addTorrent(torrent: string): Promise<DebridDownload> {
-    throw new Error('Unsupported operation');
-  }
-
-  public async generateTorrentLink(
-    link: string,
-    clientIp?: string
-  ): Promise<string> {
-    throw new Error('Unsupported operation');
   }
 
   private async listWebdavFolders(path: string): Promise<FileStat[]> {


### PR DESCRIPTION
not perfect, but separates the types better for future adaptions. I dislike that some usenet service methods are optional, but maybe that's fine and keeps things simple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime validation and clearer errors when a debrid service doesn't support torrents or Usenet, preventing unsupported operations and reducing failed media processing.

* **Refactor**
  * Debrid services split into explicit torrent and Usenet variants; public surfaces tightened so each service exposes only relevant capabilities for more predictable behaviour and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->