### PR TITLE
fix(parser): prioritize magnifying glass emojis for indexer

### DIFF
--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -44,7 +44,7 @@ class StreamParser {
   }
 
   protected get indexerEmojis(): string[] {
-    return ['🌐', '⚙️', '🔗', '🔎', '🔍', '☁️'];
+    return ['🔎', '🔍', '🌐', '⚙️', '🔗' , '☁️'];
   }
 
   protected get indexerRegex(): RegExp | undefined {


### PR DESCRIPTION
Untested and created from my phone. Might be the simplest fix to deal with an emoji clash when custom wrapping stremthru add-ons.

See https://discord.com/channels/1225024298490662974/1473996896216285265

I saw that some presets override this function and return only "🔗". Was wondering if those could be removed when this emoji is moved also 🤔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Adjusted emoji sequence matching in the description parser, refining how indexer patterns are identified and processed in user-provided text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->