### PR TITLE
docs(readme): standardize ElfHosted links and update sponsor wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ And much much more...
 Setting up AIOStreams is simple.
 
 1.  **Choose a Hosting Method**
-    - **🔓 Public Instance**: Use the **[Community Instance (Hosted by ElfHosted)](https://aiostreams.elfhosted.com/configure)**. It's free, but rate-limited and has Torrentio disabled.
-    - **🛠️ Self-Host / Paid Hosting**: For full control and no rate limits, host it yourself (Docker) or use a paid service like **[ElfHosted](https://store.elfhosted.com/product/aiostreams/elf/viren070/)** (using this link supports the project!).
+    - **🔓 Public Instance**: Use the **[Community Instance (Hosted by ElfHosted)](https://aiostreams.elfhosted.com/configure?utm_source=github&utm_medium=readme&utm_campaign=aiostreams-readme)**. It's free, but rate-limited and has Torrentio disabled.
+    - **🛠️ Self-Host / Paid Hosting**: For full control and no rate limits, host it yourself (Docker) or use a managed AIOStreams instance via **[ElfHosted](https://store.elfhosted.com/product/aiostreams/?utm_source=github&utm_medium=readme&utm_campaign=aiostreams-readme)** (ElfHosted are a project sponsor).
 
 2.  **Configure Your Addon**
     - Open the `/stremio/configure` page of your AIOStreams instance in a web browser.


### PR DESCRIPTION
Hey @Viren070 , this is just an update to the UTM tags on the ElfHosted link on the README, to improve our internal attribution analysis :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started section with revised hosting options and links for community and managed AIOStreams instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->