### PR TITLE
fix: make RegexAccess/SelAccess cleanup safe to call before init

### DIFF
--- a/packages/core/src/utils/regex-access.ts
+++ b/packages/core/src/utils/regex-access.ts
@@ -81,10 +81,13 @@ export class RegexAccess {
   }
 
   /**
-   * Clean up resources.
+   * Clean up resources. Safe to call before `initialise()`: the `manager`
+   * getter would otherwise read from `config.userLimits.regex` and trip the
+   * settings-store guard if shutdown runs before `initialiseConfig()` has
+   * resolved (e.g. SIGTERM during startup).
    */
   public static cleanup(): void {
-    this.manager.cleanup();
+    if (this._instance) this._instance.cleanup();
   }
 
   /**

--- a/packages/core/src/utils/sel-access.ts
+++ b/packages/core/src/utils/sel-access.ts
@@ -67,10 +67,13 @@ export class SelAccess {
   }
 
   /**
-   * Clean up resources.
+   * Clean up resources. Safe to call before `initialise()`: the `manager`
+   * getter would otherwise read from `config.userLimits.sel` and trip the
+   * settings-store guard if shutdown runs before `initialiseConfig()` has
+   * resolved (e.g. SIGTERM during startup).
    */
   public static cleanup(): void {
-    this.manager.cleanup();
+    if (this._instance) this._instance.cleanup();
   }
 
   /**


### PR DESCRIPTION
## Problem

`RegexAccess.cleanup()` and `SelAccess.cleanup()` call `this.manager.cleanup()`, where `manager` is a getter that lazily constructs the `SyncManager` from `config.userLimits.regex` / `config.userLimits.sel`. If shutdown runs **before** `initialiseConfig()` resolves — for example a pod stuck on a slow startup path that gets SIGTERM'd by the kubelet — the getter trips the settings-store's `makeUninitialisedSectionProxy` guard:

```
Error: appConfig.userLimits.regex was read at module-load time,
before initialiseConfig() resolved. Move this read inside a function
or method so it observes the validated, possibly env/DB-overridden
value.
    at Object.get (.../config/settings-store.js:32)
    at get manager (.../utils/regex-access.js:31)
    at RegexAccess.cleanup (.../utils/regex-access.js:66)
    at shutdown (.../server/server.js:155)
    at async process.<anonymous> (.../server/server.js:161)
```

In our case the slow startup was a `pg_advisory_lock` queue (#975) — but anything that delays `initialiseConfig()` (DB connection lag, slow Redis, slow filesystem) past the kubelet's startup/readiness probe deadline will land in the same place. The shutdown handler then turns a recoverable "killed during startup" into an unhandled rejection, which on multi-replica deployments can crashloop pods that would otherwise just retry their boot.

## Fix

Skip cleanup when `_instance` was never created. Cleanup of a never-initialised singleton is a no-op by definition; reading config to *construct* the singleton purely so we can clean it up is wrong:

```ts
public static cleanup(): void {
- this.manager.cleanup();
+ if (this._instance) this._instance.cleanup();
}
```

Applied to both `RegexAccess` and `SelAccess` (same shape).

## Test plan

- [x] Type-check: trivial — `this._instance` is the existing typed private static; only the call site changes.
- [ ] Observed in production: a v2.30 deployment under the #975 lock-pile pattern had pods SIGTERM'd while waiting on `pg_advisory_lock`, hitting this exact stack and converting "would have retried" into "process crashed mid-shutdown."

## Notes

- Independent of #975 — that PR fixes the *cause* of the slow startup; this PR makes shutdown survive *any* slow startup that gets cut short.
- The remaining `shutdown()` calls (`TaskManager.stopAll`, `stopAnalytics().catch`, `Cache.close`, `closeDb`) may have similar fragility but weren't observed crashing in our incident. Happy to extend the same guard pattern to those if you'd like, or leave them for a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup operation reliability by enabling safe execution before component initialisation is complete, preventing potential errors during application shutdown sequencing and enhancing overall lifecycle stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->