### PR TITLE
fix(config): skip precache selector validation when feature is disabled (#913)

### DIFF
--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -511,8 +511,11 @@ export async function validateConfig(
     }
   }
 
-  // validate precache selector
-  if (config.precacheSelector) {
+  // validate precache selector (only when the feature is enabled — the
+  // selector is otherwise dormant, and evaluating it on every request just
+  // pollutes logs with `SEL Expression evaluated...` for users who have the
+  // "Pre-cache Next Episode" toggle off; closes #913)
+  if (config.precacheSelector && config.precacheNextEpisode) {
     try {
       await StreamSelector.testSelect(config.precacheSelector);
     } catch (error) {


### PR DESCRIPTION
Closes #913.

## Diagnosis

`validateConfig` (in `packages/core/src/utils/config.ts`) is called from the userData middleware (`packages/server/src/middlewares/userData.ts:130`) on **every** stream / catalog / search request. Inside it, the precache selector validation block was:

```ts
// validate precache selector
if (config.precacheSelector) {
  try {
    await StreamSelector.testSelect(config.precacheSelector);
  } catch (error) {
    throw new Error(`Invalid precache selector: ${error}`);
  }
}
```

The migration in the same file (and mirrored in `packages/frontend/src/context/userData.tsx`) auto-populates `config.precacheSelector` with `DEFAULT_PRECACHE_SELECTOR` for older configs, even ones with `precacheNextEpisode: false`. So users who have the "Pre-cache Next Episode" toggle **off** still end up with a non-empty `precacheSelector` field, and every request triggers `testSelect` → full SEL eval → log line:

```
SEL | Expression evaluated in 0ms: "count(cached(streams)) == 0 ? uncached(streams) : []"
```

That's exactly what the reporter saw. The actual `precacheNextEpisode()` runtime path in `packages/core/src/main/resources.ts:619` is correctly gated on `ctx.userData.precacheNextEpisode`, so the feature itself doesn't run — only the dormant validation does.

## Fix

One-line gate:

```ts
if (config.precacheSelector && config.precacheNextEpisode) {
```

If the user later flips the toggle on, `validateConfig` re-runs at save time (and on the next request) and will catch any invalid expression before it's used at runtime. Other validated expression fields (`excludedStreamExpressions`, `requiredStreamExpressions`, etc.) don't have a corresponding feature toggle, so they're unaffected.

## Verification

- `pnpm -F core run build` — clean compile.
- Manually traced the eval path: `precacheNextEpisode()` at `packages/core/src/main/resources.ts:619` already gates the runtime path on `ctx.userData.precacheNextEpisode`. No other call site to `precacheSelector` runs in the request hot path; the only caller was `validateConfig`.
- The migration logic at `config.ts:823-834` and `userData.tsx:175-186` is unchanged — users still get the default selector populated, it just no longer gets validated until they enable the feature.

## Risks

- A user could now save a config with an invalid `precacheSelector` while the feature is disabled, then later enable it. The next save / request after enabling will re-run `validateConfig` with the gate satisfied, and the existing throw path (`Invalid precache selector: ...`) will fire — same behavior they'd get if they typed the bad selector after enabling. So the failure mode is preserved, just deferred to when it matters.
- No schema changes, no migration changes, no behavior change for users with the feature on. Build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved logging performance by reducing unnecessary validation messages when the "Pre-cache Next Episode" feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->