### PR TITLE
fix: match ranked regexes against `folderName` too

### DIFF
--- a/packages/core/src/streams/precomputer.ts
+++ b/packages/core/src/streams/precomputer.ts
@@ -248,7 +248,7 @@ class StreamPrecomputer {
       const matched: string[] = [];
       let totalScore = 0;
       for (const { regex, pattern, name, score } of regexes) {
-        if (regex.test(stream.filename)) {
+        if (regex.test(stream.filename) ||(stream.folderName && regex.test(stream.folderName))) {
           if (name) matched.push(name);
           totalScore += score;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stream pattern matching to evaluate both folder names and filenames against regex patterns, improving the accuracy of stream detection and scoring across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->