### PR TITLE
Add clean filename stream redirect

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -72,6 +72,17 @@ const StreamProxyConfig = z.object({
 
 export type StreamProxyConfig = z.infer<typeof StreamProxyConfig>;
 
+const CleanRedirectOutputConfig = z.object({
+  enabled: z.boolean().optional(),
+  redirectCode: z
+    .union([z.literal(302), z.literal(307), z.literal(308)])
+    .optional(),
+});
+
+export type CleanRedirectOutputConfig = z.infer<
+  typeof CleanRedirectOutputConfig
+>;
+
 const ResultLimitOptions = z.object({
   global: z.number().min(1).optional(),
   service: z.number().min(1).optional(),
@@ -381,7 +392,7 @@ export const ParentConfigSchema = z.object({
       proxy: BinaryMergeStrategy.default('inherit'),
       metadata: BinaryMergeStrategy.default('inherit'),
       misc: BinaryMergeStrategy.default('inherit'),
-        branding: BinaryMergeStrategy.default('inherit'),
+      branding: BinaryMergeStrategy.default('inherit'),
       fieldOverrides: z
         .record(z.string(), z.enum(['inherit', 'override', 'extend']))
         .optional(),
@@ -646,6 +657,10 @@ export const UserDataSchema = z.object({
   usePosterServiceForMeta: z.boolean().optional(),
   formatter: Formatter,
   proxy: StreamProxyConfig.optional(),
+  cleanRedirectOutput: CleanRedirectOutputConfig.optional().default({
+    enabled: false,
+    redirectCode: 307,
+  }),
   resultLimits: ResultLimitOptions.optional(),
   size: SizeFilterOptions.optional(),
   bitrate: BitrateFilterOptions.optional(),

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -1515,6 +1515,7 @@ const METADATA_FIELDS: (keyof UserData)[] = [
 const MISC_FIELDS: (keyof UserData)[] = [
   'autoPlay', 'areYouStillThere', 'statistics', 'dynamicAddonFetching',
   'nzbFailover', 'serviceWrap', 'cacheAndPlay', 'preloadStreams', 'precacheSelector',
+  'cleanRedirectOutput',
   'hideErrors', 'hideErrorsForResources', 'addonCategoryColors', 'catalogModifications', 'mergedCatalogs',
   'addonPassword', 'externalDownloads', 'autoRemoveDownloads', 'checkOwned', 'showChanges',
   'randomiseResults', 'enhanceResults', 'enhancePosters',

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -219,6 +219,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
   usePosterServiceForMeta: { label: 'Use Poster Service for Meta', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
 
   autoPlay: { label: 'Auto Play', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback' },
+  cleanRedirectOutput: { label: 'Clean Filename Redirect', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback', keywords: ['infuse', 'subtitles', 'redirect'] },
   areYouStillThere: { label: 'Are You Still There?', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback' },
   statistics: { label: 'Statistics', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'display' },
   hideErrors: { label: 'Hide Errors', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'display' },

--- a/packages/docs/content/docs/guides/clean-filename-redirect.mdx
+++ b/packages/docs/content/docs/guides/clean-filename-redirect.mdx
@@ -1,0 +1,16 @@
+---
+title: Clean Filename Redirect
+description: Use a clean initial playback filename for external player subtitle matching.
+---
+
+# Clean Filename Redirect
+
+Clean Filename Redirect rewrites HTTP stream URLs through a lightweight AIOStreams endpoint that includes a cleaned filename in the URL path, then redirects to the original stream URL.
+
+This is useful for external players such as Infuse, where subtitle matching may rely on the initial playback filename.
+
+This feature does not proxy video traffic. AIOStreams only returns an HTTP redirect; the media is still fetched from the original provider, debrid service, or CDN URL.
+
+Recommended redirect code: 307.
+
+Default: disabled.

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "groups",
     "usenet",
+    "clean-filename-redirect",
     "scored-sorting",
     "seanime",
     "development"

--- a/packages/frontend/src/components/menu/miscellaneous/_components/playback-behavior.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous/_components/playback-behavior.tsx
@@ -115,6 +115,49 @@ export function PlaybackBehavior() {
       </SettingsCard>
 
       <SettingsCard
+        title="Clean Filename Redirect"
+        id="cleanRedirectOutput"
+        description="Rewrite HTTP stream URLs through a lightweight redirect endpoint with a clean filename in the initial playback path."
+      >
+        <Switch
+          label="Enable"
+          side="right"
+          value={userData.cleanRedirectOutput?.enabled ?? false}
+          onValueChange={(value) => {
+            setUserData((prev) => ({
+              ...prev,
+              cleanRedirectOutput: {
+                ...prev.cleanRedirectOutput,
+                enabled: value,
+                redirectCode: prev.cleanRedirectOutput?.redirectCode ?? 307,
+              },
+            }));
+          }}
+        />
+        <Select
+          label="Redirect Status Code"
+          help="HTTP redirect code used by the clean filename redirect endpoint. 307 is recommended."
+          disabled={!userData.cleanRedirectOutput?.enabled}
+          options={[
+            { label: '302 Found', value: '302' },
+            { label: '307 Temporary Redirect - recommended', value: '307' },
+            { label: '308 Permanent Redirect', value: '308' },
+          ]}
+          value={String(userData.cleanRedirectOutput?.redirectCode ?? 307)}
+          onValueChange={(value) => {
+            setUserData((prev) => ({
+              ...prev,
+              cleanRedirectOutput: {
+                ...prev.cleanRedirectOutput,
+                enabled: prev.cleanRedirectOutput?.enabled ?? false,
+                redirectCode: Number(value) as 302 | 307 | 308,
+              },
+            }));
+          }}
+        />
+      </SettingsCard>
+
+      <SettingsCard
         title="Are you still there?"
         id="areYouStillThere"
         description="Stop autoplay after a number of consecutive episodes so the player returns to stream selection."

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -293,6 +293,10 @@ export const DefaultUserData: UserData = {
   formatter: {
     id: 'gdrive',
   },
+  cleanRedirectOutput: {
+    enabled: false,
+    redirectCode: 307,
+  },
   preferredQualities: Object.values(QUALITIES),
   preferredResolutions: Object.values(RESOLUTIONS),
   excludedQualities: ['CAM', 'SCR', 'TS', 'TC'],

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -13,6 +13,7 @@ import {
   proxyApi,
   templatesApi,
   syncApi,
+  streamGateApi,
 } from './routes/api/index.js';
 import {
   configure,
@@ -111,6 +112,7 @@ apiRouter.use('/anime', animeApi);
 apiRouter.use('/proxy', proxyApi);
 apiRouter.use('/templates', templatesApi);
 apiRouter.use('/sync', syncApi);
+apiRouter.use('/stream-gate', streamGateApi);
 app.use(`/api/v${constants.API_VERSION}`, apiRouter);
 
 // Stremio Routes

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -11,3 +11,4 @@ export { default as animeApi } from './anime.js';
 export { default as proxyApi } from './proxy.js';
 export { default as templatesApi } from './templates.js';
 export { default as syncApi } from './sync.js';
+export { default as streamGateApi } from './streamGate.js';

--- a/packages/server/src/routes/api/streamGate.ts
+++ b/packages/server/src/routes/api/streamGate.ts
@@ -1,0 +1,65 @@
+import { Router, Request, Response } from 'express';
+import { createLogger, decryptString } from '@aiostreams/core';
+import {
+  type CleanRedirectPayload,
+  isValidHttpUrl,
+  sanitizeFilename,
+} from '../../utils/cleanRedirect.js';
+
+const router: Router = Router();
+const logger = createLogger('stream-gate');
+
+type StreamGateParams = {
+  data: string;
+  filename: string;
+};
+
+router.get(
+  '/:data/:filename',
+  (req: Request<StreamGateParams>, res: Response) => {
+    const { data, filename } = req.params;
+
+    const decrypted = decryptString(data);
+
+    if (!decrypted.success || !decrypted.data) {
+      logger.warn('Invalid stream-gate payload');
+      res.status(400).send('Invalid request');
+      return;
+    }
+
+    let payload: CleanRedirectPayload;
+
+    try {
+      payload = JSON.parse(decrypted.data) as CleanRedirectPayload;
+    } catch {
+      res.status(400).send('Invalid payload');
+      return;
+    }
+
+    if (
+      !payload ||
+      typeof payload !== 'object' ||
+      !payload.url ||
+      !isValidHttpUrl(payload.url)
+    ) {
+      res.status(400).send('Invalid stream URL');
+      return;
+    }
+
+    const safeFilename = sanitizeFilename(filename);
+    const redirectCode = payload.redirectCode ?? 307;
+
+    if (![302, 307, 308].includes(redirectCode)) {
+      res.status(400).send('Invalid redirect code');
+      return;
+    }
+
+    res.setHeader('Content-Disposition', `inline; filename="${safeFilename}"`);
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Clean-Filename', safeFilename);
+
+    res.redirect(redirectCode, payload.url);
+  }
+);
+
+export default router;

--- a/packages/server/src/routes/stremio/stream.ts
+++ b/packages/server/src/routes/stremio/stream.ts
@@ -9,6 +9,7 @@ import {
   IdParser,
 } from '@aiostreams/core';
 import { stremioStreamRateLimiter } from '../../middlewares/ratelimit.js';
+import { wrapStreamsWithCleanRedirectGate } from '../../utils/cleanRedirect.js';
 
 const router: Router = Router();
 
@@ -61,15 +62,20 @@ router.get(
         throw new Error('Stream context not available');
       }
 
-      res
-        .status(200)
-        .json(
-          await transformer.transformStreams(
-            response,
-            streamContext.toFormatterContext(response.data.streams),
-            { provideStreamData, disableAutoplay }
-          )
-        );
+      let transformed = await transformer.transformStreams(
+        response,
+        streamContext.toFormatterContext(response.data.streams),
+        { provideStreamData, disableAutoplay }
+      );
+
+      transformed = wrapStreamsWithCleanRedirectGate(
+        transformed,
+        response.data.streams,
+        req.userData,
+        req
+      );
+
+      res.status(200).json(transformed);
     } catch (error) {
       let errorMessage =
         error instanceof Error ? error.message : 'Unknown error';

--- a/packages/server/src/utils/cleanRedirect.ts
+++ b/packages/server/src/utils/cleanRedirect.ts
@@ -1,0 +1,146 @@
+import type { Request } from 'express';
+import {
+  Env,
+  constants,
+  encryptString,
+  type AIOStreamResponse,
+  type ParsedStream,
+  type UserData,
+} from '@aiostreams/core';
+
+type RedirectCode = 302 | 307 | 308;
+
+export type CleanRedirectPayload = {
+  url: string;
+  redirectCode?: RedirectCode;
+};
+
+export function decodeRepeatedly(value: string, max = 4): string {
+  let current = String(value || '');
+
+  for (let i = 0; i < max; i++) {
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) break;
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+
+  return current;
+}
+
+export function sanitizeFilename(
+  input: string,
+  fallback = 'stream.mkv'
+): string {
+  let name = decodeRepeatedly(input || fallback);
+
+  name = name
+    .split('?')[0]
+    .split('#')[0]
+    .replace(/[\r\n"]/g, '')
+    .replace(/[\\/]/g, '_')
+    .replace(/[<>:"|?*\x00-\x1F]/g, '')
+    .replace(/\+/g, ' ')
+    .replace(/\s+/g, '.')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^\.+|\.+$/g, '')
+    .trim();
+
+  if (!name) {
+    name = fallback;
+  }
+
+  if (!/\.(mkv|mp4|avi|mov|m4v|webm)$/i.test(name)) {
+    name += '.mkv';
+  }
+
+  return name;
+}
+
+export function isValidHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getBaseUrl(req: Request<any>): string {
+  return (
+    Env.BASE_URL ||
+    `${req.protocol}://${req.hostname}${
+      req.hostname === 'localhost' ? `:${Env.PORT}` : ''
+    }`
+  );
+}
+
+function isInternalMetadataStream(
+  stream: AIOStreamResponse['streams'][number]
+): boolean {
+  const type = stream.streamData?.type;
+  return (
+    type === constants.ERROR_STREAM_TYPE ||
+    type === constants.STATISTIC_STREAM_TYPE
+  );
+}
+
+export function wrapStreamsWithCleanRedirectGate(
+  result: AIOStreamResponse,
+  parsedStreams: ParsedStream[],
+  userData: UserData,
+  req: Request<any>
+): AIOStreamResponse {
+  const config = userData.cleanRedirectOutput;
+
+  if (!config?.enabled) {
+    return result;
+  }
+
+  const redirectCode = config.redirectCode ?? 307;
+  const baseUrl = getBaseUrl(req).replace(/\/+$/, '');
+  let originalStreamIndex = 0;
+
+  return {
+    ...result,
+    streams: result.streams.map((stream) => {
+      const parsed = isInternalMetadataStream(stream)
+        ? undefined
+        : parsedStreams[originalStreamIndex++];
+
+      if (!stream.url || !isValidHttpUrl(stream.url)) {
+        return stream;
+      }
+
+      const filename = sanitizeFilename(
+        parsed?.filename ||
+          stream.behaviorHints?.filename ||
+          `stream-${originalStreamIndex}.mkv`
+      );
+
+      const encrypted = encryptString(
+        JSON.stringify({
+          url: stream.url,
+          redirectCode,
+        } satisfies CleanRedirectPayload)
+      );
+
+      if (!encrypted.success || !encrypted.data) {
+        return stream;
+      }
+
+      return {
+        ...stream,
+        url: `${baseUrl}/api/v${constants.API_VERSION}/stream-gate/${encrypted.data}/${encodeURIComponent(filename)}`,
+        behaviorHints: {
+          ...stream.behaviorHints,
+          filename,
+          videoFilename: filename,
+        },
+      };
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

Adds an optional Clean Filename Redirect output mode for streams.

When enabled, HTTP stream URLs are rewritten through:

/api/v1/stream-gate/:data/:filename

The gate responds with a redirect to the original stream URL while exposing a clean filename in the initial URL path and Content-Disposition header.

## Behavior

- Disabled by default
- Preserves existing formatter output
- Does not proxy video traffic
- Only wraps HTTP/HTTPS stream URLs
- Default redirect code: 307

## Testing

- pnpm build
- pnpm -F core test
- pnpm -F server test
- pnpm -F frontend test
- pnpm -F docs build
- Tested locally with Fusion + Infuse 8.4
- Confirmed Infuse requests the clean filename URL and receives 307 redirect

Note: frontend lint was not run as a valid check because `next lint` opens the ESLint setup wizard in this package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Clean Filename Redirect setting in Playback behaviour options. Toggle to enable/disable, with configurable HTTP redirect codes (302, 307, or 308). Disabled by default.

* **Documentation**
  * Added guide for Clean Filename Redirect feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/950)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->