### PR TITLE
fix(db): use pg_advisory_xact_lock to prevent migration lock leak

### DIFF
--- a/packages/core/src/db/migrations/runner.ts
+++ b/packages/core/src/db/migrations/runner.ts
@@ -47,16 +47,18 @@ async function withMigrationLock<T>(
   fn: () => Promise<T>
 ): Promise<T> {
   if (driver.dialect === 'postgres') {
-    await driver.exec(`SELECT pg_advisory_lock(${PG_ADVISORY_LOCK_KEY})`);
-    try {
-      return await fn();
-    } finally {
-      try {
-        await driver.exec(`SELECT pg_advisory_unlock(${PG_ADVISORY_LOCK_KEY})`);
-      } catch {
-        // best-effort
-      }
-    }
+    // `pg_advisory_xact_lock` is auto-released by Postgres on COMMIT or
+    // ROLLBACK of the transaction's pinned connection, so its lifecycle
+    // is tied to the tx and cannot leak across pool checkouts. The
+    // earlier `driver.exec(pg_advisory_lock) … driver.exec(pg_advisory_unlock)`
+    // pair sent lock and unlock through `pool.query()`, which checks
+    // out a fresh connection per call — so the unlock no-oped on a
+    // different session while the original connection returned to the
+    // pool still holding the session-level lock. See #975.
+    return driver.tx(async (tx) => {
+      await tx.exec(`SELECT pg_advisory_xact_lock(${PG_ADVISORY_LOCK_KEY})`);
+      return fn();
+    });
   }
   // SQLite: the driver's internal mutex already serializes writes; in
   // practice multi-replica + SQLite is not a supported deployment.


### PR DESCRIPTION
Closes #975.

## Problem

`withMigrationLock` in [`packages/core/src/db/migrations/runner.ts`](https://github.com/Viren070/AIOStreams/blob/main/packages/core/src/db/migrations/runner.ts#L45-L64) acquires `pg_advisory_lock` and releases `pg_advisory_unlock` via `driver.exec`, which routes each call through `pool.query()` and therefore checks out a fresh pool connection per call. The lock and unlock land on different connections; the unlock silently no-ops (caught by the existing `catch {}`), while the original connection returns to the pool **still holding the session-level lock**.

The orphaned holder is then recycled by the pool for normal app queries, and:

- Its old `xmin` snapshot prevents autovacuum from reclaiming any dead tuples database-wide.
- Every subsequent replica boot queues behind the orphan, with no way out short of `pg_terminate_backend`.
- During rolling deploys, the queue piles up. If the queue time exceeds the readiness/startup probe deadline, new pods get SIGTERM'd mid-boot — and the shutdown path can hit other init-order assertions, turning a recoverable wait into a crashloop.

On write-heavy deployments (e.g. v2.30's per-request `UPDATE users SET accessed_at` path), the accumulated bloat fills the database volume within hours-to-days. We hit ENOSPC ~24h after upgrading a 3-replica instance to v2.30.

Repro / observability:

```sql
SELECT pid, granted, l.classid, l.objid, a.state, a.application_name,
       now() - a.backend_start AS conn_age, left(a.query, 80) AS last_query
FROM pg_locks l JOIN pg_stat_activity a USING (pid)
WHERE l.locktype='advisory' AND l.classid=1095323475 AND l.objid=1296648018;
```

We saw one `granted=t, state=idle` holder whose `last_query` was an unrelated `UPDATE users …` plus N waiters from other replicas/workers booting. `1095323475 / 1296648018` is `pg_locks`' representation of the 64-bit key `0x41494F534D494752` ("AIOSMIGR").

## Fix

Switch to `pg_advisory_xact_lock` inside `driver.tx()`. Postgres auto-releases the xact lock on `COMMIT`/`ROLLBACK` of the transaction's pinned connection, so its lifecycle is tied to the tx and cannot leak across pool checkouts — regardless of how `driver.exec`/`driver.tx` are implemented downstream.

```ts
return driver.tx(async (tx) => {
  await tx.exec(`SELECT pg_advisory_xact_lock(${PG_ADVISORY_LOCK_KEY})`);
  return fn();
});
```

Notes:

- The migration work inside `fn()` continues to use the outer driver (pool); only the lock acquisition is pinned. This preserves the existing semantics where each migration commits independently via its own `driver.tx()`.
- The lock is held for the entire migration cycle (same as before). On an already-migrated DB this is sub-second; on a first run it's bounded by migration time.
- Removed the `catch {}` around unlock — there's no unlock call anymore, so there's no longer a silent failure to swallow.

## Test plan

- [x] Verified clean apply against `v2.30.0` and `main` (identical hunks).
- [x] `pnpm run build` passes inside Docker `builder` stage.
- [ ] Manually verified on a v2.30 deployment that the lock auto-releases after migration:
  ```sql
  SELECT count(*) FROM pg_locks WHERE locktype='advisory'
   AND classid=1095323475 AND objid=1296648018;
  -- Should be 0 once the deployment finishes booting,
  -- and stays at 0 across subsequent pod restarts.
  ```
- [ ] Verified autovacuum runs continuously on `users`/`analytics_events` post-deploy.

The two unchecked items I'll do once I'm running this image in production myself — happy to report back here if useful, or let CI handle it.

## Alternatives considered

- **Pin a dedicated `PoolClient` for lock + work + unlock**: works, but adds a new method to `DbDriver` and threads it through the runner. More surface area for a smaller behavioral win.
- **Open a dedicated `pg.Client` outside the pool**: side-steps the API question but adds a separate connection lifecycle to reason about.

`pg_advisory_xact_lock` is the smallest, most self-contained change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced database migration handling for PostgreSQL with improved transaction-level locking to ensure better consistency and automatic lock management during migration execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->