### PR TITLE
fix(presets/stremthru-torz): bring back overriden stream parser

### DIFF
--- a/packages/core/src/presets/stremthruTorz.ts
+++ b/packages/core/src/presets/stremthruTorz.ts
@@ -10,9 +10,21 @@ import { baseOptions, Preset } from './preset.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import { StreamParser } from '../parser/index.js';
-import { StremThruPreset } from './stremthru.js';
+import { StremThruPreset, StremThruStreamParser } from './stremthru.js';
+
+class StremthruTorzStreamParser extends StremThruStreamParser {
+  protected override applyUrlModifications(
+    url: string | undefined
+  ): string | undefined {
+    return super.applyUrlModifications(url);
+  }
+}
 
 export class StremthruTorzPreset extends StremThruPreset {
+  static override getParser(): typeof StreamParser {
+    return StremthruTorzStreamParser;
+  }
+
   static override get METADATA() {
     const supportedResources = [constants.STREAM_RESOURCE];
 


### PR DESCRIPTION
was removed by mistake in 1a9892b

fixes things like private torrent and separate audio/subtitle language detection

untested YOLO 🙈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal stream parsing architecture with a dedicated parser implementation to enhance performance and code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->