### PR TITLE
Update Flix-Streams preset provider configuration

### DIFF
--- a/packages/core/src/presets/flixStreams.ts
+++ b/packages/core/src/presets/flixStreams.ts
@@ -1,4 +1,11 @@
-import { Addon, Option, ParsedStream, Stream, UserData } from '../db/index.js';
+import {
+  Addon,
+  Option,
+  ParsedStream,
+  PresetMetadata,
+  Stream,
+  UserData,
+} from '../db/index.js';
 import { Preset, baseOptions } from './preset.js';
 import {
   constants,
@@ -202,42 +209,128 @@ const supportedResources = [
 ];
 
 const marketplaceDefaults = {
-  enable_vidzee: true,
-  enable_autoembed: false,
-  enable_vixsrc: false,
-  enable_cineby: false,
-  enable_aniways: false,
-  enable_animeav1: false,
+  box13_emby_live_categories: [],
+  box13_emby_live_order_mode: 'default',
+  debrid_vault_priority_languages: [],
+  dlstreams_include_adult: false,
+  enable_4khdhub: false,
   enable_a111477: false,
-  enable_kisskh: false,
-  enable_hdhub4u: true,
-  enable_rivestream: false,
-  enable_vadapav: false,
-  enable_uhdmovies: false,
-  enable_vegamovies: false,
-  enable_moviesmod: false,
+  enable_animeav1: false,
   enable_animeflix: false,
-  enable_gokuhd: false,
-  enable_hollymoviehd: false,
-  enable_livetv_sx: false,
-  enable_librefutbol: false,
-  enable_freelivesports: false,
-  enable_toonami_aftermath: false,
-  enable_mkvcinemas: false,
-  enable_ee3: false,
+  enable_aniways: false,
+  enable_arabseed: false,
+  enable_autoembed: false,
+  enable_box13_emby: false,
+  enable_box13_emby_live_tv: false,
+  enable_cineby: false,
+  enable_cncverse: false,
   enable_debrid_vault: true,
-  enable_jellyfin: false,
-  enable_jellyfin_live_tv: false,
+  enable_dlstreams: false,
+  enable_ee3: false,
   enable_emby: true,
-  enable_telegram: true,
   enable_filesearchtools: false,
-  enable_egybest: false,
-  enable_naija2movies: false,
-  telegram_server: 'server1',
+  enable_fivemovierulz: false,
+  enable_freelivesports: false,
+  enable_gokuhd: false,
+  enable_hdhub4u: false,
+  enable_hianime: false,
+  enable_hollymoviehd: false,
+  enable_jellyfin: true,
+  enable_jellyfin_live_tv: false,
+  enable_kisskh: false,
+  enable_librefutbol: false,
   enable_live_tv_catalog: true,
-  famelack_countries: ['us'],
+  enable_livetv_sx: false,
+  enable_maxrls: false,
+  enable_mkvcinemas: false,
+  enable_moflix: false,
+  enable_moviesmod: false,
+  enable_pelispedia: false,
+  enable_piratesiptv: false,
+  enable_pokemon_telegram: false,
+  enable_rivestream: false,
+  enable_sharkstreams: false,
+  enable_showbox: false,
+  enable_streamsports99: false,
+  enable_superembed: false,
+  enable_telegram: true,
+  enable_toonami_aftermath: false,
+  enable_tv247us: false,
+  enable_uhdmovies: false,
+  enable_vadapav: false,
+  enable_vavoo: false,
+  enable_vegamovies: false,
+  enable_vidzee: false,
+  enable_vimeus: false,
+  enable_vixsrc: false,
+  enable_warflix: false,
+  enable_watch2movies: false,
   enable_wyzie: true,
+  enable_xcine: false,
+  famelack_countries: ['us'],
+  live_event_time_format: '24h',
+  live_event_timezone: 'provider_local',
+  provider_min_quality: 'any',
+  provider_order: [
+    'enable_telegram',
+    'enable_debrid_vault',
+    'enable_jellyfin',
+    'enable_emby',
+    'enable_a111477',
+    'enable_filesearchtools',
+    'enable_warflix',
+    'enable_box13_emby',
+    'enable_uhdmovies',
+    'enable_4khdhub',
+    'enable_hdhub4u',
+    'enable_showbox',
+    'enable_vegamovies',
+    'enable_watch2movies',
+    'enable_moviesmod',
+    'enable_gokuhd',
+    'enable_animeflix',
+    'enable_maxrls',
+    'enable_pokemon_telegram',
+    'enable_vidzee',
+    'enable_cineby',
+    'enable_rivestream',
+    'enable_vixsrc',
+    'enable_vimeus',
+    'enable_vadapav',
+    'enable_mkvcinemas',
+    'enable_arabseed',
+    'enable_pelispedia',
+    'enable_xcine',
+    'enable_moflix',
+    'enable_fivemovierulz',
+    'enable_ee3',
+    'enable_hollymoviehd',
+    'enable_aniways',
+    'enable_kisskh',
+    'enable_animeav1',
+    'enable_box13_emby_live_tv',
+    'enable_dlstreams',
+    'enable_streamsports99',
+    'enable_tv247us',
+    'enable_sharkstreams',
+    'enable_vavoo',
+    'enable_livetv_sx',
+    'enable_piratesiptv',
+    'enable_cncverse',
+    'enable_librefutbol',
+    'enable_freelivesports',
+    'enable_toonami_aftermath',
+  ],
+  provider_timeout_seconds: 20,
+  showbox_febbox_cookie: '',
+  showbox_febbox_cookie_ref: '',
+  stream_sort_mode: 'default',
+  streamsports99_countries: [],
   supporter_token: '',
+  telegram_language_filter: 'english',
+  telegram_server: 'master',
+  vavoo_countries: [],
+  wyzie_apply_to_aniways_ids: true,
   wyzie_languages: ['en'],
   wyzie_formats: ['srt', 'ass'],
   wyzie_source: 'all',
@@ -245,18 +338,89 @@ const marketplaceDefaults = {
   wyzie_max_results: 8,
 } as const;
 
+const providerOptions = [
+  { value: 'enable_telegram', label: 'Signal Vault' },
+  { value: 'enable_debrid_vault', label: 'Debrid Vault' },
+  { value: 'enable_jellyfin', label: 'Media Library (Jellyfin)' },
+  { value: 'enable_emby', label: 'Media Library (Emby)' },
+  { value: 'enable_box13_emby', label: 'Media Lib (2)' },
+  { value: 'enable_a111477', label: 'Lotus Vault' },
+  { value: 'enable_filesearchtools', label: 'Archive Vault' },
+  { value: 'enable_warflix', label: 'Warflix' },
+  { value: 'enable_uhdmovies', label: 'UhdMovies' },
+  { value: 'enable_4khdhub', label: '4KHDHub' },
+  { value: 'enable_hdhub4u', label: 'HDHub4u' },
+  { value: 'enable_showbox', label: 'Showbox / FebBox' },
+  { value: 'enable_vegamovies', label: 'VegaMovies' },
+  { value: 'enable_watch2movies', label: 'Watch2Movies' },
+  { value: 'enable_moviesmod', label: 'MoviesMod' },
+  { value: 'enable_gokuhd', label: 'GokuHD' },
+  { value: 'enable_animeflix', label: 'AnimeFlix' },
+  { value: 'enable_maxrls', label: 'MaxRLS' },
+  { value: 'enable_pokemon_telegram', label: 'Pokemon Vault' },
+  { value: 'enable_vidzee', label: 'VidZee' },
+  { value: 'enable_cineby', label: 'Cineby' },
+  { value: 'enable_rivestream', label: 'RiveStream' },
+  { value: 'enable_vixsrc', label: 'VixSrc' },
+  { value: 'enable_vimeus', label: 'Vimeus' },
+  { value: 'enable_vadapav', label: 'Vadapav' },
+  { value: 'enable_mkvcinemas', label: 'MkvCinemas' },
+  { value: 'enable_arabseed', label: 'ArabSeed' },
+  { value: 'enable_pelispedia', label: 'Pelispedia' },
+  { value: 'enable_xcine', label: 'XCine' },
+  { value: 'enable_moflix', label: 'Moflix' },
+  { value: 'enable_fivemovierulz', label: '5Movierulz' },
+  { value: 'enable_ee3', label: 'EE3' },
+  { value: 'enable_hollymoviehd', label: 'HollyMovieHD' },
+  { value: 'enable_aniways', label: 'Aniways' },
+  { value: 'enable_kisskh', label: 'KissKH' },
+  { value: 'enable_animeav1', label: 'AnimeAV1' },
+] as const;
+
+const liveTvProviderOptions = [
+  { value: 'enable_box13_emby_live_tv', label: 'Media Lib (2) Live TV' },
+  { value: 'enable_dlstreams', label: 'DLStreams' },
+  { value: 'enable_streamsports99', label: 'Premium Live TV Vault' },
+  { value: 'enable_tv247us', label: 'TV247US' },
+  { value: 'enable_sharkstreams', label: 'SharkStreams' },
+  { value: 'enable_vavoo', label: 'VAVOO' },
+  { value: 'enable_livetv_sx', label: 'Live Sports' },
+  { value: 'enable_piratesiptv', label: 'Pirates IPTV' },
+  { value: 'enable_cncverse', label: 'CNCVerse' },
+  { value: 'enable_librefutbol', label: 'Libre Futbol' },
+  { value: 'enable_freelivesports', label: 'Free Live Sports' },
+  { value: 'enable_toonami_aftermath', label: 'Toonami Aftermath' },
+] as const;
+
+const providerIds = providerOptions.map((option) => option.value);
+const liveTvProviderIds = liveTvProviderOptions.map((option) => option.value);
+const allProviderIds = [...providerIds, ...liveTvProviderIds];
+const defaultProviderSelection = providerIds.filter(
+  (id) => marketplaceDefaults[id]
+);
+const defaultLiveTvProviderSelection = liveTvProviderIds.filter(
+  (id) => marketplaceDefaults[id]
+);
+
+type FlixProviderMetadata = {
+  providerOptions: { value: string; label: string }[];
+  liveTvProviderOptions: { value: string; label: string }[];
+  defaultProviderSelection: string[];
+  defaultLiveTvProviderSelection: string[];
+};
+
 const supporterHint: Option = {
   id: 'supporterHint',
   name: 'Supporter Access',
   description:
-    'Paid access unlocks the premium provider stack, including Signal Vault, Media Library, sports relays, anime sources, and the rest of the supporter-only providers. Total support is matched by payment email: 5.00 USD unlocks up to 5 providers, while 8.99 USD total unlocks up to 10 providers.',
+    'Paid access unlocks the premium provider stack, including Signal Vault, Media Library, sports relays, anime sources, and other supporter-only providers. 10.00 USD one-time unlocks up to 10 providers lifetime, 5.00 USD monthly unlocks unlimited providers while active, and Ko-fi also has a separate 1 year unlimited package.',
   type: 'alert',
   intent: 'info-basic',
 };
 
 const supporterTokenOption: Option = {
   id: 'supporter_token',
-  name: 'Lifetime supporter token',
+  name: 'Supporter token',
   description:
     'Generate a supporter token at [https://flixnest.app/flix-streams/](https://flixnest.app/flix-streams/) using your payment email and paste it here for exclusive supporter features.',
   type: 'password',
@@ -265,220 +429,70 @@ const supporterTokenOption: Option = {
   default: undefined,
 };
 
-const moreProvidersSubsection: Option = {
-  id: 'moreProviders',
-  name: 'More Providers',
-  description:
-    'Open the rest of the Flix providers if you want the full provider list.',
-  type: 'subsection',
-  subsectionIntent: 'pill',
-  showInSimpleMode: false,
-  subOptions: [
-    {
-      id: 'enable_jellyfin',
-      name: 'Enable Media Library (Jellyfin)',
-      description:
-        'Movies, TV Shows, Anime with up to 4K remux lossless links.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_a111477',
-      name: 'Enable Lotus Vault',
-      description:
-        '1.1 PB archive for movies, series, anime, and K-dramas, with frequent 4K and remux-heavy library releases.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_filesearchtools',
-      name: 'Enable Archive Vault',
-      description:
-        'Deep archive search for hard-to-find movies, shows, anime, specials, and filename matches with strong 4K and remux coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_uhdmovies',
-      name: 'Enable UhdMovies',
-      description:
-        'Direct-link fallback source for movies, TV shows, and anime episode packs, often with dual-audio or multi-language releases.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_vegamovies',
-      name: 'Enable VegaMovies',
-      description:
-        'FastDL-backed movie, TV, and anime source with quality-specific release pages and frequent multi-language releases.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_moviesmod',
-      name: 'Enable MoviesMod',
-      description: 'Source for fresh movies and TV series.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_gokuhd',
-      name: 'Enable GokuHD',
-      description:
-        'Anime links for series and movies, often with dubbed or multi-language releases.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_animeflix',
-      name: 'Enable AnimeFlix',
-      description: 'Source for anime and Japanese cinema content.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_hdhub4u',
-      name: 'Enable Hdhub4u',
-      description:
-        'Movie and series source in the free tier, with direct HubDrive movie links and episode pages resolved lazily through the same gadgetsweb middleman chain as 4KHDHub.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_vidzee',
-      name: 'Enable VidZee',
-      description: 'Fast default source for the free tier.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_cineby',
-      name: 'Enable Cineby (4K, English, Spanish, Hindi, Latino)',
-      description: 'Movie and series source with broader language coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_rivestream',
-      name: 'Enable RiveStream (English, Hindi)',
-      description:
-        'MP4-first movie and series source with English and Hindi coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_autoembed',
-      name: 'Enable AutoEmbed (English and Hindi)',
-      description:
-        'General movie and series source for wider fallback coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_vixsrc',
-      name: 'Enable VixSrc',
-      description: 'Movie and series source for broader catalog coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_vadapav',
-      name: 'Enable Vadapav',
-      description: 'Extra movie and series fallback provider.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_mkvcinemas',
-      name: 'Enable MkvCinemas (multi/hindi)',
-      description: 'Hindi and multi-audio focused movie catalog.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_ee3',
-      name: 'Enable EE3',
-      description: 'Alternative premium source for movie and series links.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_hollymoviehd',
-      name: 'Enable HollyMovieHD',
-      description: 'Additional movie source for premium fallback coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_aniways',
-      name: 'Enable Aniways (Anime links)',
-      description: 'Anime links source with Aniways and Kitsu ID matching.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_kisskh',
-      name: 'Enable KissKH (Movies, K-Drama)',
-      description: 'Movies and K-Drama provider with Asian catalog coverage.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_animeav1',
-      name: 'Enable AnimeAV1 (Anime links)',
-      description: 'Anime links source for extra anime coverage and fallback.',
-      type: 'boolean',
-      default: false,
-    },
-  ],
-};
-
 const providerSubsection: Option = {
   id: 'providers',
   name: 'Providers',
   description:
-    'The main Flix simple-mode provider set, grouped into one marketplace panel.',
+    'Select the Flix movie, series, and anime providers you want to enable. The generated config sends the selected providers back to Flix as its current enable_* flags.',
   type: 'subsection',
   subsectionIntent: 'pill',
   subOptions: [
     {
-      id: 'enable_telegram',
-      name: 'Enable Signal Vault (Movies, TV Shows, Anime)',
+      id: 'selectedProviders',
+      name: 'Enabled providers',
       description:
-        'Priority relay for movies, TV shows, and anime file pulls through the server-side bridge.',
-      type: 'boolean',
-      default: true,
+        'Multi-select provider dropdown matching the current Flix-Streams provider list.',
+      type: 'multi-select',
+      required: false,
+      options: providerOptions.map((option) => ({
+        value: option.value,
+        label: option.label,
+      })),
+      default: defaultProviderSelection,
     },
     {
-      id: 'telegram_server',
-      name: 'Signal Vault server',
+      id: 'telegram_language_filter',
+      name: 'Signal Vault language',
       description:
-        'Default is SERVER1. Pick SERVER2 or SERVER3 only if that fits your library better.',
+        'Signal Vault now uses one unified search source. English keeps the raw title query; other choices add the language token used by Flix.',
       type: 'select',
-      default: 'server1',
+      default: 'english',
       options: [
-        { value: 'server1', label: 'Server 1' },
-        { value: 'server2', label: 'Server 2' },
-        { value: 'server3', label: 'Server 3' },
+        { value: 'english', label: 'English' },
+        { value: 'hindi', label: 'Hindi' },
+        { value: 'tamil', label: 'Tamil' },
+        { value: 'telugu', label: 'Telugu' },
+        { value: 'malayalam', label: 'Malayalam' },
+        { value: 'kannada', label: 'Kannada' },
       ],
     },
     {
-      id: 'enable_debrid_vault',
-      name: 'Enable Debrid Vault (Movies, TV Shows, Anime)',
+      id: 'provider_min_quality',
+      name: 'Minimum provider quality',
       description:
-        'Magnet-indexed movie, series, and anime streams resolved on the addon host into direct playback links.',
-      type: 'boolean',
-      default: true,
+        'Optional Flix-side quality filter for providers that expose quality metadata.',
+      type: 'select',
+      default: 'any',
+      options: [
+        { value: 'any', label: 'Default / Unfiltered' },
+        { value: '480p', label: '480p or better' },
+        { value: '720p', label: '720p or better' },
+        { value: '720p_only', label: '720p only' },
+        { value: '1080p', label: '1080p or better' },
+        { value: '1080p_only', label: '1080p only' },
+        { value: '2160p', label: '4K / 2160p only' },
+      ],
     },
     {
-      id: 'enable_emby',
-      name: 'Enable Media Library (Emby)',
+      id: 'showbox_febbox_cookie',
+      name: 'Showbox / FebBox cookie',
       description:
-        'Movies, TV Shows, Anime with broad media library coverage and direct playback links.',
-      type: 'boolean',
-      default: true,
+        'Optional cookie for Showbox / FebBox if your Flix setup uses it.',
+      type: 'password',
+      required: false,
+      emptyIsUndefined: true,
+      default: undefined,
     },
-    moreProvidersSubsection,
   ],
 };
 
@@ -486,7 +500,7 @@ const liveTvSubsection: Option = {
   id: 'liveTv',
   name: 'Live TV',
   description:
-    'Free live TV catalog first, with optional sports-focused providers if you want more coverage later.',
+    'Keep the built-in free catalog on, and optionally enable Flix live TV or sports sources from one dropdown.',
   type: 'subsection',
   subsectionIntent: 'pill',
   subOptions: [
@@ -499,32 +513,17 @@ const liveTvSubsection: Option = {
       default: true,
     },
     {
-      id: 'enable_livetv_sx',
-      name: 'Live TV - Sports',
-      description: 'Broad live sports source.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_librefutbol',
-      name: 'Libre Futbol',
-      description: 'Football-heavy live sports source.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_freelivesports',
-      name: 'Free Live Sports',
-      description: 'Extra live sports fallback source.',
-      type: 'boolean',
-      default: false,
-    },
-    {
-      id: 'enable_toonami_aftermath',
-      name: 'Toonami Aftermath',
-      description: 'Dedicated live channel feed.',
-      type: 'boolean',
-      default: false,
+      id: 'selectedLiveTvProviders',
+      name: 'Enabled live TV sources',
+      description:
+        'Multi-select live TV and sports sources. Channel-level selection is still handled by Flix for sources that expose country or channel pickers.',
+      type: 'multi-select',
+      required: false,
+      options: liveTvProviderOptions.map((option) => ({
+        value: option.value,
+        label: option.label,
+      })),
+      default: defaultLiveTvProviderSelection,
     },
   ],
 };
@@ -617,9 +616,33 @@ export class FlixStreamsStreamParser extends StreamParser {
 }
 
 export class FlixStreamsPreset extends Preset {
+  private static remoteProviderMetadataCache:
+    | {
+        expiresAt: number;
+        value: FlixProviderMetadata | null;
+      }
+    | undefined;
+
   static override getParser() {
     return FlixStreamsStreamParser;
   }
+
+  static async getDynamicMetadata(): Promise<PresetMetadata> {
+    const metadata = this.METADATA;
+    const remoteProviderMetadata = await this.getRemoteProviderMetadata();
+    if (!remoteProviderMetadata) {
+      return metadata;
+    }
+
+    return {
+      ...metadata,
+      OPTIONS: this.applyProviderMetadata(
+        metadata.OPTIONS,
+        remoteProviderMetadata
+      ),
+    };
+  }
+
   static override get METADATA() {
     const options: Option[] = [
       ...baseOptions(
@@ -699,38 +722,223 @@ export class FlixStreamsPreset extends Preset {
     return `${url}/${configToken}/manifest.json`;
   }
 
+  private static async getRemoteProviderMetadata(): Promise<FlixProviderMetadata | null> {
+    const cached = this.remoteProviderMetadataCache;
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    try {
+      const baseUrl = String(this.METADATA.URL).replace(/\/$/, '');
+      const response = await fetch(`${baseUrl}/configure`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (!response.ok) {
+        throw new Error(`Flix configure fetch failed: ${response.status}`);
+      }
+      const html = await response.text();
+      const metadata = this.parseRemoteProviderMetadata(html);
+      this.remoteProviderMetadataCache = {
+        expiresAt: Date.now() + 10 * 60 * 1000,
+        value: metadata,
+      };
+      return metadata;
+    } catch {
+      this.remoteProviderMetadataCache = {
+        expiresAt: Date.now() + 60 * 1000,
+        value: null,
+      };
+      return null;
+    }
+  }
+
+  private static parseRemoteProviderMetadata(
+    html: string
+  ): FlixProviderMetadata | null {
+    const defaultConfigMatch = html.match(
+      /DEFAULT_CONFIG\s*=\s*(\{[\s\S]*?\});/
+    );
+    if (!defaultConfigMatch) {
+      return null;
+    }
+
+    const defaultConfig = JSON.parse(defaultConfigMatch[1]) as Record<
+      string,
+      any
+    >;
+    const providerOrder = Array.isArray(defaultConfig.provider_order)
+      ? defaultConfig.provider_order.filter(
+          (value): value is string =>
+            typeof value === 'string' && value.startsWith('enable_')
+        )
+      : [];
+    if (providerOrder.length === 0) {
+      return null;
+    }
+
+    const liveStartIndex = providerOrder.indexOf('enable_box13_emby_live_tv');
+    const firstLiveIndex =
+      liveStartIndex >= 0 ? liveStartIndex : providerOrder.length;
+    const providerIds = providerOrder.slice(0, firstLiveIndex);
+    const liveTvProviderIds = providerOrder.slice(firstLiveIndex);
+
+    const toOption = (id: string) => ({
+      value: id,
+      label: this.findProviderLabel(html, id) || this.labelFromProviderId(id),
+    });
+
+    return {
+      providerOptions: providerIds.map(toOption),
+      liveTvProviderOptions: liveTvProviderIds.map(toOption),
+      defaultProviderSelection: providerIds.filter(
+        (id) => defaultConfig[id] === true
+      ),
+      defaultLiveTvProviderSelection: liveTvProviderIds.filter(
+        (id) => defaultConfig[id] === true
+      ),
+    };
+  }
+
+  private static applyProviderMetadata(
+    options: Option[],
+    providerMetadata: FlixProviderMetadata
+  ): Option[] {
+    return options.map((option) => {
+      if (option.id === 'providers' && option.subOptions) {
+        return {
+          ...option,
+          subOptions: option.subOptions.map((subOption) =>
+            subOption.id === 'selectedProviders'
+              ? {
+                  ...subOption,
+                  options: providerMetadata.providerOptions,
+                  default: providerMetadata.defaultProviderSelection,
+                }
+              : subOption
+          ),
+        };
+      }
+      if (option.id === 'liveTv' && option.subOptions) {
+        return {
+          ...option,
+          subOptions: option.subOptions.map((subOption) =>
+            subOption.id === 'selectedLiveTvProviders'
+              ? {
+                  ...subOption,
+                  options: providerMetadata.liveTvProviderOptions,
+                  default: providerMetadata.defaultLiveTvProviderSelection,
+                }
+              : subOption
+          ),
+        };
+      }
+      return option;
+    });
+  }
+
+  private static findProviderLabel(html: string, id: string): string | null {
+    const inputIndex = html.indexOf(`id="${id}"`);
+    if (inputIndex === -1) {
+      return null;
+    }
+
+    const nearbyHtml = html.slice(inputIndex, inputIndex + 2500);
+    const copyMatch = nearbyHtml.match(
+      /<span class="provider-copy-text">([\s\S]*?)<\/span>/
+    );
+    if (!copyMatch) {
+      return null;
+    }
+
+    return this.cleanHtmlLabel(copyMatch[1])
+      .replace(/^Enable\s+/i, '')
+      .replace(/\s*\*$/, '')
+      .trim();
+  }
+
+  private static cleanHtmlLabel(value: string): string {
+    return value
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&#9733;/g, '*')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private static labelFromProviderId(id: string): string {
+    return id
+      .replace(/^enable_/, '')
+      .split('_')
+      .map((part) =>
+        part.length <= 3
+          ? part.toUpperCase()
+          : part.charAt(0).toUpperCase() + part.slice(1)
+      )
+      .join(' ');
+  }
+
   private static buildConfig(
     options: Record<string, any>
   ): Record<string, any> {
     const providers = options.providers || {};
-    const moreProviders = providers.moreProviders || {};
     const liveTv = options.liveTv || {};
+    const selectedProviders = this.resolveProviderSelection(
+      providers,
+      options,
+      'selectedProviders',
+      providerIds,
+      defaultProviderSelection
+    );
+    const selectedLiveTvProviders = this.resolveProviderSelection(
+      liveTv,
+      options,
+      'selectedLiveTvProviders',
+      liveTvProviderIds,
+      defaultLiveTvProviderSelection
+    );
     const wyzie = {
       ...(options.wyzie || {}),
-      wyzie_formats: options.wyzie?.wyzie_formats
-        ? options.wyzie.wyzie_formats
-            .split(',')
-            .map((format: string) => format.trim())
-        : marketplaceDefaults.wyzie_formats,
+      wyzie_formats: this.normaliseCsvOrArray(
+        options.wyzie?.wyzie_formats,
+        marketplaceDefaults.wyzie_formats
+      ),
     };
 
     const config: Record<string, any> = {
       ...marketplaceDefaults,
       supporter_token: options.supporter_token,
-      ...providers,
-      ...moreProviders,
-      ...liveTv,
+      enable_live_tv_catalog:
+        liveTv.enable_live_tv_catalog ??
+        options.enable_live_tv_catalog ??
+        marketplaceDefaults.enable_live_tv_catalog,
+      provider_min_quality:
+        providers.provider_min_quality ??
+        options.provider_min_quality ??
+        marketplaceDefaults.provider_min_quality,
+      showbox_febbox_cookie:
+        providers.showbox_febbox_cookie ??
+        options.showbox_febbox_cookie ??
+        marketplaceDefaults.showbox_febbox_cookie,
+      telegram_language_filter:
+        providers.telegram_language_filter ??
+        options.telegram_language_filter ??
+        marketplaceDefaults.telegram_language_filter,
       ...wyzie,
     };
 
-    delete config.moreProviders;
     delete config.supporter_email;
+    delete config.selectedProviders;
+    delete config.selectedLiveTvProviders;
 
-    if (config.supporter_token) {
-      config.enable_vidzee = false;
+    for (const id of allProviderIds) {
+      config[id] = false;
+    }
+    for (const id of [...selectedProviders, ...selectedLiveTvProviders]) {
+      config[id] = true;
     }
 
     config.enable_jellyfin_live_tv = false;
+    config.telegram_server = 'master';
 
     if (config.enable_live_tv_catalog) {
       config.famelack_countries = ['us'];
@@ -739,5 +947,59 @@ export class FlixStreamsPreset extends Preset {
     }
 
     return config;
+  }
+
+  private static resolveProviderSelection(
+    sectionOptions: Record<string, any>,
+    rootOptions: Record<string, any>,
+    selectionKey: string,
+    allowedIds: readonly string[],
+    defaultSelection: readonly string[]
+  ): string[] {
+    const explicitSelection =
+      sectionOptions[selectionKey] ?? rootOptions[selectionKey];
+    if (Array.isArray(explicitSelection)) {
+      return this.filterKnownProviderIds(explicitSelection, allowedIds);
+    }
+
+    const legacyEnabled = allowedIds.filter(
+      (id) => sectionOptions[id] === true || rootOptions[id] === true
+    );
+    const legacyDisabled = allowedIds.some(
+      (id) => sectionOptions[id] === false || rootOptions[id] === false
+    );
+    if (legacyEnabled.length > 0 || legacyDisabled) {
+      return legacyEnabled;
+    }
+
+    return [...defaultSelection];
+  }
+
+  private static filterKnownProviderIds(
+    value: unknown[],
+    allowedIds: readonly string[]
+  ): string[] {
+    const allowed = new Set(allowedIds);
+    return value.filter(
+      (item): item is string =>
+        typeof item === 'string' &&
+        (allowed.has(item) || /^enable_[a-z0-9_]+$/i.test(item))
+    );
+  }
+
+  private static normaliseCsvOrArray(
+    value: unknown,
+    fallback: readonly string[]
+  ): string[] {
+    if (Array.isArray(value)) {
+      return value.filter((item): item is string => typeof item === 'string');
+    }
+    if (typeof value === 'string' && value.trim()) {
+      return value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+    }
+    return [...fallback];
   }
 }

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -163,21 +163,44 @@ let PRESET_LIST: string[] = [
 
 export class PresetManager {
   static getPresetList(): PresetMinimalMetadata[] {
-    return PRESET_LIST.map((presetId) => this.fromId(presetId).METADATA).map(
-      (metadata: PresetMetadata) => ({
-        ID: metadata.ID,
-        NAME: metadata.NAME,
-        LOGO: metadata.LOGO,
-        DESCRIPTION: metadata.DESCRIPTION,
-        SUPPORTED_RESOURCES: metadata.SUPPORTED_RESOURCES,
-        SUPPORTED_STREAM_TYPES: metadata.SUPPORTED_STREAM_TYPES,
-        SUPPORTED_SERVICES: metadata.SUPPORTED_SERVICES,
-        OPTIONS: metadata.OPTIONS,
-        BUILTIN: metadata.BUILTIN,
-        DISABLED: metadata.DISABLED,
-        CATEGORY: metadata.CATEGORY,
+    return PRESET_LIST.map((presetId) =>
+      this.toMinimalMetadata(this.fromId(presetId).METADATA)
+    );
+  }
+
+  static async getPresetListDynamic(): Promise<PresetMinimalMetadata[]> {
+    return Promise.all(
+      PRESET_LIST.map(async (presetId) => {
+        const preset = this.fromId(presetId);
+        let metadata = preset.METADATA;
+        if (typeof (preset as any).getDynamicMetadata === 'function') {
+          try {
+            metadata = await (preset as any).getDynamicMetadata();
+          } catch {
+            metadata = preset.METADATA;
+          }
+        }
+        return this.toMinimalMetadata(metadata);
       })
     );
+  }
+
+  private static toMinimalMetadata(
+    metadata: PresetMetadata
+  ): PresetMinimalMetadata {
+    return {
+      ID: metadata.ID,
+      NAME: metadata.NAME,
+      LOGO: metadata.LOGO,
+      DESCRIPTION: metadata.DESCRIPTION,
+      SUPPORTED_RESOURCES: metadata.SUPPORTED_RESOURCES,
+      SUPPORTED_STREAM_TYPES: metadata.SUPPORTED_STREAM_TYPES,
+      SUPPORTED_SERVICES: metadata.SUPPORTED_SERVICES,
+      OPTIONS: metadata.OPTIONS,
+      BUILTIN: metadata.BUILTIN,
+      DISABLED: metadata.DISABLED,
+      CATEGORY: metadata.CATEGORY,
+    };
   }
 
   static fromId(id: string): typeof Preset {

--- a/packages/server/src/routes/api/status.ts
+++ b/packages/server/src/routes/api/status.ts
@@ -93,7 +93,7 @@ const statusInfo = async (): Promise<StatusResponse> => {
         },
         timeout: Env.DEFAULT_TIMEOUT ?? null,
       },
-      presets: PresetManager.getPresetList().map((preset) => ({
+      presets: (await PresetManager.getPresetListDynamic()).map((preset) => ({
         ...preset,
         DISABLED: FeatureControl.disabledAddons.has(preset.ID)
           ? {


### PR DESCRIPTION
Refreshes the Flix-Streams marketplace preset to match the current Flix configuration flow.

Changes include:

replaces individual provider toggles with multi-select provider selection removes outdated Signal Vault server selection and uses the current unified Signal Vault config updates movie/series/anime and live TV provider options maps selected providers back to Flix-compatible enable_* config flags adds dynamic provider metadata loading from the Flix configure page with a static fallback keeps compatibility with older saved toggle-based configs Tested with:

pnpm -F core -F server run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced provider configuration with multi-select controls for content providers and live TV sources.
- Added new customisation options for provider quality thresholds, language preferences, and authentication settings.
- Implemented dynamic configuration support to retrieve provider settings from backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->