### PR TITLE
fix(parser): extend 10bit visual tag to match hi10 (in addition to hi10p)

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -79,7 +79,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     SCR: createRegex('((dvd|bd|web|hd)?[ .\\-_]?)?(scr(eener)?)'),
   },
   visualTags: {
-    '10bit': createRegex('10[ .\\-_]?bit|hi10p'),
+    '10bit': createRegex('10[ .\\-_]?bit|hi10p?'),
     'HDR10+': createRegex('hdr[ .\\-_]?10[ .\\-_]?(p(lus)?|[+])'),
     HDR10: createRegex('hdr[ .\\-_]?10(?![ .\\-_]?(?:\\+|p(lus)?))'),
     HDR: createRegex('hdr(?![ .\\-_]?10)(?![ .\\-_]?(?:\\+|p(lus)?))'),


### PR DESCRIPTION
## Summary
Extends the 10bit visual tag regex to also match `hi10` (in addition to the existing `hi10p` match). This covers torrents that use the shorter "hi10" tag for H.264 High 10 Profile content, commonly found in anime releases.

## Change
- **Before:** `10[ .\-_]?bit|hi10p` – matched only `hi10p`
- **After:** `10[ .\-_]?bit|hi10p?` – matches both `hi10` and `hi10p`

The `?` makes the trailing `p` optional, so both variants are recognized.

## Reference
- Regex tested with Seadex releases at: https://regex101.com/r/GsncCf/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced 10-bit video format detection to recognise additional naming conventions, improving content classification accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->