### PR TITLE
feat: Allow multiple removes

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -903,7 +903,7 @@ export abstract class BaseFormatter {
              args.push(match[1] ?? match[2] ?? '');
           }
 
-          if (args.length === 0) return variable;
+          if (args.length === 0) return undefined;
           
           let result = variable;
           for (const arg of args) {
@@ -968,7 +968,7 @@ export abstract class BaseFormatter {
              args.push(match[1] ?? match[2] ?? '');
           }
 
-          if (args.length === 0) return variable;
+          if (args.length === 0) return undefined;
 
           return variable.filter((v) => !args.includes(v));
         }


### PR DESCRIPTION
Allows you to put multiple removes in one instead of chaining them.

Example:

::remove('1','2')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The remove modifier now accepts multiple quoted arguments, enabling removal of several specified values from strings and arrays in a single operation.

* **Bug Fixes / Behaviour Change**
  * If no removal arguments are provided the modifier now returns undefined instead of leaving the input unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->