### PR TITLE
fix: synced URL overrides not persisting after updates

### DIFF
--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -265,7 +265,9 @@ export class SelAccess {
 
       // Match by extracted names vs stored exprNames
       if (o.exprNames && o.exprNames.length > 0) {
-        const names = extractNamesFromExpression(expr.expression, false);
+        const names = extractNamesFromExpression(expr.expression, false)?.map(
+          (n) => (n.startsWith('#') ? n.slice(1).trim() : n)
+        );
         const matches = (list?: string[]) =>
           !!list &&
           list.length === o.exprNames!.length &&


### PR DESCRIPTION
Fixes #929 

An initial override was correctly matching an exact expression match, however once an expression change was made, it would fallback to a name match. The frontend strips the #, and the backend does not, causing the override to silently stop applying in the backend. This fix also strips the # in the backend to match the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of SEL override matching through enhanced null-safety and name normalisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->