### PR TITLE
fix: support socks5h addon proxy urls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -587,6 +587,7 @@ LOG_TIMEZONE=Etc/UTC
 # --- Addon Proxy URL ---
 # The proxy URL to use for all requests to upstream addons.
 # Example: ADDON_PROXY=http://warp:1080 (using https://github.com/cmj2002/warp-docker)
+# Example (SOCKS5 with remote DNS): ADDON_PROXY=socks5h://user:pass@gluetun:1388
 # ADDON_PROXY=
 
 # --- Addon Proxy Configuration ---

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -178,7 +178,10 @@ export function getProxyAgent(proxyUrl: string): Dispatcher | undefined {
 
   if (!proxyAgent) {
     const proxyUrlObj = new URL(proxyUrl);
-    if (proxyUrlObj.protocol === 'socks5:') {
+    if (
+      proxyUrlObj.protocol === 'socks5:' ||
+      proxyUrlObj.protocol === 'socks5h:'
+    ) {
       proxyAgent = socksDispatcher({
         type: 5,
         port: parseInt(proxyUrlObj.port),


### PR DESCRIPTION
## Summary
- route `socks5h://` addon proxy URLs through the SOCKS dispatcher path
- keep existing `socks5://` behavior unchanged
- document `socks5h://` usage in `.env.sample`

## Problem
`ADDON_PROXY=socks5h://...` was not recognized as SOCKS in `getProxyAgent()`.
It fell back to Undici `ProxyAgent`, which only accepts HTTP(S) proxy URLs, causing runtime errors like:
`Invalid URL protocol: the URL must start with http: or https:`.

## Fix
Treat both `socks5:` and `socks5h:` as SOCKS5 protocols and use `socksDispatcher` for both.

## Notes
- no functional changes to stream proxy services (`builtin`, `stremthru`, `mediaflow`)
- this change only affects outgoing addon request proxying via `ADDON_PROXY`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended proxy protocol support to include SOCKS5h proxies, which now function equivalently to standard SOCKS5.

* **Documentation**
  * Added sample configuration demonstrating SOCKS5 proxy setup with remote DNS resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->