### PR TITLE
fix: pass streams parameter to toFormatterContext in ChillLink route

### DIFF
--- a/packages/server/src/routes/chilllink/streams.ts
+++ b/packages/server/src/routes/chilllink/streams.ts
@@ -63,7 +63,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
       .json(
         await transformer.transformStreams(
           response,
-          streamContext.toFormatterContext()
+          streamContext.toFormatterContext(response.data.streams)
         )
       );
   } catch (error) {


### PR DESCRIPTION
The toFormatterContext() call was missing the streams parameter, preventing calculation of maxSeScore and maxRegexScore. This caused normalized score variables (nSeScore, nRegexScore) to return null in ChillLink.

This matches the implementation in the Stremio route which correctly passes response.data.streams.