### PR TITLE
feat(builtins): add torznab freeleech info

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -866,8 +866,9 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
         ? '⚡'
         : '⏳'
       : '';
+    const isFreeleech = torrentOrNzb?.downloadvolumefactor === 0;
 
-    const name = `${torrentOrNzb.service?.library ? '🗃️ ' : ''}${isPrivate ? '🔑 ' : ''}[${shortCode} ${cacheIndicator}] ${this.name} `;
+    const name = `${torrentOrNzb.service?.library ? '🗃️ ' : ''}${isPrivate ? '🔑 ' : ''}[${shortCode} ${cacheIndicator}] ${this.name} ${isFreeleech ? 'FREELEECH' : ''} `;
     const description = `${torrentOrNzb.title ? torrentOrNzb.title : ''}\n${torrentOrNzb.file.name ? torrentOrNzb.file.name : ''}\n${
       torrentOrNzb.indexer ? `🔍 ${torrentOrNzb.indexer}` : ''
     } ${'seeders' in torrentOrNzb && torrentOrNzb.seeders ? `👤 ${torrentOrNzb.seeders}` : ''} ${

--- a/packages/core/src/builtins/torznab/addon.ts
+++ b/packages/core/src/builtins/torznab/addon.ts
@@ -74,6 +74,10 @@ export class TorznabAddon extends BaseNabAddon<NabAddonConfig, TorznabApi> {
           ![-1, 999].includes(result.torznab.seeders)
             ? result.torznab.seeders
             : undefined,
+        downloadvolumefactor:
+          typeof result.torznab?.downloadvolumefactor === 'number'
+            ? result.torznab.downloadvolumefactor
+            : undefined,
         indexer: result.jackettindexer?.name ?? undefined,
         title: result.title,
         size:

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -909,6 +909,7 @@ export const ParsedStreamSchema = z.object({
       seeders: z.number().optional(),
       sources: z.array(z.string().min(1)).optional(),
       private: z.boolean().optional(),
+      freeleech: z.boolean().optional(),
     })
     .optional(),
   countryWhitelist: z.array(z.string().length(3)).optional(),

--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -79,6 +79,7 @@ interface BaseFile {
   group?: string;
   languages?: string[]; // languages extracted from indexer attributes (e.g. newznab/torznab)
   age?: number; // age in hours
+  downloadvolumefactor?: number; // multiplier for the download volume that counts toward the user’s account on the tracker
   duration?: number; // duration in seconds
   library?: boolean; // whether the file is already in the user's library
 }

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -109,6 +109,7 @@ export interface ParseValue {
     seasonPack: boolean;
     seeders: number | null;
     private: boolean;
+    freeleech: boolean | null;
     age: string | null;
     ageHours: number | null;
     duration: number | null;
@@ -402,6 +403,7 @@ export abstract class BaseFormatter {
         indexer: stream.indexer || null,
         seeders: stream.torrent?.seeders ?? null,
         private: stream.torrent?.private ?? false,
+        freeleech: stream.torrent?.freeleech ?? null,
         year: stream.parsedFile?.year || null,
         type: stream.type || null,
         title: stream.parsedFile?.title || null,

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -162,6 +162,7 @@ class StreamParser {
       fileIdx:
         stream.fileIdx ?? this.getFileIdx(stream, parsedStream) ?? undefined,
       private: this.isPrivate(stream, parsedStream),
+      freeleech: this.isFreeleech(stream, parsedStream),
     };
 
     return parsedStream;
@@ -381,6 +382,13 @@ class StreamParser {
   }
 
   protected isPrivate(
+    stream: Stream,
+    currentParsedStream: ParsedStream
+  ): boolean | undefined {
+    return false;
+  }
+
+  protected isFreeleech(
     stream: Stream,
     currentParsedStream: ParsedStream
   ): boolean | undefined {

--- a/packages/core/src/presets/builtin.ts
+++ b/packages/core/src/presets/builtin.ts
@@ -96,6 +96,13 @@ export class BuiltinStreamParser extends StreamParser {
     return stream.name?.includes('🔑') ? true : false;
   }
 
+  protected override isFreeleech(
+    stream: Stream,
+    _currentParsedStream: ParsedStream
+  ): boolean | undefined {
+    return stream.name?.includes('FREELEECH') ? true : false;
+  }
+
   protected getStreamType(
     stream: Stream,
     service: ParsedStream['service'],


### PR DESCRIPTION
makes use of the `downloadvolumefactor` info in torznab results to determine if something is freeleech or not. via e.g. `{stream.freeleech::istrue[" FL "||""]} ` it is then possible to mark such streams in the formatter which is highly usable when private trackers are connected.

Refs: https://en.wikipedia.org/wiki/Glossary_of_BitTorrent_terms#Freeleech
Refs: https://torznab.github.io/spec-1.3-draft/revisions/1.2-Torznab-Download-Upload-Factors.html

<img width="447" height="332" alt="image" src="https://github.com/user-attachments/assets/0c382c58-cfaf-42ed-8b03-897d3c28e86e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and label freeleech torrents so they’re clearly marked in stream names.
  * Support for Torznab-provided download volume factor to improve torrent handling.
  * Streams and stored torrent records now include a freeleech indicator for better categorisation and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->