### PR TITLE
fix(api): stop leaking passwords in URL on user login (#926)

### DIFF
--- a/packages/docs/content/docs/apis/user.mdx
+++ b/packages/docs/content/docs/apis/user.mdx
@@ -56,16 +56,25 @@ curl -X HEAD "https://your-instance.example.com/api/v1/user?uuid=xxxxxxxx-xxxx-x
 
 ## Get User
 
-`GET /api/v1/user`
+`POST /api/v1/user/load`
 
-Returns the full user configuration and an encrypted copy of the password for use in subsequent requests.
+Returns the full user configuration and an encrypted copy of the password for use in subsequent requests. Prefer this form over `GET /api/v1/user` — the password is sent in the JSON body so it never appears in URLs, HTTP access logs, browser history, or `Referer` headers.
 
-### Query Parameters
+### Request Body
 
-| Parameter  | Type   | Required | Description                 |
-| ---------- | ------ | -------- | --------------------------- |
-| `uuid`     | string | ✅       | UUID (or alias) of the user |
-| `password` | string | ✅       | User's plaintext password   |
+```json
+{
+  "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "password": "mypassword",
+  "raw": false
+}
+```
+
+| Field      | Type    | Required | Description                                                                                |
+| ---------- | ------- | -------- | ------------------------------------------------------------------------------------------ |
+| `uuid`     | string  | ✅       | UUID (or alias) of the user                                                                |
+| `password` | string  | ✅       | User's plaintext password                                                                  |
+| `raw`      | boolean | ❌       | When `true`, returns the raw stored config without server-side hydration. Defaults to `false`. |
 
 ### Response `200`
 
@@ -85,6 +94,33 @@ Returns the full user configuration and an encrypted copy of the password for us
 | ------------------- | ------ | ------------------------------------------------------------------------------------------ |
 | `userData`          | object | Full user configuration object                                                             |
 | `encryptedPassword` | string | Server-encrypted password — pass this back in the manifest URL instead of the raw password |
+
+### Example
+
+```bash
+curl -X POST "https://your-instance.example.com/api/v1/user/load" \
+  -H "Content-Type: application/json" \
+  -d '{"uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "password": "mypassword"}'
+```
+
+---
+
+## Get User (deprecated)
+
+`GET /api/v1/user`
+
+<Callout type="warn">
+  **Deprecated.** This form puts the password in the query string, so it ends up in HTTP access logs, browser history, and `Referer` headers. Use `POST /api/v1/user/load` instead. See [#926](https://github.com/Viren070/AIOStreams/issues/926).
+</Callout>
+
+Returns the same payload as `POST /api/v1/user/load`. Kept for backward compatibility with existing automation; the server logs a deprecation warning on every call.
+
+### Query Parameters
+
+| Parameter  | Type   | Required | Description                 |
+| ---------- | ------ | -------- | --------------------------- |
+| `uuid`     | string | ✅       | UUID (or alias) of the user |
+| `password` | string | ✅       | User's plaintext password   |
 
 ### Example
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -239,18 +239,20 @@ interface GDriveTokenResponse {
 }
 
 /**
- * Load user configuration
+ * Load user configuration. Uses POST /user/load instead of GET /user so
+ * the password rides in the request body — keeping it out of HTTP access
+ * logs, browser history, and Referer headers (issue #926).
  */
 export async function loadUserConfig(uuid: string, password: string) {
-  return api<LoadUserResponse>(
-    `GET /user?uuid=${uuid}&password=${encodeURIComponent(password)}`
-  );
+  return api<LoadUserResponse>('POST /user/load', {
+    body: { uuid, password },
+  });
 }
 
 export async function loadRawUserConfig(uuid: string, password: string) {
-  return api<LoadUserResponse>(
-    `GET /user?uuid=${uuid}&password=${encodeURIComponent(password)}&raw=true`
-  );
+  return api<LoadUserResponse>('POST /user/load', {
+    body: { uuid, password, raw: true },
+  });
 }
 
 /**

--- a/packages/server/src/middlewares/alias.ts
+++ b/packages/server/src/middlewares/alias.ts
@@ -21,7 +21,10 @@ export function resolveUuidAliasForUserApi(
         req.uuid = configuration?.uuid;
       }
     }
-  } else if (method === 'PUT' || method === 'DELETE') {
+  } else if (method === 'PUT' || method === 'DELETE' || method === 'POST') {
+    // POST is included for /api/v1/user/load (and incidentally /verify,
+    // /password) so aliases work there too. POST /api/v1/user (create)
+    // has no `uuid` in the body so the lookup below no-ops.
     const value = (req.body ?? {}).uuid;
     if (typeof value === 'string' && !uuidRegex.test(value)) {
       const configuration = Env.ALIASED_CONFIGURATIONS.get(value);

--- a/packages/server/src/routes/api/user.ts
+++ b/packages/server/src/routes/api/user.ts
@@ -55,13 +55,20 @@ router.head('/', async (req, res, next) => {
   }
 });
 
-// getting user details
-router.get('/', async (req, res, next) => {
-  const { uuid, password, raw } = {
-    uuid: req.uuid || req.query.uuid,
-    password: req.query.password,
-    raw: req.query.raw,
-  };
+// Shared handler used by both `GET /` (deprecated, query string) and
+// `POST /load` (preferred, JSON body). The GET form leaks the password
+// into HTTP access logs, browser history, Referer headers, etc. — see
+// issue #926. POST /load lets the password ride in the request body so
+// reverse proxies don't log it. The GET handler is kept for backward
+// compatibility (the API is public; users may have automation hitting
+// it) and emits a deprecation warning on each call.
+async function handleGetUserDetails(
+  uuid: unknown,
+  password: unknown,
+  raw: unknown,
+  next: (err?: any) => void,
+  res: any
+) {
   if (typeof uuid !== 'string' || typeof password !== 'string') {
     next(
       new APIError(
@@ -75,7 +82,7 @@ router.get('/', async (req, res, next) => {
   let userData = null;
   try {
     userData =
-      raw === 'true'
+      raw === 'true' || raw === true
         ? await UserRepository.getRawUser(uuid, password)
         : await UserRepository.getUser(uuid, password);
   } catch (error: any) {
@@ -110,6 +117,43 @@ router.get('/', async (req, res, next) => {
         encryptedPassword: encryptedPassword,
       },
     })
+  );
+}
+
+// getting user details (DEPRECATED form — password rides in the query
+// string and ends up in HTTP access logs / browser history / Referer
+// headers, see #926). Kept for backward compatibility with existing
+// clients and documented automation; new callers should use
+// `POST /api/v1/user/load`.
+router.get('/', async (req, res, next) => {
+  logger.warn(
+    'Deprecated: GET /api/v1/user exposes the password in the request URL ' +
+      '(visible in HTTP access logs, browser history, Referer headers). ' +
+      'Use POST /api/v1/user/load instead. See https://github.com/Viren070/AIOStreams/issues/926'
+  );
+  await handleGetUserDetails(
+    req.uuid || req.query.uuid,
+    req.query.password,
+    req.query.raw,
+    next,
+    res
+  );
+});
+
+// getting user details — preferred form: password is in the JSON body
+// so it never appears in URLs, access logs, or Referer headers.
+router.post('/load', async (req, res, next) => {
+  const body = (req.body ?? {}) as {
+    uuid?: unknown;
+    password?: unknown;
+    raw?: unknown;
+  };
+  await handleGetUserDetails(
+    req.uuid || body.uuid,
+    body.password,
+    body.raw,
+    next,
+    res
   );
 });
 


### PR DESCRIPTION
Closes #926.

## Diagnosis

The login flow uses `GET /api/v1/user?uuid=...&password=...`. Because the password rides in the URL, it ends up in every place HTTP request URLs land:

- reverse-proxy access logs (nginx / caddy / cloudflare in front of Docker — exactly where the reporter caught it)
- browser address bar + history
- HTTP `Referer` headers when the page navigates outbound
- any intermediate CDN / proxy log on the request path

Reporter's nginx log:

```
GET /api/v1/user?uuid=c95c8a2e-...&password=ThePasswordText&raw=true HTTP/2.0
```

The other mutating endpoints (`POST /user`, `PUT /user`, `DELETE /user`, `POST /user/password`, `POST /user/verify`) all carry credentials in the body and don't have this problem. Only the read path was broken.

## Fix

Three coordinated changes:

1. **Server** (`packages/server/src/routes/api/user.ts`) — extract the existing `GET /` handler body into a shared `handleGetUserDetails` helper, then add `POST /load` that calls the same helper with `req.body.{uuid,password,raw}`. The legacy `GET /` handler is preserved (the API is publicly documented; users may have automation hitting it) but now logs a deprecation warning on every call:

   ```
   Deprecated: GET /api/v1/user exposes the password in the request URL
   (visible in HTTP access logs, browser history, Referer headers).
   Use POST /api/v1/user/load instead. See https://github.com/Viren070/AIOStreams/issues/926
   ```

2. **Frontend** (`packages/frontend/src/lib/api.ts`) — switch `loadUserConfig` and `loadRawUserConfig` from `GET /user?uuid=...&password=...` to `POST /user/load` with a JSON body. Same return shape, no callers had to change.

3. **Alias middleware** (`packages/server/src/middlewares/alias.ts`) — extend the POST branch so `req.body.uuid` aliases resolve on POST endpoints. This is needed for `POST /load` (otherwise users with `ALIASED_CONFIGURATIONS` set would lose alias support compared to the GET form) and incidentally fixes the silent gap on `POST /verify` and `POST /password`. `POST /api/v1/user` (create) has no `uuid` in the body, so the lookup no-ops there.

4. **Docs** (`packages/docs/content/docs/apis/user.mdx`) — lead with `POST /api/v1/user/load` as the recommended form, keep the `GET` form documented as **deprecated** with a callout linking to #926.

## Verification

- `pnpm -F core run build`, `pnpm -F server run build`, `pnpm -F frontend run build` — all clean.
- Traced both call paths to confirm the shared helper produces the same response shape on both methods (same `userData` + `encryptedPassword` payload, same error mapping for `MISSING_REQUIRED_FIELDS`, `ENCRYPTION_ERROR`, `INTERNAL_SERVER_ERROR`).
- `raw` parameter accepts string `'true'` (legacy GET, query strings are always strings) **or** boolean `true` (new POST, JSON), so frontend can send `raw: true` directly without the `'true'` quoting.
- Frontend rate limiter `userApiRateLimiter` and the alias middleware are still applied at the router level, so they cover both methods.
- No DB schema changes, no migration changes, no environment variable changes.

## Risks

- **Backward compat**: the deprecated GET endpoint still works exactly as before. Existing automation, manifest URL flows, and any third-party clients keep functioning. The deprecation warning is server-side only (log level `warn`), it doesn't change responses.
- **Alias resolution on other POST endpoints**: previously `POST /verify` and `POST /password` accepted `req.body.uuid` directly without alias resolution. Now they do alias resolution, which is consistency-positive (the docs already claim "Wherever a UUID is accepted, you may supply a configured alias"). If anyone had a UUID that happened to also be a configured alias key, the resolver short-circuits on UUID format (`uuidRegex.test(value)`) so the existing behavior is preserved for actual UUIDs.
- **No password change is required from users** — the password value itself is unchanged, only its transport.

## Follow-ups (not in this PR)

- Consider eventually removing `GET /api/v1/user` after a deprecation window. Not in scope here.
- Audit any logs that might persist `req.query` or full request URLs server-side (out of scope; the reported leak is in the reverse proxy, which this PR fixes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added POST /api/v1/user/load endpoint to retrieve full user configuration and encrypted password.
  * Added POST endpoint for user account creation.

* **Documentation**
  * Updated API documentation with new endpoint specifications and migration guidance.
  * Marked GET /api/v1/user as deprecated whilst maintaining full backward compatibility for existing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->