### PR TITLE
fix(precomputer): make rseMatched() see prior expression matches

### DIFF
--- a/packages/core/src/streams/precomputer.ts
+++ b/packages/core/src/streams/precomputer.ts
@@ -166,12 +166,13 @@ class StreamPrecomputer {
 
     // Initialize all streams with a score of 0
     const streamScores = new Map<string, number>();
-    const streamExpressionNames = new Map<string, string[]>();
     for (const stream of streams) {
       streamScores.set(stream.id, 0);
     }
 
-    // Evaluate each ranked expression and accumulate scores
+    // Evaluate each ranked expression and accumulate scores.
+    // Write rankedStreamExpressionsMatched onto each stream as we go so that
+    // subsequent expressions can query prior matches via rseMatched().
     for (const { expression, score, enabled } of this.userData
       .rankedStreamExpressions) {
       if (enabled === false) {
@@ -180,18 +181,17 @@ class StreamPrecomputer {
 
       try {
         const selectedStreams = await selector.select(streams, expression);
+        const exprNames = extractNamesFromExpression(expression);
 
         // Add the score to each matched stream
         for (const stream of selectedStreams) {
           const currentScore = streamScores.get(stream.id) ?? 0;
           streamScores.set(stream.id, currentScore + score);
-          const exprNames = extractNamesFromExpression(expression);
           if (exprNames) {
-            const existingNames = streamExpressionNames.get(stream.id) || [];
-            streamExpressionNames.set(stream.id, [
-              ...existingNames,
+            stream.rankedStreamExpressionsMatched = [
+              ...(stream.rankedStreamExpressionsMatched ?? []),
               ...exprNames,
-            ]);
+            ];
           }
         }
       } catch (error) {
@@ -206,9 +206,6 @@ class StreamPrecomputer {
     // Apply the computed scores to the streams
     for (const stream of streams) {
       stream.streamExpressionScore = streamScores.get(stream.id) ?? 0;
-      stream.rankedStreamExpressionsMatched = streamExpressionNames.get(
-        stream.id
-      );
     }
 
     const nonZeroScores = streams.filter(


### PR DESCRIPTION
Fixes #932.

`precomputeRankedStreamExpressions` only wrote `stream.rankedStreamExpressionsMatched` after the whole expression-evaluation loop finished, so any expression in that loop that called `rseMatched()` saw an undefined `rankedStreamExpressionsMatched` on every stream and returned `[]`. That made `negate(rseMatched(streams, 'X'), …)` a no-op for cross-expression exclusion within a single pass.

This writes the matched names onto each stream as soon as an expression resolves, so subsequent expressions in the same pass can query prior matches via `rseMatched()`. The post-loop write is removed since the field is now kept current inline. Behaviour for streams matched by no expression is unchanged: `rankedStreamExpressionsMatched` stays `undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimised internal stream expression matching logic for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->