### PR TITLE
Add resources to built in library

### DIFF
--- a/packages/core/src/presets/library.ts
+++ b/packages/core/src/presets/library.ts
@@ -208,9 +208,7 @@ export class LibraryPreset extends BuiltinAddonPreset {
         .join(' | '),
       enabled: true,
       library: true,
-      resources: (options.resources && options.resources.length > 0)
-          ? options.resources
-          : this.METADATA.SUPPORTED_RESOURCES,
+      resources: options.resources || this.METADATA.SUPPORTED_RESOURCES,
       mediaTypes: options.mediaTypes || [],
       timeout: options.timeout || this.METADATA.TIMEOUT,
       preset: {


### PR DESCRIPTION
This adds the resources tab to the built in library addon so you can disable metadata and catalog for people who only want library streams to show up as results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Resources" option to LibraryPreset configuration: multi-select with pre-populated labels for each supported resource type.

* **Enhancements**
  * Addon generation now populates the resources field from selected options, or defaults to supported resources when none are selected (no longer leaves it undefined).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->