### PR TITLE
fix: multiple filter improvements

### DIFF
--- a/packages/core/src/parser/file.ts
+++ b/packages/core/src/parser/file.ts
@@ -86,7 +86,9 @@ class FileParser {
       filename = filename.replace(parsed.title, '').trim();
       filename = filename.replace(/\s+/g, '.').replace(/^\.+|\.+$/g, '');
     }
-    const resolution = matchPattern(filename, PARSE_REGEX.resolutions);
+    const resolution =
+      matchPattern(filename, PARSE_REGEX.resolutions) ||
+      matchPattern(filename, PARSE_REGEX.alternativeResolutions);
     const quality = matchPattern(filename, PARSE_REGEX.qualities);
     const encode = matchPattern(filename, PARSE_REGEX.encodes);
     const audioChannels = matchMultiplePatterns(

--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -16,6 +16,9 @@ type PARSE_REGEX = {
     Record<(typeof constants.RESOLUTIONS)[number], RegExp>,
     'Unknown'
   >;
+  alternativeResolutions: Partial<
+    Record<(typeof constants.RESOLUTIONS)[number], RegExp>
+  >;
   qualities: Omit<
     Record<(typeof constants.QUALITIES)[number], RegExp>,
     'Unknown'
@@ -43,7 +46,7 @@ type PARSE_REGEX = {
 export const PARSE_REGEX: PARSE_REGEX = {
   resolutions: {
     '2160p': createRegex(
-      '(bd|hd|m)?(4k|2160(p|i)?)|u(ltra)?[ .\\-_]?hd|3840\\s?x\\s?(\\d{4})'
+      '(bd|hd|m)?2160(p|i)?|3840\\s?x\\s?(\\d{4})'
     ),
     '1440p': createRegex(
       '(bd|hd|m)?(1440(p|i)?)|2k|w?q(uad)?[ .\\-_]?hd|2560\\s?x(\\d{4})'
@@ -59,6 +62,10 @@ export const PARSE_REGEX: PARSE_REGEX = {
     '360p': createRegex('(bd|hd|m)?(360(p|i)?)'),
     '240p': createRegex('(bd|hd|m)?((240|266)(p|i)?)'),
     '144p': createRegex('(bd|hd|m)?(144(p|i)?)'),
+  },
+  // Fallback to prevent matching the wrong resolution in certain cases, e.g. downscaled or UHD Blu-ray sourced releases
+  alternativeResolutions: {
+    '2160p': createRegex('4k|u(ltra)?[ .\\-_]?hd'),
   },
   qualities: {
     'BluRay REMUX': createRegex('(bd|br|b|uhd)?remux'),
@@ -87,7 +94,7 @@ export const PARSE_REGEX: PARSE_REGEX = {
     DV: createRegex('do?(lby)?[ .\\-_]?vi?(sion)?(?:[ .\\-_]?atmos)?|dv'),
     '3D': createRegex('(bd)?(3|three)[ .\\-_]?(d(imension)?(al)?)'),
     IMAX: createRegex('imax'),
-    AI: createRegex('ai[ .\\-_]?(upscale|enhanced|remaster)?'),
+    AI: createRegex('ai|(ai)?(upscal(ed?|ing)|enhanced?|re[ .\\-_]?graded?)'),
     SDR: createRegex('sdr'),
     'H-OU': createRegex('h?(alf)?[ .\\-_]?(ou|over[ .\\-_]?under)'),
     'H-SBS': createRegex('h?(alf)?[ .\\-_]?(sbs|side[ .\\-_]?by[ .\\-_]?side)'),


### PR DESCRIPTION
- Improved AI regex to account for more cases: https://regex101.com/r/AcNHu6
- Implemented relevant parts from PR [#733](https://github.com/Viren070/AIOStreams/pull/733) to prevent incorrect resolution detection.

I only know regex so if anything else is wrong or could be improved, maintainers can edit this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Resolution parsing enhanced with improved fallback mechanisms to better identify 4K, Ultra HD, and alternative resolution indicators within content metadata
  * Artificial intelligence tag recognition expanded to capture upscaling, enhancement, and professional grading variations in video content
  * Optimised regex patterns for improved metadata detection accuracy across diverse formats and input sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->