### PR TITLE
fix: preserve subsection sub-option defaults on save

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -405,8 +405,8 @@ export class NewznabPreset extends BuiltinAddonPreset {
         enabled: true,
         backbones: options.zyclopsHealthProxy.backbones,
         providerHosts: providerHosts,
-        showUnknown: options.zyclopsHealthProxy.showUnknown,
-        singleIp: options.zyclopsHealthProxy.singleIp,
+        showUnknown: options.zyclopsHealthProxy.showUnknown ?? false,
+        singleIp: options.zyclopsHealthProxy.singleIp ?? true,
       };
     }
     const config: Record<string, any> = {

--- a/packages/frontend/src/components/shared/template-option.tsx
+++ b/packages/frontend/src/components/shared/template-option.tsx
@@ -566,10 +566,17 @@ const TemplateOption: React.FC<TemplateOptionProps> = ({
     case 'subsection': {
       const [modalOpen, setModalOpen] = useState(false);
       const subOptions = (option.subOptions ?? []) as Option[];
-      const currentValue = (forcedValue ??
+      const savedValue = (forcedValue ??
         value ??
         defaultValue ??
         {}) as Record<string, any>;
+      const subDefaults: Record<string, any> = {};
+      for (const sub of subOptions) {
+        if (sub.default !== undefined) {
+          subDefaults[sub.id] = sub.default;
+        }
+      }
+      const currentValue = { ...subDefaults, ...savedValue };
 
       const [localValue, setLocalValue] =
         useState<Record<string, any>>(currentValue);


### PR DESCRIPTION
## Summary

The Single-IP Mode toggle in Newznab's Zyclops health proxy subsection has `default: true`, but the value is silently lost on save when the user doesn't explicitly interact with the toggle. The UI displays it as ON (the boolean renderer falls back to the schema default at display time — [`template-option.tsx:335`](https://github.com/Viren070/AIOStreams/blob/main/packages/frontend/src/components/shared/template-option.tsx#L335)), so users have no indication anything is wrong, but outbound proxy requests go out with `single_ip=0`.

For a Zyclops-style indexer-fronting proxy, that toggle is the difference between "only the proxy's IP touches the upstream indexer" and "every user's IP hits the upstream indexer directly". The latter risks indexer ToS violation and account bans, while the user genuinely believes Single-IP Mode is on.

### Root cause

The subsection modal seeds `localValue` from the saved object only:

```ts
const currentValue = (forcedValue ?? value ?? defaultValue ?? {}) as Record<string, any>;
const [localValue, setLocalValue] = useState<Record<string, any>>(currentValue);
```

Sub-option defaults are never merged in. So a user who never explicitly toggles a field saves the subsection without that key, and downstream `userData.zyclopsHealthProxy.singleIp ? '1' : '0'` (in [`newznab/addon.ts`](https://github.com/Viren070/AIOStreams/blob/main/packages/core/src/builtins/newznab/addon.ts)) coerces `undefined → '0'`.

### Fix

Two parts:

1. **Newznab preset (`generateAddons`)** — apply the schema defaults (`singleIp ?? true`, `showUnknown ?? false`) when building the addon config. This corrects existing user configs missing the field on next manifest generation, without requiring a user resave. The pattern already exists in other presets (`meteor.ts`, `flixStreams.ts`).

2. **`TemplateOption` subsection** — seed the modal's `localValue` with sub-option defaults merged *under* the saved value. Saved values still win; only `undefined` sub-options pick up their schema defaults. This prevents the same class of bug recurring for any future subsection field with a non-`undefined` default.

## Test plan

- [ ] Add a new Newznab addon, enable Zyclops health proxy, configure a backbone, leave Single-IP Mode untouched, save. Verify outbound requests contain `single_ip=1`.
- [ ] For an existing user whose saved config has no `singleIp` field, verify the next manifest generation produces `single_ip=1` with no user action.
- [ ] Toggle Single-IP Mode OFF explicitly, save, verify outbound requests contain `single_ip=0` (saved `false` still wins over default `true`).
- [ ] For any other preset that uses `subsection` with `default: true` sub-options, verify those defaults are persisted on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health proxy configuration to properly apply default values (`showUnknown` and `singleIp`) when settings are not explicitly configured.
  * Improved template option handling to correctly merge and display default values alongside user-saved settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/944)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->