### PR TITLE
fix(core/nab): redact apikey query param in INFO/DEBUG logs

### DIFF
--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -7,6 +7,7 @@ import {
   getTimeTakenSincePoint,
   createLogger,
   makeRequest,
+  makeUrlLogSafe,
 } from '../../../utils/index.js';
 import { Parser } from 'xml2js';
 import { Logger } from 'winston';
@@ -439,7 +440,9 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
     url.search = searchParams.toString();
     const urlString = url.toString();
 
-    this.logger.info(`Making ${this.namespace} request to: ${urlString}`);
+    this.logger.info(
+      `Making ${this.namespace} request to: ${makeUrlLogSafe(urlString)}`
+    );
 
     try {
       const response = await makeRequest(urlString, {
@@ -479,7 +482,7 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
 
       const parsedResult = schema.parse(result);
       this.logger.debug(
-        `Completed ${this.namespace} request for ${urlString} in ${getTimeTakenSincePoint(start)}`
+        `Completed ${this.namespace} request for ${makeUrlLogSafe(urlString)} in ${getTimeTakenSincePoint(start)}`
       );
       return parsedResult;
     } catch (error) {

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -43,7 +43,7 @@ export function makeUrlLogSafe(url: string) {
     })
     .join('/')
     .replace(/(?<![^?&])(password=[^&]+)/g, 'password=****')
-    .replace(/(?<![^?&])(apiKey=[^&]+)/g, 'apiKey=****');
+    .replace(/(?<![^?&])(apikey=[^&]+)/gi, 'apikey=****');
 }
 
 export interface RequestOptions {


### PR DESCRIPTION
## Summary
- Redacts lower-case `apikey` query parameters in `makeUrlLogSafe` with case-insensitive matching.
- Wraps Newznab/Torznab request INFO and DEBUG URL logs with `makeUrlLogSafe(urlString)`.

## Leak context
Prowlarr can return Newznab URLs where `DownloadMappingService.ConvertToProxyLink` bakes the Prowlarr `apikey` into the query string. AIOStreams then logs the constructed `urlString` for Newznab requests at INFO and DEBUG, which exposed that key because the sanitizer only matched `apiKey` case-sensitively.

## Verification
- Built patched v2.27.3 image on the aiostreams host: `aiostreams-prowlarr-redact:v2.27.3-redactfix`.
- Smoke-triggered a Newznab search through the patched image against the existing Prowlarr container without replacing the live AIOStreams service.
- Captured container logs and ran a fixed-string grep for the 32-character Prowlarr key: `NO_LEAK_IN_PATCHED_LOGS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced request logging security to mask sensitive API keys in URLs using improved case-insensitive parameter detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/947)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->