### PR TITLE
Add Method 4 (ElfHosted Managed) and Indexer IP note

### DIFF
--- a/packages/docs/content/docs/guides/usenet.mdx
+++ b/packages/docs/content/docs/guides/usenet.mdx
@@ -249,7 +249,7 @@ If you want the self-hosted setup without the complexity, ElfHosted offers a [pr
 - A bundled indexer to get started (_you can add more of your own later_)
 - 150 Mbps proxy bandwidth (_boostable_), enough to happily stream a 4K REMUX (_also usable for proxying debrid streams_)
 
-Preconfigured, fully supported, available in 5 minutes.
+Pre-configured, fully supported, available in 5 minutes.
 
 <Callout type="info">
   This is the same software stack as the self-hosted method, just hosted and pre-wired. The AIOStreams configuration steps in earlier guides apply unchanged.
@@ -278,9 +278,9 @@ Some indexers flag mismatched IPs between the search request and the NZB grab as
 
 **ElfHosted**
 
-When running an ElfHosted AIOStreams instance, your search IP and grab IP are always the same, and routed through a built-in NZBHydra/SABnzbd proxy on your instances, so that usage patterns are identical to traditional Usenet access.
+When running an ElfHosted AIOStreams instance, your search IP and grab IP are always the same, routed through a built-in NZBHydra/SABnzbd proxy on your instance, so usage patterns are identical to traditional Usenet access.
 
-ElfHosted also offer managed [NZBHydra2](https://store.elfhosted.com/product/nzbhydra/) or [Prowlarr](https://store.elfhosted.com/product/prowlarr/) instances ($1 trial) for users wanting to augment an existing setup.
+ElfHosted also offers managed [NZBHydra2](https://store.elfhosted.com/product/nzbhydra/) or [Prowlarr](https://store.elfhosted.com/product/prowlarr/) instances ($1 trial) for users wanting to augment an existing setup.
 
 The public [Zyclops NewzNab Healthcheck Proxy](https://zyclops.elfhosted.com/) (_an ElfHosted project_) is another means of ensuring your search IP matches your grab IP, and functionality to add Zyclops healthchecks is built into AIOStreams Newznab addons. Be sure to review the highlighted implications re credential / NZB sharing and your indexer's TOS.
 

--- a/packages/docs/content/docs/guides/usenet.mdx
+++ b/packages/docs/content/docs/guides/usenet.mdx
@@ -239,6 +239,24 @@ This is the most critical configuration step.
 
 ---
 
+## Method 4: ElfHosted (Managed)
+
+If you want the self-hosted setup without the complexity, ElfHosted offers a [pre-configured AIOStreams + nzbDAV bundle](https://store.elfhosted.com/product/aiostreams-nzbdav/) that includes:
+
+- A private AIOStreams instance (_yours to manage_)
+- nzbDAV, secured behind ElfHosted SSO
+- A bundled Usenet provider account
+- A bundled indexer to get started (_you can add more of your own later_)
+- 150 Mbps proxy bandwidth (_boostable_), enough to happily stream a 4K REMUX (_also usable for proxying debrid streams_)
+
+Preconfigured, fully supported, available in 5 minutes.
+
+<Callout type="info">
+  This is the same software stack as the self-hosted method, just hosted and pre-wired. The AIOStreams configuration steps in earlier guides apply unchanged.
+</Callout>
+
+---
+
 ## Indexer IP Considerations
 
 Some indexers flag mismatched IPs between the search request and the NZB grab as a TOS violation.
@@ -257,6 +275,14 @@ Some indexers flag mismatched IPs between the search request and the NZB grab as
 
 - **NZBHydra2:** Proxies grabs by default (preferred behaviour), unless the redirect option is enabled.
 - **Prowlarr:** Only redirects NZB grabs — this will cause an IP mismatch.
+
+**ElfHosted**
+
+When running an ElfHosted AIOStreams instance, your search IP and grab IP are always the same, and routed through a built-in NZBHydra/SABnzbd proxy on your instances, so that usage patterns are identical to traditional Usenet access.
+
+ElfHosted also offer managed [NZBHydra2](https://store.elfhosted.com/product/nzbhydra/) or [Prowlarr](https://store.elfhosted.com/product/prowlarr/) instances ($1 trial) for users wanting to augment an existing setup.
+
+The public [Zyclops NewzNab Healthcheck Proxy](https://zyclops.elfhosted.com/) (_an ElfHosted project_) is another means of ensuring your search IP matches your grab IP, and functionality to add Zyclops healthchecks is built into AIOStreams Newznab addons. Be sure to review the highlighted implications re credential / NZB sharing and your indexer's TOS.
 
 ### Indexer Policies
 


### PR DESCRIPTION
Adds a managed-deployment alternative to the existing 3 methods, plus a note in Indexer IP Considerations covering ElfHosted's same-IP behaviour, managed NZBHydra2/Prowlarr offerings, and the Zyclops NewzNab Healthcheck Proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Method 4: ElfHosted (Managed)" guide describing the pre-configured ElfHosted bundle (AIOStreams + nzbDAV) and how it aligns with existing self-hosted steps.
  * Expanded "Indexer IP Considerations" with ElfHosted-specific routing notes, including built-in proxy behaviour and available managed NZBHydra2/Prowlarr and public proxy options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/943)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->