### PR TITLE
Fix Meteor multi-debrid URI malformed error

### DIFF
--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -442,11 +442,14 @@ class StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    return stream.url
-      ? decodeURIComponent(stream.url).match(
-          /(?:(?<=btih:)|(?<=[-/[(;:&]))[a-fA-F0-9]{40}(?=$|[-\]\)/:;&?])/
-        )?.[0]
-      : undefined;
+    if (!stream.url) return undefined;
+    try {
+      return decodeURIComponent(stream.url).match(
+        /(?:(?<=btih:)|(?<=[-/[(;:&]))[a-fA-F0-9]{40}(?=$|[-\]\)/:;&?])/
+      )?.[0];
+    } catch {
+      return undefined;
+    }
   }
 
   protected getFileIdx(

--- a/packages/core/src/presets/meteor.ts
+++ b/packages/core/src/presets/meteor.ts
@@ -238,7 +238,7 @@ export class MeteorPreset extends Preset {
         'seeders',
         'language',
       ],
-    });
+    }, 'urlSafe');
 
     return `${url}/${configString}/manifest.json`;
   }


### PR DESCRIPTION
Use URL-safe base64 for Meteor config encoding -  standard base64 can produce + and / which break Meteor's URL routing when using multiple debrid services.

Also wrap decodeURIComponent in getInfoHash with try/catch so a bad stream URL doesn't crash all streams from an addon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened stream URL handling with enhanced error detection mechanisms that gracefully manage missing or corrupted URLs, significantly improving application stability during content streaming and retrieval operations.

## Refactor
* Optimised manifest URL encoding implementation by adopting URL-safe base64 encoding techniques, ensuring better compatibility, reliability, and proper formatting across various deployment environments and network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->