### PR TITLE
fix(debrid): Preserve folder size for fallback service-wrapped streams

### DIFF
--- a/packages/core/src/main/serviceWrapper.ts
+++ b/packages/core/src/main/serviceWrapper.ts
@@ -443,6 +443,14 @@ async function buildDebridStreams(
           result.file.name ?? result.title
         );
       }
+      const size =
+        result.file.index === -1 && original?.size !== undefined
+          ? original.size
+          : result.file.size;
+      const folderSize =
+        result.file.index === -1 && original?.folderSize !== undefined
+          ? original.folderSize
+          : result.size;
       const debridStream: ParsedStream = {
         ...(original ?? {
           id: `wrap-${result.hash}-${result.service?.id}`,
@@ -464,8 +472,8 @@ async function buildDebridStreams(
             }
           : undefined,
         library: result.service?.library,
-        size: result.file.size,
-        folderSize: result.size,
+        size,
+        folderSize,
         filename: result.file.name ?? result.title ?? original?.filename,
         folderName: result.file.name ? result.title : original?.folderName,
         torrent: {


### PR DESCRIPTION
## Summary
- Keep the original parsed stream file size and folder size when a wrapped debrid result falls back to a synthetic selected file.
- Preserve file-vs-folder metadata for folder torrents when the debrid service response does not expose or select a concrete file.

## Verification
- `pnpm -F core exec prettier --write src/main/serviceWrapper.ts`
- `pnpm -F core build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream data handling by implementing fallback logic for size calculations, ensuring more accurate values are used when processing specific stream scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->