### PR TITLE
fix(presets): fix yastream catalog id for movie

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1025,6 +1025,11 @@ HDHUB_URL=https://hdhub.thevolecitor.qzz.io
 # ---------------- Subhero -----------------
 # SUBHERO_URL=https://subhero.chromeknight.dev
 
+# --------------- yastream ---------------
+# YASTREAM_URL=https://yastream.tamthai.de
+# DEFAULT_YASTREAM_TIMEOUT=
+# DEFAULT_YASTREAM_USER_AGENT=
+
 # --------------- StreamAsia ---------------
 # STREAMASIA_URL=https://stremio-dramacool-addon.xyz
 

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -47,6 +47,7 @@ import { FKStreamPreset } from './fkstream.js';
 import { FlixStreamsPreset } from './flixStreams.js';
 import { AIOSubtitlePreset } from './aiosubtitle.js';
 import { SubHeroPreset } from './subhero.js';
+import { YastreamPreset } from './yastream.js';
 import { StreamAsiaPreset } from './streamasia.js';
 import { MoreLikeThisPreset } from './moreLikeThis.js';
 import { GDriveAPI } from '../builtins/gdrive/index.js';
@@ -128,6 +129,7 @@ let PRESET_LIST: string[] = [
   'flix-streams',
   'astream',
   'brazuca-torrents',
+  'yastream',
   'streamasia',
   'usa-tv',
   'argentina-tv',
@@ -280,6 +282,8 @@ export class PresetManager {
         return AIOSubtitlePreset;
       case 'subhero':
         return SubHeroPreset;
+      case 'yastream':
+        return YastreamPreset;
       case 'streamasia':
         return StreamAsiaPreset;
       case 'more-like-this':

--- a/packages/core/src/presets/yastream.ts
+++ b/packages/core/src/presets/yastream.ts
@@ -32,7 +32,7 @@ export class YastreamPreset extends Preset {
             label: 'Korean Series',
           },
           {
-            value: 'kisskh.movies.Korean',
+            value: 'kisskh.movie.Korean',
             label: 'Korean Movies',
           },
           {
@@ -40,7 +40,7 @@ export class YastreamPreset extends Preset {
             label: 'Chinese Series',
           },
           {
-            value: 'kisskh.movies.Chinese',
+            value: 'kisskh.movie.Chinese',
             label: 'Chinese Movies',
           },
           {
@@ -48,7 +48,7 @@ export class YastreamPreset extends Preset {
             label: 'US Series',
           },
           {
-            value: 'kisskh.movies.US',
+            value: 'kisskh.movie.US',
             label: 'US Movies',
           },
           {
@@ -56,7 +56,7 @@ export class YastreamPreset extends Preset {
             label: 'Thai Series',
           },
           {
-            value: 'kisskh.movies.Thai',
+            value: 'kisskh.movie.Thai',
             label: 'Thai Movies',
           },
           {
@@ -64,7 +64,7 @@ export class YastreamPreset extends Preset {
             label: 'Philippine Series',
           },
           {
-            value: 'kisskh.movies.Philippine',
+            value: 'kisskh.movie.Philippine',
             label: 'Philippine Movies',
           },
           {
@@ -72,7 +72,7 @@ export class YastreamPreset extends Preset {
             label: 'Japanese Series',
           },
           {
-            value: 'kisskh.movies.Japanese',
+            value: 'kisskh.movie.Japanese',
             label: 'Japanese Movies',
           },
           {
@@ -80,7 +80,7 @@ export class YastreamPreset extends Preset {
             label: 'Hongkong Series',
           },
           {
-            value: 'kisskh.movies.Hongkong',
+            value: 'kisskh.movie.Hongkong',
             label: 'Hongkong Movies',
           },
           {
@@ -88,7 +88,7 @@ export class YastreamPreset extends Preset {
             label: 'Taiwanese Series',
           },
           {
-            value: 'kisskh.movies.Taiwanese',
+            value: 'kisskh.movie.Taiwanese',
             label: 'Taiwanese Movies',
           },
         ],

--- a/packages/core/src/presets/yastream.ts
+++ b/packages/core/src/presets/yastream.ts
@@ -1,0 +1,324 @@
+import { Addon, Option, UserData } from '../db/index.js';
+import { constants, createLogger, Env, ServiceId } from '../utils/index.js';
+import { baseOptions, Preset } from './preset.js';
+
+const logger = createLogger('core');
+
+export class YastreamPreset extends Preset {
+  static override get METADATA() {
+    const supportedResources = [
+      constants.STREAM_RESOURCE,
+      constants.CATALOG_RESOURCE,
+      constants.META_RESOURCE,
+      constants.SUBTITLES_RESOURCE,
+    ];
+
+    const options: Option[] = [
+      ...baseOptions(
+        'yastream',
+        supportedResources,
+        Env.DEFAULT_YASTREAM_TIMEOUT
+      ),
+      {
+        id: 'kisskhCatalogs',
+        name: 'Kisskh Catalogs | Multi',
+        description: 'The catalogs to use for Kisskh',
+        type: 'multi-select',
+        required: false,
+        default: ['kisskh.series.Korean'],
+        options: [
+          {
+            value: 'kisskh.series.Korean',
+            label: 'Korean Series',
+          },
+          {
+            value: 'kisskh.movies.Korean',
+            label: 'Korean Movies',
+          },
+          {
+            value: 'kisskh.series.Chinese',
+            label: 'Chinese Series',
+          },
+          {
+            value: 'kisskh.movies.Chinese',
+            label: 'Chinese Movies',
+          },
+          {
+            value: 'kisskh.series.US',
+            label: 'US Series',
+          },
+          {
+            value: 'kisskh.movies.US',
+            label: 'US Movies',
+          },
+          {
+            value: 'kisskh.series.Thai',
+            label: 'Thai Series',
+          },
+          {
+            value: 'kisskh.movies.Thai',
+            label: 'Thai Movies',
+          },
+          {
+            value: 'kisskh.series.Philippine',
+            label: 'Philippine Series',
+          },
+          {
+            value: 'kisskh.movies.Philippine',
+            label: 'Philippine Movies',
+          },
+          {
+            value: 'kisskh.series.Japanese',
+            label: 'Japanese Series',
+          },
+          {
+            value: 'kisskh.movies.Japanese',
+            label: 'Japanese Movies',
+          },
+          {
+            value: 'kisskh.series.Hongkong',
+            label: 'Hongkong Series',
+          },
+          {
+            value: 'kisskh.movies.Hongkong',
+            label: 'Hongkong Movies',
+          },
+          {
+            value: 'kisskh.series.Taiwanese',
+            label: 'Taiwanese Series',
+          },
+          {
+            value: 'kisskh.movies.Taiwanese',
+            label: 'Taiwanese Movies',
+          },
+        ],
+      },
+      {
+        id: 'onetouchtvCatalogs',
+        name: 'Onetouchtv Catalogs | Multi',
+        description: 'The catalogs to use for Ottv',
+        type: 'multi-select',
+        required: false,
+        default: ['onetouchtv.series.Korean'],
+        options: [
+          {
+            value: 'onetouchtv.series.Popular',
+            label: 'Popular Series',
+          },
+          {
+            value: 'onetouchtv.series.Korean',
+            label: 'Korean Series',
+          },
+          {
+            value: 'onetouchtv.series.Chinese',
+            label: 'Chinese Series',
+          },
+          {
+            value: 'onetouchtv.series.Thai',
+            label: 'Thai Series',
+          },
+        ],
+      },
+      {
+        id: 'idramaCatalogs',
+        name: 'iDrama Catalogs | Khmer',
+        description: 'The catalogs to use for iDrama',
+        type: 'boolean',
+        required: false,
+      },
+      {
+        id: 'kisskhStream',
+        name: 'Kisskh Stream and Subtitles | Multi',
+        description: 'Get stream and subtitles from kisskh',
+        type: 'boolean',
+        required: false,
+        default: true,
+      },
+      {
+        id: 'onetouchtvStream',
+        name: 'Onetouchtv Stream and Subtitles | Multi',
+        description: 'Get stream and subtitles from onetouchtv',
+        type: 'boolean',
+        required: false,
+        default: true,
+      },
+      {
+        id: 'idramaStream',
+        name: 'iDrama Stream | Khmer',
+        description: 'Get stream from iDrama',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+      {
+        id: 'kkphimStream',
+        name: 'kkphim Stream | Vietnamese',
+        description: 'Get stream from kkphim',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+      {
+        id: 'ophimStream',
+        name: 'ophim Stream | Vietnamese',
+        description: 'Get stream and subtitles from ophim',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+      {
+        id: 'nsfw',
+        name: 'Show Adult/NSFW poster',
+        description: 'Show adult/nsfw poster if enabled',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+      {
+        id: 'info',
+        name: 'Show detail stream information',
+        description:
+          'Show resolution, time, size for stream (take longer to load)',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+      {
+        id: 'poster',
+        name: 'Use custom poster with ratings',
+        description: 'Show custom poster with ratings',
+        type: 'select',
+        required: false,
+        default: 'rpdb',
+        options: [
+          { label: 'Rating Poster RPDB', value: 'rpdb' },
+          { label: 'Easy ratings ERDB', value: 'erdb' },
+          { label: 'Extended ratings XRDB', value: 'xrdb' },
+        ],
+      },
+      {
+        id: 'socials',
+        name: '',
+        description: '',
+        type: 'socials',
+        socials: [
+          { id: 'website', url: 'https://yastream.tamthai.de' },
+          { id: 'discord', url: 'https://discord.gg/fnXwYn7wBf' },
+          { id: 'github', url: 'https://github.com/hoangtamthai/yastream' },
+          { id: 'ko-fi', url: 'https://ko-fi.com/hoangtamthai' },
+        ],
+      },
+    ];
+
+    return {
+      ID: 'yastream',
+      NAME: 'yastream',
+      LOGO: `${Env.YASTREAM_URL}/img/yas.png`,
+      URL: Env.YASTREAM_URL,
+      TIMEOUT: Env.DEFAULT_YASTREAM_TIMEOUT || Env.DEFAULT_TIMEOUT,
+      USER_AGENT: Env.DEFAULT_YASTREAM_USER_AGENT || Env.DEFAULT_USER_AGENT,
+      DESCRIPTION:
+        'Stream Asian Dramas, Series and Movies directly from multiple sources. Powered by TMDB and TVDB for metadata.',
+      OPTIONS: options,
+      SUPPORTED_STREAM_TYPES: [constants.HTTP_STREAM_TYPE],
+      SUPPORTED_SERVICES: [],
+      SUPPORTED_RESOURCES: supportedResources,
+    };
+  }
+
+  static async generateAddons(
+    userData: UserData,
+    options: Record<string, any>
+  ): Promise<Addon[]> {
+    return [this.generateAddon(options)];
+  }
+
+  private static generateAddon(options: Record<string, any>): Addon {
+    const url = this.generateManifestUrl(options);
+    return {
+      name: options.name || this.METADATA.NAME,
+      manifestUrl: url,
+      enabled: true,
+      resources: options.resources,
+      timeout: options.timeout || this.METADATA.TIMEOUT,
+      preset: {
+        id: '',
+        type: this.METADATA.ID,
+        options: options,
+      },
+      headers: {
+        'User-Agent': this.METADATA.USER_AGENT,
+      },
+    };
+  }
+
+  private static generateManifestUrl(options: Record<string, any>) {
+    const url = (options.url || this.METADATA.URL).replace(/\/$/, '');
+    if (url.endsWith('/manifest.json')) {
+      return url;
+    }
+
+    const encodedUserData = this.generateEncodedConfig(options);
+    return `${url}/${encodedUserData}/manifest.json`;
+  }
+
+  private static generateEncodedConfig(options: Record<string, any>) {
+    enum Provider {
+      KISSKH = 'kisskh',
+      IDRAMA = 'idrama',
+      KKPHIM = 'kkphim',
+      OPHIM = 'ophim',
+      ONETOUCHTV = 'onetouchtv',
+    }
+    interface UserConfig {
+      catalogs: string[];
+      catalog: Provider[];
+      stream: Provider[];
+      nsfw: boolean;
+      info: boolean;
+      poster: 'rpdb' | 'erdb' | 'xrdb';
+    }
+    const userConfig: UserConfig = {
+      catalogs: [options.kisskhCatalogs, options.onetouchtvCatalogs].flat(),
+      stream: [],
+      catalog: [],
+      nsfw: options.nsfw,
+      info: options.info,
+      poster: options.poster,
+    };
+    // catalogs
+    if (options.kisskhCatalogs) {
+      userConfig.catalogs.push('kisskh.series.Search');
+      userConfig.catalogs.push('kisskh.movies.Search');
+      userConfig.catalog.push(Provider.KISSKH);
+    }
+    if (options.onetouchtvCatalogs) {
+      userConfig.catalogs.push('onetouchtv.series.Search');
+      userConfig.catalog.push(Provider.ONETOUCHTV);
+    }
+    if (options.idramaCatalogs) {
+      userConfig.catalogs.push('idrama.series.Search');
+      userConfig.catalogs.push('idrama.series.iDrama');
+      userConfig.catalog.push(Provider.IDRAMA);
+    }
+    // stream
+    if (options.kisskhStream) {
+      userConfig.stream.push(Provider.KISSKH);
+    }
+    if (options.onetouchtvStream) {
+      userConfig.stream.push(Provider.ONETOUCHTV);
+    }
+    if (options.idramaStream) {
+      userConfig.stream.push(Provider.IDRAMA);
+    }
+    if (options.kkphimStream) {
+      userConfig.stream.push(Provider.KKPHIM);
+    }
+    if (options.ophimStream) {
+      userConfig.stream.push(Provider.OPHIM);
+    }
+    const encodedConfig = this.base64EncodeJSON(userConfig, 'default');
+
+    return encodedConfig;
+  }
+}

--- a/packages/core/src/presets/yastream.ts
+++ b/packages/core/src/presets/yastream.ts
@@ -278,8 +278,14 @@ export class YastreamPreset extends Preset {
       info: boolean;
       poster: 'rpdb' | 'erdb' | 'xrdb';
     }
+    const kisskhCatalogs = Array.isArray(options.kisskhCatalogs)
+      ? options.kisskhCatalogs
+      : [];
+    const onetouchtvCatalogs = Array.isArray(options.onetouchtvCatalogs)
+      ? options.onetouchtvCatalogs
+      : [];
     const userConfig: UserConfig = {
-      catalogs: [options.kisskhCatalogs, options.onetouchtvCatalogs].flat(),
+      catalogs: [...kisskhCatalogs, ...onetouchtvCatalogs],
       stream: [],
       catalog: [],
       nsfw: options.nsfw,
@@ -287,12 +293,12 @@ export class YastreamPreset extends Preset {
       poster: options.poster,
     };
     // catalogs
-    if (options.kisskhCatalogs) {
+    if (kisskhCatalogs.length > 0) {
       userConfig.catalogs.push('kisskh.series.Search');
       userConfig.catalogs.push('kisskh.movies.Search');
       userConfig.catalog.push(Provider.KISSKH);
     }
-    if (options.onetouchtvCatalogs) {
+    if (onetouchtvCatalogs.length > 0) {
       userConfig.catalogs.push('onetouchtv.series.Search');
       userConfig.catalog.push(Provider.ONETOUCHTV);
     }

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -2028,6 +2028,19 @@ export const Env = cleanEnv(process.env, {
     desc: 'Default SubHero user agent',
   }),
 
+  YASTREAM_URL: url({
+    default: 'https://yastream.tamthai.de',
+    desc: 'yastream URL',
+  }),
+  DEFAULT_YASTREAM_TIMEOUT: num({
+    default: undefined,
+    desc: 'Default yastream timeout',
+  }),
+  DEFAULT_YASTREAM_USER_AGENT: userAgent({
+    default: undefined,
+    desc: 'Default yastream user agent',
+  }),
+
   STREAMASIA_URL: url({
     default: 'https://stremio-dramacool-addon.xyz',
     desc: 'StreamAsia URL',

--- a/packages/core/src/utils/startup.ts
+++ b/packages/core/src/utils/startup.ts
@@ -1546,6 +1546,19 @@ const logStartupInfo = () => {
     logKeyValue('  User Agent:', Env.DEFAULT_SUBHERO_USER_AGENT, '     ');
   }
 
+  // yastream
+  logKeyValue('yastream:', Env.YASTREAM_URL);
+  if (Env.DEFAULT_YASTREAM_TIMEOUT) {
+    logKeyValue(
+      '  Timeout:',
+      formatMilliseconds(Env.DEFAULT_YASTREAM_TIMEOUT),
+      '     '
+    );
+  }
+  if (Env.DEFAULT_YASTREAM_USER_AGENT) {
+    logKeyValue('  User Agent:', Env.DEFAULT_YASTREAM_USER_AGENT, '     ');
+  }
+
   // StreamAsia
   logKeyValue('StreamAsia:', Env.STREAMASIA_URL);
   if (Env.DEFAULT_STREAMASIA_TIMEOUT) {


### PR DESCRIPTION
Fix yastream movie catalog id from 'movies' to 'movie'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added yastream integration as a new preset option
  * Users can now configure yastream with customisable URL, timeout, and user-agent settings
  * Supports catalogue selections, provider stream toggles, NSFW filtering, and social features
  * Configuration parameters are logged during application startup for visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->