### PR TITLE
feat: migrate domain and fix TOP Posters API Key validation, update UI

### DIFF
--- a/packages/core/src/poster/index.ts
+++ b/packages/core/src/poster/index.ts
@@ -23,7 +23,7 @@ export type PosterServiceType = 'rpdb' | 'top-poster' | 'aioratings' | 'openpost
  */
 export const ALL_POSTER_SERVICE_DOMAINS = [
   'api.ratingposterdb.com',
-  'api.top-streaming.stream',
+  'api.top-posters.com',
   'apiv2.aioratings.com',
 ];
 

--- a/packages/core/src/poster/topPoster.ts
+++ b/packages/core/src/poster/topPoster.ts
@@ -5,7 +5,7 @@ import { Env } from '../utils/env.js';
 
 export class TopPoster extends BasePosterService {
   readonly serviceName = 'Top Poster';
-  readonly ownDomains = ['api.top-streaming.stream'];
+  readonly ownDomains = ['api.top-posters.com'];
   readonly redirectPathSegment = 'top-poster';
 
   constructor(apiKey: string) {
@@ -21,24 +21,27 @@ export class TopPoster extends BasePosterService {
     let response;
     try {
       response = await makeRequest(
-        `https://api.top-streaming.stream/auth/verify/${this.apiKey}`,
+        `https://api.top-posters.com/auth/verify/${this.apiKey}`,
         {
           timeout: 10000,
           ignoreRecursion: true,
+          headers: {
+            'User-Agent': `AIOStreams/${Env.VERSION}`,
+          },
         }
       );
     } catch (error: any) {
-      throw new Error(`Failed to connect to Top Poster API: ${error.message}`);
+      throw new Error(`Failed to connect to TOP Posters API: ${error.message}`);
     }
 
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error('Invalid Top Poster API key');
+        throw new Error('Invalid TOP Posters API key');
       } else if (response.status === 429) {
-        throw new Error('Top Poster API rate limit exceeded');
+        throw new Error('TOP Posters API rate limit exceeded');
       } else {
         throw new Error(
-          `Top Poster API returned an unexpected status: ${response.status} - ${response.statusText}`
+          `TOP Posters API returned an unexpected status: ${response.status} - ${response.statusText}`
         );
       }
     }
@@ -48,12 +51,12 @@ export class TopPoster extends BasePosterService {
       data = TopPosterIsValidResponse.parse(await response.json());
     } catch (error: any) {
       throw new Error(
-        `Top Poster API returned malformed JSON: ${error.message}`
+        `TOP Posters API returned malformed JSON: ${error.message}`
       );
     }
 
     if (!data.valid) {
-      throw new Error('Invalid Top Poster API key');
+      throw new Error('Invalid TOP Posters API key');
     }
 
     this.apiKeyValidationCache.set(
@@ -65,6 +68,6 @@ export class TopPoster extends BasePosterService {
   }
 
   protected buildPosterUrl(idType: string, idValue: string): string {
-    return `https://api.top-streaming.stream/${this.apiKey}/${idType}/poster-default/${idValue}.jpg?fallback=true`;
+    return `https://api.top-posters.com/${this.apiKey}/${idType}/poster/${idValue}.jpg?fallback=true`;
   }
 }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -797,9 +797,9 @@ const TOP_LEVEL_OPTION_DETAILS: Record<
       'Get your free API key from [here](https://ratingposterdb.com/api-key/) for posters with ratings.',
   },
   topPosterApiKey: {
-    name: 'Top Poster API Key',
+    name: 'TOP Posters API Key',
     description:
-      'Get your free API key from [here](https://api.top-streaming.stream/user/register) for posters with ratings.',
+      'Get your free API key from [here](https://api.top-posters.com/user/register) for posters with ratings.',
   },
   tvdbApiKey: {
     name: 'TVDB API Key',

--- a/packages/frontend/src/components/menu/addons/_components/sortable-catalog-item.tsx
+++ b/packages/frontend/src/components/menu/addons/_components/sortable-catalog-item.tsx
@@ -508,7 +508,7 @@ export function SortableCatalogItem({
 
                     <Switch
                       label="Poster Services"
-                      help="Replace movie/show posters with posters from poster services (RPDB or Top Poster) when supported"
+                      help="Replace movie/show posters with posters from poster services (RPDB or TOP Posters) when supported"
                       side="right"
                       value={catalog.usePosterService ?? false}
                       onValueChange={(usePosterService) => {

--- a/packages/frontend/src/components/menu/services/_components/poster-services.tsx
+++ b/packages/frontend/src/components/menu/services/_components/poster-services.tsx
@@ -19,7 +19,7 @@ export function PosterServices() {
         options={[
           { label: 'None', value: 'none' },
           { label: 'RPDB', value: 'rpdb' },
-          { label: 'Top Poster', value: 'top-poster' },
+          { label: 'TOP Posters', value: 'top-poster' },
           { label: 'AIOratings', value: 'aioratings' },
           { label: 'OpenPosterDB', value: 'openposterdb' },
         ]}
@@ -60,17 +60,17 @@ export function PosterServices() {
       {userData.posterService === 'top-poster' && (
         <PasswordInput
           autoComplete="off"
-          label="Top Poster API Key"
+          label="TOP Posters API Key"
           help={
             <span>
               Get your API Key from{' '}
               <a
-                href="https://api.top-streaming.stream/user/register"
+                href="https://api.top-posters.com/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[--brand] hover:underline"
               >
-                here
+                TOP Posters
               </a>
             </span>
           }


### PR DESCRIPTION
## Description
This PR updates the integration with the Top Posters API to reflect their new domain and tries to solve some public instances problems not able to validate the API Key, by adding the user agent to the request.

## Changes:
- Updated Top Posters API base URL to `https://api.top-posters.com`.
- Changed the default identifier path from `poster-default` to `poster`.
- Added the `{user_agent}` header when making a /auth/verify/ call.
- Updated the Frontend UI to better match the API name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Migrated TOP Posters service to new domain with updated branding throughout the application.
  * Updated signup and registration links to point to the new TOP Posters domain.
  * Improved service request headers for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->