### PR TITLE
fix(builtins/nab): merge string torznab:attr instead of overwriting them

### DIFF
--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -123,7 +123,14 @@ const createTorznabItemSchema = () =>
         .array(AttributeSchema)
         .optional()
         .transform(
-          (arr) => arr?.reduce((acc, attr) => ({ ...acc, ...attr }), {}) ?? {}
+          (arr) => arr?.reduce((acc, attr) => {
+            for (const key in attr) {
+              acc[key] = acc[key] && typeof acc[key] === 'string' && typeof attr[key] === 'string'
+                ? acc[key] + ',' + attr[key]
+                : attr[key];
+            }
+            return acc;
+          }, {}) ?? {}
         ),
     })
     .transform((item) => ({


### PR DESCRIPTION
CinemaZ is returning data like the following via Jackett
```xml
      <torznab:attr name="language" value="Czech" />
      <torznab:attr name="language" value="German" />
      <torznab:attr name="language" value="Hungarian" />
      <torznab:attr name="language" value="Polish" />
      <torznab:attr name="subs" value="Croatian" />
      <torznab:attr name="subs" value="Czech" />
      <torznab:attr name="subs" value="English" />
      <torznab:attr name="subs" value="Hungarian" />
      <torznab:attr name="subs" value="Macedonian" />
      <torznab:attr name="subs" value="Polish" />
      <torznab:attr name="subs" value="Romanian" />
      <torznab:attr name="subs" value="Serbian" />
      <torznab:attr name="subs" value="Slovenian" />
```

which was not handled properly in the transformation logic (later values were overwriting previous ones). now all string values are merged instead. I think this is still a bit of a workaround for quirky indexers or vague specs, but maybe it is an acceptable one?

before
<img width="905" height="66" alt="image" src="https://github.com/user-attachments/assets/3735579a-1d6e-4320-92f8-c53747b64d73" />


after
<img width="1051" height="67" alt="image" src="https://github.com/user-attachments/assets/d01c6f9c-c748-4ad0-814a-7dd60baf3f53" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced attribute merging for improved result quality. String attribute values from multiple sources are now properly concatenated with comma separators instead of being overwritten. This ensures comprehensive and accurate data representation, with all relevant attribute information preserved in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->