### PR TITLE
fix(presets/stremthru): implement correct indexer parsing

### DIFF
--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -20,13 +20,6 @@ export class StremThruStreamParser extends StreamParser {
     return stream.name?.includes('🔑') ? true : false;
   }
 
-  protected override getIndexer(
-    stream: Stream,
-    currentParsedStream: ParsedStream
-  ): string | undefined {
-    return undefined;
-  }
-
   protected get filenameRegex(): RegExp | undefined {
     return this.getRegexForTextAfterEmojis(['📄', '📁']);
   }
@@ -40,6 +33,10 @@ export class StremThruStreamParser extends StreamParser {
       /📦\s*(\d+(\.\d+)?)\s?(KB|MB|GB|TB)/i
     );
     return folderSize;
+  }
+
+  protected override get indexerEmojis(): string[] {
+    return ['🔍'];
   }
 }
 


### PR DESCRIPTION
useful for upcoming newz if added manually via e.g. torz preset to get the correct indexer

refs: https://discord.com/channels/1225024298490662974/1473996896216285265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Indexing behaviour for StremThru stream parsing has been made configurable via an emoji-based indexer (🔍) instead of a fixed override, offering more flexible control over which streams are indexed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->