### PR TITLE
Get file size from NzbDav history instead of WebDAV

### DIFF
--- a/packages/core/src/debrid/usenet-stream-base.ts
+++ b/packages/core/src/debrid/usenet-stream-base.ts
@@ -40,7 +40,7 @@ const HistorySlotSchema = z.object({
   category: z.string().optional(),
   storage: z.string().nullable().optional(),
   fail_message: z.string().optional(),
-  bytes: z.number().optional(),
+  bytes: z.number().int().optional(),
 });
 
 const HistoryResponseSchema = z.object({


### PR DESCRIPTION
Get file size from NzbDav history instead of WebDAV so built-in library addon accurately reports file size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-size accuracy in library and NZB listings by using recorded historical size as a fallback when immediate file size is unavailable or non-positive.
  * History entries now carry optional size metadata so listings display more consistent and reliable sizes when current file-size data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->