### PR TITLE
fix: Prevent formatter regex backtracking and limit template nesting depth

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -991,9 +991,10 @@ class BaseFormatterRegexBuilder {
       key.replace(/[\(\)\'\"\$\^\~\=\>\<]/g, '\\$&')
     );
     let pattern = `::(${validModifiers.join('|')})`;
-    // replace .*? with [^']* / [^"]* so the match can't bleed past quotes
+    // replace .*? so matches can't bleed past quotes, ::, or bracket boundaries
     pattern = pattern.replace(/\.\*\?(?=\\')/g, "[^']*");
     pattern = pattern.replace(/\.\*\?(?=\\")/g, '[^"]*');
+    pattern = pattern.replace(/\.\*\?/g, '(?:(?!::)[^}\\[\\]])*');
     return pattern;
   }
   /**


### PR DESCRIPTION
This fix prevents the parser from matching past the quotes and other operators which was causing the server to hang/timeout.

I also included a fix in this PR that limits nested operations depth to 5 to prevent a potential issue where too many nested operations would exponentially increase straining the cpu.

I have tested both of these fixes with all built in templates + some custom ones and found no issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template compilation stability by implementing depth-bounded recursion to prevent excessive nesting, with warning notifications when limits are exceeded.
  * Enhanced regex pattern matching safety with stricter boundary detection for improved pattern reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->