### PR TITLE
feat(search): read source indexer attribution

### DIFF
--- a/packages/core/src/builtins/newznab/addon.ts
+++ b/packages/core/src/builtins/newznab/addon.ts
@@ -192,6 +192,7 @@ export class NewznabAddon extends BaseNabAddon<NewznabAddonConfig, NewznabApi> {
         age: age,
         title: result.title,
         indexer:
+          result.newznab?.sourceIndexerName?.toString() ??
           result.newznab?.hydraIndexerName?.toString() ??
           meta.capabilities.server.title,
         size:


### PR DESCRIPTION
Reads the generic source field from upstream search results, so AIOS shows upstream source information.

Before results would show as `NZBDav` with this change they would show as `NZBGeek`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved indexer identification in Newznab searches to prioritise more reliable naming sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->