### PR TITLE
fix(core): fix AI Companion manifest generation

### DIFF
--- a/packages/core/src/presets/aiCompanion.ts
+++ b/packages/core/src/presets/aiCompanion.ts
@@ -262,9 +262,10 @@ export class AICompanionPreset extends Preset {
     form.append('max_results', options.maxResults.toString());
 
     const defaultCatalogs = AICompanionPreset.catalogs.map((c) => c.value);
+    // Both arrays are pre-sorted, so JSON.stringify is a safe content comparison
     const changedCatalogs =
-      movieFeedCatalogs !== defaultCatalogs ||
-      seriesFeedCatalogs !== defaultCatalogs;
+      JSON.stringify(movieFeedCatalogs) !== JSON.stringify(defaultCatalogs) ||
+      JSON.stringify(seriesFeedCatalogs) !== JSON.stringify(defaultCatalogs);
     form.append('changed_catalogs', changedCatalogs ? 'true' : 'false');
     movieFeedCatalogs.forEach((catalog: string) =>
       form.append('include_catalogs_movies', catalog)
@@ -272,9 +273,6 @@ export class AICompanionPreset extends Preset {
     seriesFeedCatalogs.forEach((catalog: string) =>
       form.append('include_catalogs_series', catalog)
     );
-
-    form.append('include_catalogs_movies', movieFeedCatalogs.join(','));
-    form.append('include_catalogs_series', seriesFeedCatalogs.join(','));
 
     let manifestUrl: string | undefined = await manifestCache.get(cacheKey);
     if (manifestUrl) {


### PR DESCRIPTION
## Summary

Fix AI Companion manifest generation by sending catalog selections only once and by computing `changed_catalogs` via array content equality instead of array identity.

**Two issues in `aiCompanion.ts` `generateManifestUrl`:**

1. **Duplicate form field appends (lines 269–277):** `include_catalogs_movies` and `include_catalogs_series` are appended once per selected value via `forEach`, then appended again as a single comma-joined string. The AI Companion backend models these fields as repeated form values (`list[str]`), so the extra comma-joined append sends an incorrect payload. AIO then fails while parsing the `/save-config` response as JSON:
   ```
   Failed to generate manifest URL for AI Companion: SyntaxError:
   Unexpected non-whitespace character after JSON at position 4
   ```

2. **Broken array comparison (lines 265–267):** `changedCatalogs` compares arrays by reference (`!==`), but `defaultCatalogs` is freshly created via `.map()` each time — so it always evaluates to `true` regardless of actual content. Replaced with `JSON.stringify` comparison, which is safe here because both arrays are pre-sorted.

**Note:** The upstream AI Companion service's own configure page appears to have the same duplicate-field pattern, but this PR corrects AIO's own integration path independently.

## Changes
- Remove the extra comma-joined `form.append` calls for `include_catalogs_movies` and `include_catalogs_series` — keep only the `forEach` individual appends
- Replace array identity comparison with `JSON.stringify` content comparison for `changed_catalogs`

## Test plan
- [ ] Configure AI Companion addon with default catalogs → Install should succeed without JSON parse error
- [ ] Configure AI Companion with non-default catalog selections → `changed_catalogs` should be `true`
- [ ] Configure AI Companion with default catalog selections → `changed_catalogs` should be `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimised internal comparison logic for catalogue configuration, improving code efficiency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->