### PR TITLE
feat: add a way to hardcode stream.type = "usenet" and service.id = N…

### DIFF
--- a/packages/core/src/presets/custom.ts
+++ b/packages/core/src/presets/custom.ts
@@ -2,8 +2,12 @@ import { Addon, Option, UserData } from '../db/index.js';
 import { Preset, baseOptions } from './preset.js';
 import { appConfig, RESOURCES } from '../utils/index.js';
 import { constants } from '../utils/index.js';
+import { StreamParser } from '../parser/index.js';
 
 export class CustomPreset extends Preset {
+  static override getParser(): typeof StreamParser {
+    return CustomStreamParser;
+  }
   static override get METADATA() {
     const options: Option[] = [
       {
@@ -103,6 +107,16 @@ export class CustomPreset extends Preset {
         type: 'boolean',
       },
       {
+        id: 'forceUsenet',
+        name: 'Force Usenet stream/service',
+        description:
+          'When enabled, sets stream.type to "usenet" and service.id to NZBDAV_SERVICE for all streams from this addon.',
+        type: 'boolean',
+        required: false,
+        default: false,
+        showInSimpleMode: false,
+      },
+      {
         id: 'resultPassthrough',
         name: 'Result Passthrough',
         description:
@@ -175,5 +189,30 @@ export class CustomPreset extends Preset {
         'User-Agent': this.METADATA.USER_AGENT,
       },
     };
+  }
+}
+
+class CustomStreamParser extends StreamParser {
+  protected getService(
+    stream: any,
+    currentParsedStream: any
+  ): any | undefined {
+    const force = (this.addon?.preset as any)?.options?.forceUsenet;
+    if (force) {
+      return { id: constants.NZBDAV_SERVICE, cached: true };
+    }
+    return super.getService(stream, currentParsedStream);
+  }
+
+  protected getStreamType(
+    stream: any,
+    service: any,
+    currentParsedStream: any
+  ): any {
+    const force = (this.addon?.preset as any)?.options?.forceUsenet;
+    if (force) {
+      return constants.USENET_STREAM_TYPE;
+    }
+    return super.getStreamType(stream, service, currentParsedStream);
   }
 }


### PR DESCRIPTION
…ZBDAV_SERVICE as an option in Custom.ts

Particularly made for qooode/nzbdavex to leverage some features from Usenet-Streamer addon:

1.  Prevent confusion when installing davex
2. Ensure that features arent lost from have Usenet hardcoded, such as filtering with Tams and have the appropriate tags during search
3. Will be temporary until a more feature specific plugin is made for davex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Force Usenet stream/service" option to custom presets configuration. When enabled, forces Usenet streaming for the preset. Defaults to disabled and only visible in advanced settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Viren070/AIOStreams/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->