### PR TITLE
fix: Allow embedded quotes

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -992,8 +992,9 @@ class BaseFormatterRegexBuilder {
     );
     let pattern = `::(${validModifiers.join('|')})`;
     // replace .*? so matches can't bleed past quotes, ::, or bracket boundaries
-    pattern = pattern.replace(/\.\*\?(?=\\')/g, "[^']*");
-    pattern = pattern.replace(/\.\*\?(?=\\")/g, '[^"]*');
+    // allow embedded quotes (e.g. Director's Cut) — only treat ' as terminator when followed by , ) or whitespace
+    pattern = pattern.replace(/\.\*\?(?=\\')/g, "[^']*(?:'(?![,)\\s])[^']*)*");
+    pattern = pattern.replace(/\.\*\?(?=\\")/g, '[^"]*(?:"(?![,)\\s])[^"]*)*');
     pattern = pattern.replace(/\.\*\?/g, '(?:(?!::)[^}\\[\\]])*');
     return pattern;
   }


### PR DESCRIPTION
stream.edition would fail if people had director's cut and collector's edition in their replace since it was terminating at the quote. This fix will make it so ' is only a terminator when followed by , ) or whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pattern matching for template modifiers, with enhanced quote handling to ensure more accurate parsing during template compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->