### PR TITLE
feat(presets): add HdHub preset

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -802,6 +802,9 @@ PRUNE_MAX_DAYS=-1
 # URLs and default timeouts for various external Stremio addons that AIOStreams can integrate with.
 # Change these if you use self-hosted versions or if defaults become outdated.
 
+# ----------- HDHUB ------------
+HDHUB_URL=https://hdhub.thevolecitor.qzz.io
+
 # ----------- COMET ------------
 # This can also be set to a list of URLs which would show as options to users when configuring
 # e.g. COMET_URL='["https://comet.feels.legal", "https://comet.example.com"]'

--- a/packages/core/src/presets/hdhub.ts
+++ b/packages/core/src/presets/hdhub.ts
@@ -1,0 +1,171 @@
+import {
+  Addon,
+  Option,
+  UserData,
+  Resource,
+  ParsedStream,
+  Stream,
+} from '../db/index.js';
+import { baseOptions, Preset } from './preset.js';
+import { Env } from '../utils/index.js';
+import { constants, ServiceId } from '../utils/index.js';
+import { StreamParser } from '../parser/index.js';
+
+class HdHubStreamParser extends StreamParser {
+  protected get indexerRegex(): RegExp | undefined {
+    return /(?:^\s*\[(HLS Stream)\]|^\s*(.+?)\s*\|\s*4KHDHub\s*$)/im;
+  }
+  protected getIndexer(
+    stream: Stream,
+    _currentParsedStream: ParsedStream
+  ): string | undefined {
+    const regex = this.indexerRegex;
+    if (!regex) return undefined;
+    const match = stream.description?.match(regex);
+    if (match) return (match[1] ?? match[2])?.trim();
+    return undefined;
+  }
+  protected getFilename(
+    stream: Stream,
+    currentParsedStream: ParsedStream
+  ): string | undefined {
+    const filename = super.getFilename(stream, currentParsedStream);
+    if (filename) {
+      return filename
+        .replace(/^\[HLS Stream\]\s*/i, '')
+        .replace(/.*\[💾\s*\d+(\.\d+)?\s*(GB|MB|TB)\]\s*/, '');
+    }
+    return filename;
+  }
+}
+
+export class HdHubPreset extends Preset {
+  static override getParser(): typeof StreamParser {
+    return HdHubStreamParser;
+  }
+
+  static override get METADATA() {
+    const supportedServices: ServiceId[] = [constants.TORBOX_SERVICE];
+
+    const supportedResources = [constants.STREAM_RESOURCE];
+
+    const options: Option[] = [
+      ...baseOptions('HdHub', supportedResources, Env.DEFAULT_HDHUB_TIMEOUT, [
+        Env.HDHUB_URL,
+      ]),
+      {
+        id: 'mediaTypes',
+        name: 'Media Types',
+        description:
+          'Limits this addon to the selected media types for streams. For example, selecting "Movie" means this addon will only be used for movie streams (if the addon supports them). Leave empty to allow all.',
+        type: 'multi-select',
+        required: false,
+        showInSimpleMode: false,
+        default: [],
+        options: [
+          {
+            label: 'Movie',
+            value: 'movie',
+          },
+          {
+            label: 'Series',
+            value: 'series',
+          },
+          {
+            label: 'Anime',
+            value: 'anime',
+          },
+        ],
+      },
+      {
+        id: 'tb_only',
+        name: 'TorBox Only',
+        description: 'Only show TorBox streams (hide free CDN streams)',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+    ];
+
+    return {
+      ID: 'hdhub',
+      NAME: 'HdHub',
+      LOGO: 'https://hdhub.thevolecitor.qzz.io/logo.png',
+      URL: Env.HDHUB_URL,
+      TIMEOUT: Env.DEFAULT_HDHUB_TIMEOUT || Env.DEFAULT_TIMEOUT,
+      USER_AGENT: Env.DEFAULT_HDHUB_USER_AGENT || Env.DEFAULT_USER_AGENT,
+      SUPPORTED_SERVICES: supportedServices,
+      DESCRIPTION:
+        'High-performance HdHub scraper with TorBox passthrough and hybrid CDN support.',
+      OPTIONS: options,
+      SUPPORTED_STREAM_TYPES: [
+        constants.HTTP_STREAM_TYPE,
+        constants.DEBRID_STREAM_TYPE,
+      ],
+      SUPPORTED_RESOURCES: supportedResources,
+    };
+  }
+
+  static async generateAddons(
+    userData: UserData,
+    options: Record<string, any>
+  ): Promise<Addon[]> {
+    const services = this.getUsableServices(userData);
+    if (services?.find((service) => service.id === constants.TORBOX_SERVICE)) {
+      return [
+        this.generateAddon(
+          options,
+          this.getServiceCredential(constants.TORBOX_SERVICE, userData)
+        ),
+      ];
+    }
+    return [this.generateAddon(options)];
+  }
+
+  private static generateAddon(
+    options: Record<string, any>,
+    torboxKey?: string
+  ): Addon {
+    return {
+      name: options.name || this.METADATA.NAME,
+      displayIdentifier: torboxKey
+        ? constants.SERVICE_DETAILS[constants.TORBOX_SERVICE].shortName
+        : undefined,
+      manifestUrl: this.generateManifestUrl(options, torboxKey),
+      enabled: true,
+      mediaTypes: options.mediaTypes,
+      resources: options.resources || this.METADATA.SUPPORTED_RESOURCES,
+      timeout: options.timeout || this.METADATA.TIMEOUT,
+      preset: {
+        id: '',
+        type: this.METADATA.ID,
+        options: options,
+      },
+      headers: {
+        'User-Agent': this.METADATA.USER_AGENT,
+      },
+    };
+  }
+
+  private static generateManifestUrl(
+    options: Record<string, any>,
+    torboxKey?: string
+  ) {
+    let url = options.url || this.METADATA.URL;
+    if (url.endsWith('/manifest.json')) {
+      return url;
+    }
+    url = url.replace(/\/$/, '');
+
+    const config = {
+      torbox: torboxKey || 'unset',
+      qualities: '2160p,1080p,720p,480p',
+      sort: 'desc',
+      tb_only: options.tb_only || false,
+    };
+
+    const configString = this.base64EncodeJSON(config, 'urlSafe');
+
+    return `${url}/${configString}/manifest.json`;
+  }
+}

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -75,6 +75,7 @@ import { NekoBtPreset } from './nekoBt.js';
 import { EasynewsSearchPreset } from './easynewsSearch.js';
 import { SeaDexPreset } from './seadex.js';
 import { StreamNZBPreset } from './streamnzb.js';
+import { HdHubPreset } from './hdhub.js';
 import { Preset } from './index.js';
 
 let PRESET_LIST: string[] = [
@@ -120,6 +121,7 @@ let PRESET_LIST: string[] = [
   'dmm-cast',
   'nuvio-streams',
   'webstreamr',
+  'hdhub',
   'astream',
   'brazuca-torrents',
   'streamasia',
@@ -151,6 +153,7 @@ let PRESET_LIST: string[] = [
   'ai-search',
   'more-like-this',
   'content-deep-dive',
+  'hdhub',
 ].filter(Boolean);
 
 export class PresetManager {
@@ -320,6 +323,8 @@ export class PresetManager {
         return EasynewsSearchPreset;
       case 'streamnzb':
         return StreamNZBPreset;
+      case 'hdhub':
+        return HdHubPreset;
       default:
         throw new Error(`Preset ${id} not found`);
     }

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1832,6 +1832,19 @@ export const Env = cleanEnv(process.env, {
     desc: 'Default WebStreamr user agent',
   }),
 
+  HDHUB_URL: url({
+    default: 'https://hdhub.thevolecitor.qzz.io',
+    desc: 'Base URL for the HdHub Stremio Addon',
+  }),
+  DEFAULT_HDHUB_TIMEOUT: num({
+    default: undefined,
+    desc: 'Default timeout for the HdHub Stremio Addon',
+  }),
+  DEFAULT_HDHUB_USER_AGENT: userAgent({
+    default: undefined,
+    desc: 'Default user agent for the HdHub Stremio Addon',
+  }),
+
   TMDB_ADDON_URL: url({
     default: 'https://tmdb.elfhosted.com',
     desc: 'TMDB Addon URL',

--- a/packages/core/src/utils/startup.ts
+++ b/packages/core/src/utils/startup.ts
@@ -1135,6 +1135,19 @@ const logStartupInfo = () => {
       );
     }
 
+    // HdHub
+    logKeyValue('HdHub:', Env.HDHUB_URL);
+    if (Env.DEFAULT_HDHUB_TIMEOUT) {
+      logKeyValue(
+        '  Timeout:',
+        formatMilliseconds(Env.DEFAULT_HDHUB_TIMEOUT),
+        '     '
+      );
+    }
+    if (Env.DEFAULT_HDHUB_USER_AGENT) {
+      logKeyValue('  User Agent:', Env.DEFAULT_HDHUB_USER_AGENT, '     ');
+    }
+
     // DMM Cast (Note: no URL env var, only timeout and user agent)
     if (Env.DEFAULT_DMM_CAST_TIMEOUT || Env.DEFAULT_DMM_CAST_USER_AGENT) {
       logKeyValue('DMM Cast:', 'Configuration only');


### PR DESCRIPTION
This PR adds a new preset for the HdHub addon.

- Includes Http streams from various providers.
- Optional TorBox integration as a debrid.
- Includes `TorBox Only` toggle supporting hybrid/debrid-only setups.
-  Adds `HDHUB_URL` to environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HdHub addon integration as a new streaming source with TorBox-aware behaviour, selectable qualities, sort order, optional TorBox-only filtering and configurable request timeout.
* **Configuration**
  * Sample environment variable for HdHub base URL added (with sensible default) plus optional defaults for timeout and user-agent.
* **Chores**
  * Startup logging updated to include HdHub configuration visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->