### PR TITLE
Use Meteor's own logo URL

### DIFF
--- a/packages/core/src/presets/meteor.ts
+++ b/packages/core/src/presets/meteor.ts
@@ -94,7 +94,7 @@ export class MeteorPreset extends Preset {
     return {
       ID: 'meteor',
       NAME: 'Meteor',
-      LOGO: 'https://i.ibb.co/0V90bryY/image.png',
+      LOGO: `${Env.METEOR_URL[0]}/static/icon.png`,
       URL: Env.METEOR_URL[0],
       TIMEOUT: Env.DEFAULT_METEOR_TIMEOUT || Env.DEFAULT_TIMEOUT,
       USER_AGENT: Env.DEFAULT_METEOR_USER_AGENT || Env.DEFAULT_USER_AGENT,


### PR DESCRIPTION
Use Meteor's hosted logo instead of imgbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the Meteor addon logo configuration to load from a dynamic path instead of a fixed external URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->