### PR TITLE
feat(builtins): add short cache TTL for recently aired episodes

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -885,7 +885,7 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
           const daysSince = Math.floor(
             (now.getTime() - airDate.getTime()) / (1000 * 60 * 60 * 24)
           );
-          if (daysSince <= 1) {
+          if (daysSince >= 0 && daysSince <= 1) {
             searchMetadata.recentCacheTTL = Env.BUILTIN_SEARCH_RECENT_TTL;
           }
         }

--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -40,6 +40,7 @@ import {
 import { processTorrents, processNZBs } from '../utils/debrid.js';
 import { calculateAbsoluteEpisode } from '../utils/general.js';
 import { MetadataService } from '../../metadata/service.js';
+import { TMDBMetadata } from '../../metadata/tmdb.js';
 import { MetadataTitle } from '../../metadata/utils.js';
 import { Logger } from 'winston';
 import pLimit from 'p-limit';
@@ -60,6 +61,10 @@ export interface SearchMetadata extends TitleMetadata {
   titlesWithLang?: MetadataTitle[];
   /** ISO 639-1 code of the content's original language (from TMDB). */
   originalLanguage?: string;
+  /** Short cache TTL (seconds) to use instead of the normal per-scraper TTL.
+   *  Set when BUILTIN_SEARCH_RECENT_ENABLED is true and the episode aired within
+   *  the last day, so new torrents are discovered quickly around release day. */
+  recentCacheTTL?: number;
 }
 
 export const BaseDebridConfigSchema = z.object({
@@ -854,6 +859,42 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       tvdbId: metadata.tvdbId ?? null,
       isAnime: animeEntry ? true : false,
     };
+
+    if (
+      Env.BUILTIN_SEARCH_RECENT_ENABLED &&
+      searchMetadata.tmdbId != null &&
+      parsedId.season &&
+      parsedId.episode &&
+      type !== 'movie'
+    ) {
+      try {
+        const tmdb = new TMDBMetadata({
+          accessToken: this.userData.tmdbReadAccessToken,
+          apiKey: this.userData.tmdbApiKey,
+        });
+        const episodeDetails = await tmdb.getEpisodeDetails(
+          searchMetadata.tmdbId,
+          Number(parsedId.season),
+          Number(parsedId.episode)
+        );
+        if (episodeDetails?.airDate) {
+          const airDate = new Date(episodeDetails.airDate);
+          airDate.setHours(0, 0, 0, 0);
+          const now = new Date();
+          now.setHours(0, 0, 0, 0);
+          const daysSince = Math.floor(
+            (now.getTime() - airDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+          if (daysSince <= 1) {
+            searchMetadata.recentCacheTTL = Env.BUILTIN_SEARCH_RECENT_TTL;
+          }
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Could not fetch episode air date for cache TTL decision: ${error}`
+        );
+      }
+    }
 
     this.logger.debug(
       `Got search metadata for ${parsedId.type}:${parsedId.value} in ${getTimeTakenSincePoint(start)}`,

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -199,13 +199,13 @@ export abstract class BaseNabAddon<
       this.logger.debug('Performing queries', { queries });
       const searchPromises = queries.map((q) =>
         queryLimit(() =>
-          this.fetchResults(searchFunction, { ...queryParams, q })
+          this.fetchResults(searchFunction, { ...queryParams, q }, metadata.recentCacheTTL)
         )
       );
       const allResults = await Promise.all(searchPromises);
       results = allResults.flat();
     } else {
-      results = await this.fetchResults(searchFunction, queryParams);
+      results = await this.fetchResults(searchFunction, queryParams, metadata.recentCacheTTL);
     }
     this.logger.info(
       `Completed search for ${capabilities.server.title} in ${getTimeTakenSincePoint(start)}`,
@@ -256,13 +256,14 @@ export abstract class BaseNabAddon<
 
   private async fetchResults(
     searchFunction: string,
-    params: Record<string, string>
+    params: Record<string, string>,
+    recentCacheTTL?: number
   ): Promise<SearchResultItem<A['namespace']>[]> {
     const queryLimit = createQueryLimit();
     const maxPages = Env.BUILTIN_NAB_MAX_PAGES;
 
     const initialResponse: SearchResponse<A['namespace']> =
-      await this.api.search(searchFunction, params);
+      await this.api.search(searchFunction, params, recentCacheTTL);
     let allResults = [...initialResponse.results];
 
     this.logger.debug('Initial search response', {
@@ -321,10 +322,11 @@ export abstract class BaseNabAddon<
             const offset = initialOffset + limit * (i + 1);
             return queryLimit(
               () =>
-                this.api.search(searchFunction, {
-                  ...params,
-                  offset: offset.toString(),
-                }) as Promise<SearchResponse<A['namespace']>>
+                this.api.search(
+                  searchFunction,
+                  { ...params, offset: offset.toString() },
+                  recentCacheTTL
+                ) as Promise<SearchResponse<A['namespace']>>
             );
           });
 
@@ -358,10 +360,8 @@ export abstract class BaseNabAddon<
       while (pageCount < maxPages) {
         const response: SearchResponse<A['namespace']> = await this.api.search(
           searchFunction,
-          {
-            ...params,
-            offset: currentOffset.toString(),
-          }
+          { ...params, offset: currentOffset.toString() },
+          recentCacheTTL
         );
 
         if (response.results.length === 0) {

--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -366,7 +366,8 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
 
   public async search(
     searchFunction: string = 'search',
-    params: Record<string, string | number | boolean> = {}
+    params: Record<string, string | number | boolean> = {},
+    recentCacheTTL?: number
   ): Promise<SearchResponse<N>> {
     const cacheKey = `${this.baseUrl}${this.apiPath}?t=${searchFunction}&${JSON.stringify(params)}&apikey=${this.apiKey}&${JSON.stringify(this.params)}`;
 
@@ -375,6 +376,7 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
       searchCacheKey: cacheKey,
       bgCacheKey: `nab:${cacheKey}`,
       cacheTTL: Env.BUILTIN_NAB_SEARCH_CACHE_TTL,
+      recentCacheTTL,
       fetchFn: () =>
         this.request(
           searchFunction,

--- a/packages/core/src/builtins/easynews-search/addon.ts
+++ b/packages/core/src/builtins/easynews-search/addon.ts
@@ -121,10 +121,10 @@ export class EasynewsSearchAddon extends BaseDebridAddon<EasynewsSearchAddonConf
       queryLimit(async () => {
         const start = Date.now();
         try {
-          const result = await this.api.search({
-            query,
-            paginate: this.userData.paginate,
-          });
+          const result = await this.api.search(
+            { query, paginate: this.userData.paginate },
+            metadata.recentCacheTTL
+          );
           logger.info(
             `Easynews search for "${query}" took ${getTimeTakenSincePoint(start)}`,
             { results: result.results.length }

--- a/packages/core/src/builtins/easynews-search/api.ts
+++ b/packages/core/src/builtins/easynews-search/api.ts
@@ -232,7 +232,10 @@ export class EasynewsApi {
    * Search for content with optional pagination
    * Returns results along with download server info
    */
-  async search(options: EasynewsSearchOptions): Promise<EasynewsSearchResult> {
+  async search(
+    options: EasynewsSearchOptions,
+    recentCacheTTL?: number
+  ): Promise<EasynewsSearchResult> {
     const cacheKey = JSON.stringify(options);
 
     return searchWithBackgroundRefresh({
@@ -240,6 +243,7 @@ export class EasynewsApi {
       searchCacheKey: cacheKey,
       bgCacheKey: `easynews:${cacheKey}`,
       cacheTTL: Env.BUILTIN_EASYNEWS_SEARCH_CACHE_TTL ?? 300,
+      recentCacheTTL,
       fetchFn: () => this.performSearchWithPagination(options),
       isEmptyResult: (result) => result.results.length === 0,
       logger,

--- a/packages/core/src/builtins/eztv/addon.ts
+++ b/packages/core/src/builtins/eztv/addon.ts
@@ -87,11 +87,14 @@ export class EztvAddon extends BaseDebridAddon<EztvAddonConfig> {
     const maxPages = Env.BUILTIN_EZTV_MAX_PAGES;
 
     // Perform initial search
-    const initialResponse = await this.api.getTorrents({
-      imdbId: imdbIdWithoutTt,
-      limit: 100,
-      page: 1,
-    });
+    const initialResponse = await this.api.getTorrents(
+      {
+        imdbId: imdbIdWithoutTt,
+        limit: 100,
+        page: 1,
+      },
+      metadata.recentCacheTTL
+    );
 
     let allTorrents = [...initialResponse.torrents];
 
@@ -117,11 +120,14 @@ export class EztvAddon extends BaseDebridAddon<EztvAddonConfig> {
         const pagePromises = Array.from({ length: pagesToFetch }, (_, i) => {
           const pageNumber = i + 2; // Start from page 2 since we already fetched page 1
           return queryLimit(() =>
-            this.api.getTorrents({
-              imdbId: imdbIdWithoutTt,
-              limit: 100,
-              page: pageNumber,
-            })
+            this.api.getTorrents(
+              {
+                imdbId: imdbIdWithoutTt,
+                limit: 100,
+                page: pageNumber,
+              },
+              metadata.recentCacheTTL
+            )
           );
         });
 

--- a/packages/core/src/builtins/eztv/api.ts
+++ b/packages/core/src/builtins/eztv/api.ts
@@ -93,7 +93,8 @@ class EztvAPI {
   }
 
   async getTorrents(
-    options: EztvGetTorrentsOptions
+    options: EztvGetTorrentsOptions,
+    recentCacheTTL?: number
   ): Promise<EztvGetTorrentsResponse> {
     const parsed = EztvGetTorrentsOptions.parse(options);
     const cacheKey = JSON.stringify(parsed);
@@ -103,6 +104,7 @@ class EztvAPI {
       searchCacheKey: cacheKey,
       bgCacheKey: `eztv:${cacheKey}`,
       cacheTTL: Env.BUILTIN_EZTV_SEARCH_CACHE_TTL,
+      recentCacheTTL,
       fetchFn: () =>
         this.request<EztvGetTorrentsResponse>('/api/get-torrents', {
           schema: EztvGetTorrentsResponseSchema,

--- a/packages/core/src/builtins/knaben/addon.ts
+++ b/packages/core/src/builtins/knaben/addon.ts
@@ -78,12 +78,15 @@ export class KnabenAddon extends BaseDebridAddon<KnabenAddonConfig> {
     const searchPromises = queries.map((q) =>
       queryLimit(async () => {
         const start = Date.now();
-        const { hits } = await this.api.search({
-          query: q,
-          categories,
-          size: 300,
-          hideUnsafe: false,
-        });
+        const { hits } = await this.api.search(
+          {
+            query: q,
+            categories,
+            size: 300,
+            hideUnsafe: false,
+          },
+          metadata.recentCacheTTL
+        );
         logger.info(
           `Knaben search for ${q} took ${getTimeTakenSincePoint(start)}`,
           {

--- a/packages/core/src/builtins/knaben/api.ts
+++ b/packages/core/src/builtins/knaben/api.ts
@@ -121,7 +121,10 @@ class KnabenAPI {
     };
   }
 
-  async search(options: KnabenSearchOptions): Promise<KnabenSearchResponse> {
+  async search(
+    options: KnabenSearchOptions,
+    recentCacheTTL?: number
+  ): Promise<KnabenSearchResponse> {
     const body = KnabenSearchOptionsRequest.parse(options);
     const cacheKey = JSON.stringify(options);
 
@@ -130,6 +133,7 @@ class KnabenAPI {
       searchCacheKey: cacheKey,
       bgCacheKey: `knaben:${cacheKey}`,
       cacheTTL: Env.BUILTIN_KNABEN_SEARCH_CACHE_TTL,
+      recentCacheTTL,
       fetchFn: () =>
         this.request<KnabenSearchResponse>('', {
           schema: KnabenSearchResponse,

--- a/packages/core/src/builtins/prowlarr/addon.ts
+++ b/packages/core/src/builtins/prowlarr/addon.ts
@@ -216,6 +216,7 @@ export class ProwlarrAddon extends BaseDebridAddon<ProwlarrAddonConfig> {
           indexerIds: chosenIndexers.map((indexer) => indexer.id),
           type: 'search',
           limit: 2000,
+          recentCacheTTL: metadata.recentCacheTTL,
         });
         this.logger.info(
           `Prowlarr ${protocol} search for ${q} took ${getTimeTakenSincePoint(start)}`,

--- a/packages/core/src/builtins/prowlarr/api.ts
+++ b/packages/core/src/builtins/prowlarr/api.ts
@@ -153,12 +153,14 @@ class ProwlarrApi {
     type,
     limit,
     offset,
+    recentCacheTTL,
   }: {
     query: string;
     indexerIds: number[];
     type: 'search';
     limit?: number;
     offset?: number;
+    recentCacheTTL?: number;
   }): Promise<ProwlarrApiResponse<ProwlarrApiSearchItem[]>> {
     const cacheKey = `${this.baseUrl}:${type}:${query}:${indexerIds.join(',')}:${limit}:${offset}`;
 
@@ -167,6 +169,7 @@ class ProwlarrApi {
       searchCacheKey: cacheKey,
       bgCacheKey: `prowlarr:${cacheKey}`,
       cacheTTL: Env.BUILTIN_PROWLARR_SEARCH_CACHE_TTL,
+      recentCacheTTL,
       fetchFn: () =>
         this.request<ProwlarrApiSearchItem[]>(
           'search',

--- a/packages/core/src/builtins/torbox-search/addon.ts
+++ b/packages/core/src/builtins/torbox-search/addon.ts
@@ -73,16 +73,28 @@ export class TorBoxSearchAddon extends BaseDebridAddon<TorBoxSearchAddonConfig> 
       return [];
     }
 
+    const { recentCacheTTL } = await this.getSearchMetadata();
+    const effectiveTTL =
+      recentCacheTTL ?? Env.BUILTIN_TORBOX_SEARCH_SEARCH_API_CACHE_TTL;
+
     const cacheKey = this.getCacheKey(parsedId, 'torrent');
     const cachedTorrents = await this.searchCache.get(cacheKey);
 
     if (cachedTorrents && this.useCache) {
-      logger.info(
-        `Found ${cachedTorrents.length} (cached) torrents for ${parsedId.type}:${parsedId.value}`
+      if (
+        recentCacheTTL == null ||
+        (await this.searchCache.getTTL(cacheKey)) <= effectiveTTL
+      ) {
+        logger.info(
+          `Found ${cachedTorrents.length} (cached) torrents for ${parsedId.type}:${parsedId.value}`
+        );
+        return cachedTorrents
+          .filter((t) => t.hash)
+          .map((t) => this.torrentToUnprocessed(t));
+      }
+      logger.debug(
+        `Cache entry for ${cacheKey} predates release day, re-fetching`
       );
-      return cachedTorrents
-        .filter((t) => t.hash)
-        .map((t) => this.torrentToUnprocessed(t));
     }
 
     const start = Date.now();
@@ -139,7 +151,7 @@ export class TorBoxSearchAddon extends BaseDebridAddon<TorBoxSearchAddonConfig> 
             (this.userData.searchUserEngines &&
               Env.BUILTIN_TORBOX_SEARCH_CACHE_PER_USER_SEARCH_ENGINE)
         ),
-        Env.BUILTIN_TORBOX_SEARCH_SEARCH_API_CACHE_TTL
+        effectiveTTL
       );
     }
 
@@ -158,16 +170,28 @@ export class TorBoxSearchAddon extends BaseDebridAddon<TorBoxSearchAddonConfig> 
       return [];
     }
 
+    const { recentCacheTTL } = await this.getSearchMetadata();
+    const effectiveTTL =
+      recentCacheTTL ?? Env.BUILTIN_TORBOX_SEARCH_SEARCH_API_CACHE_TTL;
+
     const cacheKey = this.getCacheKey(parsedId, 'usenet');
     const cachedTorrents = await this.searchCache.get(cacheKey);
 
     if (cachedTorrents && this.useCache) {
-      logger.info(
-        `Found ${cachedTorrents.length} (cached) NZBs for ${parsedId.type}:${parsedId.value}`
+      if (
+        recentCacheTTL == null ||
+        (await this.searchCache.getTTL(cacheKey)) <= effectiveTTL
+      ) {
+        logger.info(
+          `Found ${cachedTorrents.length} (cached) NZBs for ${parsedId.type}:${parsedId.value}`
+        );
+        return cachedTorrents
+          .filter((t) => t.nzb)
+          .map((t) => this.torrentToNzb(t));
+      }
+      logger.debug(
+        `Cache entry for ${cacheKey} predates release day, re-fetching`
       );
-      return cachedTorrents
-        .filter((t) => t.nzb)
-        .map((t) => this.torrentToNzb(t));
     }
 
     const start = Date.now();
@@ -218,11 +242,7 @@ export class TorBoxSearchAddon extends BaseDebridAddon<TorBoxSearchAddonConfig> 
     }
 
     if (this.useCache) {
-      await this.searchCache.set(
-        cacheKey,
-        filteredTorrents,
-        Env.BUILTIN_TORBOX_SEARCH_SEARCH_API_CACHE_TTL
-      );
+      await this.searchCache.set(cacheKey, filteredTorrents, effectiveTTL);
     }
 
     return filteredTorrents

--- a/packages/core/src/builtins/torrent-galaxy/addon.ts
+++ b/packages/core/src/builtins/torrent-galaxy/addon.ts
@@ -79,10 +79,13 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
 
         // First fetch to get total and page size
         logger.debug(`Fetching first page for query "${q}"`);
-        const firstPageResponse = await this.api.search({
-          query: q,
-          page: 1,
-        });
+        const firstPageResponse = await this.api.search(
+          {
+            query: q,
+            page: 1,
+          },
+          metadata.recentCacheTTL
+        );
 
         const { total, pageSize } = firstPageResponse;
         let allResults = [...firstPageResponse.results];
@@ -116,10 +119,13 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
 
         // Fetch all remaining pages in parallel
         const pagePromises = pageNumbers.map(async (pageNum) => {
-          const { results } = await this.api.search({
-            query: q,
-            page: pageNum,
-          });
+          const { results } = await this.api.search(
+            {
+              query: q,
+              page: pageNum,
+            },
+            metadata.recentCacheTTL
+          );
           logger.debug(`Fetched page ${pageNum} for query "${q}"`, {
             newResults: results.length,
           });

--- a/packages/core/src/builtins/torrent-galaxy/api.ts
+++ b/packages/core/src/builtins/torrent-galaxy/api.ts
@@ -95,7 +95,8 @@ class TorrentGalaxyAPI {
   }
 
   async search(
-    options: TorrentGalaxySearchOptions
+    options: TorrentGalaxySearchOptions,
+    recentCacheTTL?: number
   ): Promise<TorrentGalaxySearchResponse> {
     let queryParams = new URLSearchParams();
     if (options.page) {
@@ -107,6 +108,7 @@ class TorrentGalaxyAPI {
       searchCacheKey: cacheKey,
       bgCacheKey: `tgx:${cacheKey}`,
       cacheTTL: Env.BUILTIN_TORRENT_GALAXY_SEARCH_CACHE_TTL,
+      recentCacheTTL,
       fetchFn: () =>
         this.request<TorrentGalaxySearchResponse>(
           `/get-posts/keywords:${encodeURIComponent(options.query)}:format:json`,

--- a/packages/core/src/builtins/utils/general.ts
+++ b/packages/core/src/builtins/utils/general.ts
@@ -159,6 +159,10 @@ interface SearchWithBgRefreshOptions<T> {
   fetchFn: () => Promise<T>;
   isEmptyResult: (result: T) => boolean;
   logger: Logger;
+  /** Short cache TTL (seconds) that overrides the normal TTL. Set when
+   *  BUILTIN_SEARCH_RECENT_ENABLED is true and the episode aired within the
+   *  last day so new torrents are discovered quickly around release day. */
+  recentCacheTTL?: number;
 }
 
 /**
@@ -187,11 +191,38 @@ export async function searchWithBackgroundRefresh<T>(
     fetchFn,
     isEmptyResult,
     logger,
+    recentCacheTTL,
   } = options;
+
+  const effectiveTTL = recentCacheTTL ?? cacheTTL;
+  const isRecent = recentCacheTTL != null;
 
   const cachedResult = await searchCache.get(searchCacheKey);
 
   if (cachedResult !== undefined) {
+    if (isRecent) {
+      // The cached entry may have been written before the episode aired (when
+      // the long TTL was appropriate). If its remaining TTL exceeds the short
+      // recent TTL it is stale relative to release-day semantics, fetch fresh
+      // synchronously so this request gets up-to-date results.
+      const remainingTTL = await searchCache.getTTL(searchCacheKey);
+      if (remainingTTL > effectiveTTL) {
+        logger.debug(
+          `Cache entry for ${searchCacheKey} predates release day (remaining=${remainingTTL}s > recentTTL=${effectiveTTL}s), fetching fresh`
+        );
+        const freshResult = await fetchFn();
+        if (!isEmptyResult(freshResult)) {
+          await searchCache.set(searchCacheKey, freshResult, effectiveTTL);
+          await bgRefreshCache.set(
+            bgCacheKey,
+            Date.now(),
+            Env.BUILTIN_MINIMUM_BACKGROUND_REFRESH_INTERVAL
+          );
+        }
+        return freshResult;
+      }
+    }
+
     triggerBackgroundRefresh({
       searchCache,
       searchCacheKey,
@@ -200,6 +231,7 @@ export async function searchWithBackgroundRefresh<T>(
       fetchFn,
       isEmptyResult,
       logger,
+      recentCacheTTL,
     });
     return cachedResult;
   }
@@ -208,7 +240,7 @@ export async function searchWithBackgroundRefresh<T>(
 
   // Don't cache empty results
   if (!isEmptyResult(result)) {
-    await searchCache.set(searchCacheKey, result, cacheTTL);
+    await searchCache.set(searchCacheKey, result, effectiveTTL);
     await bgRefreshCache.set(
       bgCacheKey,
       Date.now(),
@@ -231,6 +263,7 @@ function triggerBackgroundRefresh<T>(options: {
   fetchFn: () => Promise<T>;
   isEmptyResult: (result: T) => boolean;
   logger: Logger;
+  recentCacheTTL?: number;
 }): void {
   const {
     searchCacheKey,
@@ -240,6 +273,7 @@ function triggerBackgroundRefresh<T>(options: {
     fetchFn,
     isEmptyResult,
     logger,
+    recentCacheTTL,
   } = options;
 
   (async () => {
@@ -259,7 +293,12 @@ function triggerBackgroundRefresh<T>(options: {
 
       // Update cache if result is not empty
       if (!isEmptyResult(freshResult)) {
-        await searchCache.set(searchCacheKey, freshResult, cacheTTL, true);
+        await searchCache.set(
+          searchCacheKey,
+          freshResult,
+          recentCacheTTL ?? cacheTTL,
+          true
+        );
         await bgRefreshCache.set(
           bgCacheKey,
           now,

--- a/packages/core/src/metadata/tmdb.ts
+++ b/packages/core/src/metadata/tmdb.ts
@@ -23,6 +23,7 @@ const ALTERNATIVE_TITLES_PATH = '/alternative_titles';
 const ID_CACHE_TTL = 30 * 24 * 60 * 60; // 30 days
 const TITLE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
 const AUTHORISATION_CACHE_TTL = 2 * 24 * 60 * 60; // 2 days
+const EPISODE_DETAILS_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
 
 // Zod schemas for API responses
 const GenreSchema = z.object({
@@ -154,6 +155,12 @@ export class TMDBMetadata {
   private readonly apiKey: string | undefined;
   private static readonly validationCache: Cache<string, boolean> =
     Cache.getInstance<string, boolean>('tmdb_validation');
+  private static readonly episodeDetailsCache: Cache<
+    string,
+    { airDate?: string; runtime?: number }
+  > = Cache.getInstance<string, { airDate?: string; runtime?: number }>(
+    'tmdb_episode_details'
+  );
   public constructor(auth?: { accessToken?: string; apiKey?: string }) {
     if (
       !auth?.accessToken &&
@@ -491,6 +498,12 @@ export class TMDBMetadata {
     seasonNumber: number,
     episodeNumber: number
   ): Promise<{ airDate?: string; runtime?: number } | undefined> {
+    const cacheKey = `${tmdbId}:${seasonNumber}:${episodeNumber}`;
+    const cached = await TMDBMetadata.episodeDetailsCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const url = new URL(
       API_BASE_URL +
         `/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`
@@ -507,10 +520,16 @@ export class TMDBMetadata {
     }
     const json = await response.json();
     const episodeData = TVEpisodeDetailsSchema.parse(json);
-    return {
+    const result = {
       airDate: episodeData.air_date ?? undefined,
       runtime: episodeData.runtime ?? undefined,
     };
+    await TMDBMetadata.episodeDetailsCache.set(
+      cacheKey,
+      result,
+      EPISODE_DETAILS_CACHE_TTL
+    );
+    return result;
   }
 
   public async getNextEpisodeAirDate(

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -2207,6 +2207,14 @@ export const Env = cleanEnv(process.env, {
     default: 1 * 24 * 60 * 60, // 1 day
     desc: 'Minimum interval between background refreshes for built-in addon search caches. Triggered during normal searches.',
   }),
+  BUILTIN_SEARCH_RECENT_ENABLED: bool({
+    default: false,
+    desc: 'When enabled, built-in scraper search results for episodes that aired within the last day are cached with a short TTL (BUILTIN_SEARCH_RECENT_TTL) instead of the normal per-scraper TTL, so new torrents are discovered quickly around release day.',
+  }),
+  BUILTIN_SEARCH_RECENT_TTL: num({
+    default: 10 * 60, // 10 minutes
+    desc: 'Short search cache TTL (seconds) applied to recently aired episodes when BUILTIN_SEARCH_RECENT_ENABLED is true.',
+  }),
 
   BUILTIN_GDRIVE_CLIENT_ID: str({
     default: undefined,

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -66,6 +66,8 @@ AIOStreams is configured via environment variables. When using Docker Compose, t
 | `BUILTIN_GET_TORRENT_CONCURRENCY`               | `100`                            | Concurrency for torrent metadata fetch tasks                                                                |
 | `BUILTIN_GET_TORRENT_LAZILY`                    | `true`                           | Fetch non-magnet torrents in the background instead of blocking the search                                  |
 | `BUILTIN_MINIMUM_BACKGROUND_REFRESH_INTERVAL`   | `86400`                          | Minimum interval between background cache refreshes (seconds)                                               |
+| `BUILTIN_SEARCH_RECENT_ENABLED`                 | `false`                          | When enabled, episodes that aired within the last day use `BUILTIN_SEARCH_RECENT_TTL`                       |
+| `BUILTIN_SEARCH_RECENT_TTL`                     | `600`                            | Short cache TTL (seconds) for recently aired episodes when `BUILTIN_SEARCH_RECENT_ENABLED` is true          |
 
 ### Prowlarr
 


### PR DESCRIPTION
## Problem

Built-in scrapers cache search results with long TTLs (default 7 days).

When an episode airs, any user who searched before release day gets a stale cache hit until it expires, potentially missing torrents that appeared on release day.

## Solution

Two new env vars gate the behaviour (disabled by default):


| Variable | Default | Description |
| --- | --- | --- |
| `BUILTIN_SEARCH_RECENT_ENABLED` | `false` | Enable short TTL for recently aired episodes |
| `BUILTIN_SEARCH_RECENT_TTL` | `600` | Cache TTL in seconds to use (default 10 min) |

When enabled, `getSearchMetadata` fetches the episode air date from TMDB (cached 7 days).

If the episode aired within the last day, `recentCacheTTL` is set on `SearchMetadata` and threaded through to `searchWithBackgroundRefresh` as an optional TTL override.

If a cache entry's remaining TTL exceeds `recentCacheTTL`, it was written before release day with a longer TTL, the next request force fetches fresh results synchronously rather than waiting for the long TTL to expire.

**Scrapers covered**
- *znab (Torznab/Newznab)
- Prowlarr
- Knaben
- EZTV
- Torrent Galaxy
- Easynews Search
- TorBox Search

## Notes
- Feature is opt-in and off by default, no behaviour change for existing deployments
- Movies are excluded
- TMDB air date lookup is skipped entirely when the feature is disabled
- TMDB episode details are cached for 7 days to avoid repeated API calls

 ## Notes for reviewer

I'm fairly confident this is the right approach for wiring the TTL override through the scraper stack, each api class already owns its `searchWithBackgroundRefresh` call and the `cacheTTL` parameter, so threading `recentCacheTTL` as an optional sibling felt like the natural fit. If there's a cleaner pattern I missed, happy to rework it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent short-term caching for recently aired episodes (configurable TTL) to improve search freshness across providers.
  * Per-episode metadata caching to speed up lookups and reduce repeated external queries.
  * Cache-refresh behaviour updated to synchronously refresh stale “recent” results when needed.

* **Documentation**
  * Added environment variables to toggle recent-episode caching and set its TTL (defaults documented).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->