### PR TITLE
fix(builtins/torrentgalaxy): use different domain by default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -205,7 +205,7 @@ BUILTIN_PROWLARR_INDEXERS_CACHE_TTL=1209600
 
 
 # --- Torrent Galaxy ---
-# BUILTIN_TORRENT_GALAXY_URL=https://torrentgalaxy.space
+# BUILTIN_TORRENT_GALAXY_URL=https://torrentgalaxy.one
 # Default timeout of the addon in the marketplace
 # BUILTIN_DEFAULT_TORRENT_GALAXY_TIMEOUT=
 # The timeout for requests to TGx

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -2463,7 +2463,7 @@ export const Env = cleanEnv(process.env, {
   }),
 
   BUILTIN_TORRENT_GALAXY_URL: url({
-    default: 'https://torrentgalaxy.space',
+    default: 'https://torrentgalaxy.one',
     desc: 'Builtin Torrent Galaxy URL',
   }),
   BUILTIN_DEFAULT_TORRENT_GALAXY_TIMEOUT: num({

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -103,7 +103,7 @@ AIOStreams is configured via environment variables. When using Docker Compose, t
 
 | Variable                                  | Description                                      |
 | ----------------------------------------- | ------------------------------------------------ |
-| `BUILTIN_TORRENT_GALAXY_URL`              | TGx URL (default: `https://torrentgalaxy.space`) |
+| `BUILTIN_TORRENT_GALAXY_URL`              | TGx URL (default: `https://torrentgalaxy.one`) |
 | `BUILTIN_TORRENT_GALAXY_SEARCH_TIMEOUT`   | Timeout for TGx searches (default: 30000 ms)     |
 | `BUILTIN_TORRENT_GALAXY_SEARCH_CACHE_TTL` | Cache TTL (default: 604800)                      |
 | `BUILTIN_TORRENT_GALAXY_PAGE_LIMIT`       | Max pages to fetch (default: 5)                  |


### PR DESCRIPTION
.space does not work anymore, the domain's SSL is misconfigured it seems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Torrent Galaxy addon endpoint to reflect the current service URL.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/940)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->