### PR TITLE
fix(builtins/eztv): do not fail with missing torrents prop

### DIFF
--- a/packages/core/src/builtins/eztv/api.ts
+++ b/packages/core/src/builtins/eztv/api.ts
@@ -54,7 +54,7 @@ const EztvGetTorrentsResponseSchema = z
     torrents_count: z.number(),
     limit: z.number(),
     page: z.number(),
-    torrents: z.array(EztvTorrentSchema),
+    torrents: z.array(EztvTorrentSchema).default([]),
   })
   .transform((data) => ({
     imdbId: data.imdb_id,


### PR DESCRIPTION
Fixes 

```
Failed to parse EZTV API response: ✖ Invalid input: expected array, received undefined\n  → at torrents
```

with e.g. https://eztvx.to/api/get-torrents?imdb_id=1884856&limit=100&page=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of EZTV torrents handling to gracefully manage cases where torrent information may be absent from responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->