### PR TITLE
feat(core/formatters): support variable resolution in replace() first argument

### DIFF
--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -896,7 +896,11 @@ export abstract class BaseFormatter {
             new RegExp(`${findStartChar}\\s*,\\s*${findEndChar}`)
           );
 
-          if (!shouldBeUndefined && key && replaceKey !== undefined) {
+          if (
+            shouldBeUndefined === undefined &&
+            key &&
+            replaceKey !== undefined
+          ) {
             let resolvedKey = key;
             if (key.startsWith('{') && key.endsWith('}') && parseValue) {
               // When the first argument to replace(...) is a {variable} expression, resolve it


### PR DESCRIPTION
This feature makes the replace method work with any formatter variable, such as {stream.title}, {addon.name} etc...
This might be useful for any person who wants to take their custom formatter any step forward.

### AS IS
`filename`: Movie.Title.2023.2160p.BluRay.HEVC.DV.TrueHD.Atmos.7.1.iTA.ENG-GROUP.mkv
`{stream.filename::replace('.', ' ')::replace('{stream.title}', '')}` replaces all the dots with a whitespace but it doesn't replace the stream title (Movie Title in this case) with an empty string

### TO  BE
`filename`: Movie.Title.2023.2160p.BluRay.HEVC.DV.TrueHD.Atmos.7.1.iTA.ENG-GROUP.mkv
`{stream.filename::replace('.', ' ')::replace('{stream.title}', '')}` replaces all the dots with a whitespace and it does replace the stream title (Movie Title in this case) with an empty string. 
So it will result in `2023 2160p BluRay HEVC DV TrueHD Atmos 7 1 iTA ENG-GROUP mkv`

Resolves #790 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replace operations now resolve dynamic placeholders at runtime before performing replacements; errors or empty resolutions preserve the original placeholder to avoid unintended broad matches.
  * Modifier application carries runtime value-resolution context through the formatting pipeline, allowing multi-modifier chains to operate on resolved values.
  * No breaking public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->