### PR TITLE
feat(sel): add multiEpisode filter function

### DIFF
--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -945,6 +945,23 @@ export abstract class StreamExpressionEngine {
       );
     };
 
+    this.parser.functions.multiEpisode = function (
+      streams: ParsedStream[],
+      minEpisodes: number = 2
+    ) {
+      if (!Array.isArray(streams) || streams.some((stream) => !stream.type)) {
+        throw new Error('Your streams input must be an array of streams');
+      } else if (typeof minEpisodes !== 'number' || minEpisodes < 1) {
+        throw new Error('minEpisodes must be a positive number');
+      }
+
+      return streams.filter(
+        (stream) =>
+          stream.parsedFile?.episodes &&
+          stream.parsedFile.episodes.length >= minEpisodes
+      );
+    };
+
     this.parser.functions.addon = function (
       streams: ParsedStream[],
       ...addons: string[]


### PR DESCRIPTION
## Summary

- Adds a new SEL function `multiEpisode(streams, minEpisodes?)` that filters streams based on `parsedFile.episodes.length`
- Enables users to exclude multi-episode packs (e.g. S01E01-E08) while keeping single episode results — including single episodes selected from cached season pack folders
- Default threshold is 2 episodes; configurable via optional second parameter

## Motivation

The existing `seasonPack` function can't cleanly distinguish multi-episode files from single episodes:
- `seasonPack(streams, 'onlySeasons')` only catches packs with **no** episode info (e.g. "S01") — misses packs like "S01E01-E08" where episodes are parsed
- `seasonPack(streams, 'seasonPack')` is too aggressive — also excludes single episodes selected from cached season pack folders (via the `folderSize > size * 2` heuristic)

`multiEpisode` fills this gap by checking the episodes array length directly.

## Usage

In excluded stream expressions:
```
multiEpisode(streams)        — excludes streams with 2+ episodes
multiEpisode(streams, 3)     — excludes streams with 3+ episodes
```

Combined with `seasonPack(streams, 'onlySeasons')`, this covers all season pack variants:
| Stream type | `seasonPack('onlySeasons')` | `multiEpisode` |
|---|---|---|
| Pure season pack "S01" (no episodes) | ✅ caught | — |
| Multi-episode pack "S01E01-E08" | ❌ missed | ✅ caught |
| Single episode "S01E01" | — | ✅ kept |
| Single episode from cached pack folder | — | ✅ kept |

## Test plan

- [ ] Verify `multiEpisode(streams)` returns streams with `parsedFile.episodes.length >= 2`
- [ ] Verify `multiEpisode(streams, 3)` respects custom threshold
- [ ] Verify single-episode streams are not matched
- [ ] Verify error handling for invalid inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stream filtering capability that allows filtering streams based on a minimum episode count requirement, with a default threshold of 2 episodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->