### PR TITLE
feat: Infuse mode — external-player subtitles for Apple TV

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -776,6 +776,22 @@ export const UserDataSchema = z.object({
       singleStream: z.boolean().optional(),
     })
     .optional(),
+  /**
+   * Infuse mode (Stremio + Infuse on Apple TV). When enabled, playable streams
+   * are rewritten into `infuse://` external-launch URLs with a subtitle baked
+   * in (Infuse never requests subtitles itself). Language comes from
+   * `preferredSubtitles` (default English); provider priority follows the
+   * configured subtitle-addon order.
+   */
+  infuse: z
+    .object({
+      enabled: z.boolean().optional(),
+      /** Streams (from the top) to resolve a per-file, filename-matched subtitle for. The rest reuse an id-based lookup. */
+      topN: z.number().min(0).max(50).optional(),
+      /** Subtitle candidates baked per stream; the proxy serves the first that fetches (silent fallback). */
+      candidates: z.number().min(1).max(5).optional(),
+    })
+    .optional(),
   services: ServiceList.optional(),
   presets: PresetList,
   addonCategoryColors: z.record(z.string(), z.string()).optional(), // maps custom category name → colour key

--- a/packages/core/src/main/infuse.test.ts
+++ b/packages/core/src/main/infuse.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  infuseTargetLanguages,
+  selectInfuseSubtitles,
+  infuseSubProxyUrl,
+  infuseSubtitleIsoCode,
+  buildInfusePlayUrl,
+} from './infuse.js';
+import type { Subtitle } from '../db/schemas.js';
+
+const sub = (id: string, url: string, lang: string): Subtitle => ({
+  id,
+  url,
+  lang,
+});
+
+describe('infuseTargetLanguages', () => {
+  it('defaults to English when none are set', () => {
+    expect(infuseTargetLanguages(undefined)).toEqual(['English']);
+    expect(infuseTargetLanguages([])).toEqual(['English']);
+  });
+
+  it('normalises codes/names and preserves priority order', () => {
+    expect(infuseTargetLanguages(['ar'])).toEqual(['Arabic']);
+    expect(infuseTargetLanguages(['Arabic', 'en'])).toEqual([
+      'Arabic',
+      'English',
+    ]);
+  });
+
+  it('drops unrecognised values, falling back to English if all drop', () => {
+    expect(infuseTargetLanguages(['not-a-language'])).toEqual(['English']);
+  });
+});
+
+describe('selectInfuseSubtitles', () => {
+  const subs = [
+    sub('1', 'https://x/en1.srt', 'English'),
+    sub('2', 'https://x/ar1.srt', 'Arabic'),
+    sub('3', 'https://x/ar2.srt', 'Arabic'),
+    sub('4', 'https://x/en1.srt', 'English'), // dup URL of #1
+  ];
+
+  it('picks by target-language priority, deduped by URL, capped by limit', () => {
+    const picked = selectInfuseSubtitles(subs, ['Arabic', 'English'], 3);
+    expect(picked.map((s) => s.url)).toEqual([
+      'https://x/ar1.srt',
+      'https://x/ar2.srt',
+      'https://x/en1.srt',
+    ]);
+  });
+
+  it('respects the limit', () => {
+    expect(selectInfuseSubtitles(subs, ['Arabic'], 1).map((s) => s.url)).toEqual(
+      ['https://x/ar1.srt']
+    );
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(selectInfuseSubtitles(subs, ['French'], 3)).toEqual([]);
+  });
+});
+
+describe('infuseSubtitleIsoCode', () => {
+  it('maps a subtitle language to a lowercase ISO 639-1 code', () => {
+    expect(infuseSubtitleIsoCode(sub('1', 'u', 'English'))).toBe('en');
+    expect(infuseSubtitleIsoCode(sub('1', 'u', 'Arabic'))).toBe('ar');
+  });
+  it('falls back to und for unknown/empty', () => {
+    expect(infuseSubtitleIsoCode(undefined)).toBe('und');
+    expect(infuseSubtitleIsoCode(sub('1', 'u', 'gibberish'))).toBe('und');
+  });
+});
+
+describe('infuseSubProxyUrl', () => {
+  it('ends in Subtitle-<iso>.srt and encodes candidates in the path', () => {
+    const url = infuseSubProxyUrl(
+      'https://addon.example.com/',
+      ['https://p/a.srt', 'https://p/b.srt'],
+      'ar',
+      'Movie.2024.mkv'
+    );
+    expect(url).toMatch(
+      /^https:\/\/addon\.example\.com\/infuse-sub\/[A-Za-z0-9_-]+\/Subtitle-ar\.srt\?t=/
+    );
+    // trailing slash on baseUrl is normalised (no double slash)
+    expect(url).not.toContain('.com//infuse-sub');
+    const payload = url.match(/\/infuse-sub\/([A-Za-z0-9_-]+)\//)![1];
+    const decoded = JSON.parse(
+      Buffer.from(payload, 'base64url').toString('utf-8')
+    );
+    expect(decoded).toEqual(['https://p/a.srt', 'https://p/b.srt']);
+  });
+
+  it('omits the ?t= query when no filename is given', () => {
+    const url = infuseSubProxyUrl('https://a.co', ['https://p/a.srt'], 'en');
+    expect(url.endsWith('Subtitle-en.srt')).toBe(true);
+  });
+});
+
+describe('buildInfusePlayUrl', () => {
+  const base = 'https://addon.example.com';
+
+  it('builds an infuse:// play URL with media, proxied sub, and filename', () => {
+    const link = buildInfusePlayUrl(
+      base,
+      'https://debrid/video.mkv',
+      [sub('1', 'https://p/ar.srt', 'Arabic')],
+      'Movie.2024.mkv'
+    );
+    expect(link.startsWith('infuse://x-callback-url/play?url=')).toBe(true);
+    expect(link).toContain(encodeURIComponent('https://debrid/video.mkv'));
+    expect(link).toContain('&sub=');
+    expect(link).toContain('&filename=Movie.2024.mkv');
+    // the sub points at our proxy, labelled Arabic
+    const subParam = new URL(
+      decodeURIComponent(link.split('&sub=')[1].split('&')[0])
+    );
+    expect(subParam.pathname.endsWith('Subtitle-ar.srt')).toBe(true);
+  });
+
+  it('omits sub= when there are no subtitles', () => {
+    const link = buildInfusePlayUrl(base, 'https://debrid/v.mkv', []);
+    expect(link).not.toContain('&sub=');
+    expect(link.startsWith('infuse://x-callback-url/play?url=')).toBe(true);
+  });
+});

--- a/packages/core/src/main/infuse.ts
+++ b/packages/core/src/main/infuse.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers for "Infuse mode" — building the `infuse://` launch URL and the
+ * subtitle-proxy path, and resolving target subtitle languages. Kept free of
+ * I/O and global config (callers pass `baseUrl`) so they are easily unit
+ * tested. The orchestration (querying subtitle addons, rewriting streams) lives
+ * in `resources.ts`; the proxy endpoint lives in the server's `app.ts`.
+ */
+import { normaliseLanguage, languageToCode } from '../utils/languages.js';
+import type { Subtitle } from '../db/schemas.js';
+
+export const INFUSE_DEFAULT_TOP_N = 5;
+export const INFUSE_DEFAULT_CANDIDATES = 3;
+export const INFUSE_DEFAULT_LANGUAGE = 'English';
+
+/**
+ * Resolve the ordered list of target subtitle languages (canonical display
+ * names) from a user's `preferredSubtitles`, falling back to English when none
+ * are set/recognised.
+ */
+export function infuseTargetLanguages(
+  preferredSubtitles: readonly string[] | undefined
+): string[] {
+  const prefs = (preferredSubtitles ?? [])
+    .map((l) => normaliseLanguage(l))
+    .filter((l): l is string => !!l);
+  return prefs.length > 0 ? prefs : [INFUSE_DEFAULT_LANGUAGE];
+}
+
+/**
+ * From a flat list of subtitles, pick those matching the target languages in
+ * target-priority order, deduped by URL, capped at `limit`. Ordered so the
+ * subtitle proxy can fall back to the next candidate if an earlier one is dead.
+ */
+export function selectInfuseSubtitles(
+  subtitles: Subtitle[],
+  targets: string[],
+  limit: number
+): Subtitle[] {
+  const out: Subtitle[] = [];
+  const seen = new Set<string>();
+  for (const target of targets) {
+    for (const s of subtitles) {
+      if (s.url && !seen.has(s.url) && normaliseLanguage(s.lang) === target) {
+        seen.add(s.url);
+        out.push(s);
+        if (out.length >= limit) return out;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build this addon's subtitle-proxy URL. The path ends in `Subtitle-<iso>.srt`
+ * so Infuse recognises it as a subtitle (by extension) and labels the track by
+ * language. Candidate upstream URLs are base64url(JSON)-encoded in the path; the
+ * media filename rides in `?t=` purely for server-side logging.
+ */
+export function infuseSubProxyUrl(
+  baseUrl: string,
+  subUrls: string[],
+  isoCode: string,
+  mediaFilename?: string
+): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  const payload = Buffer.from(JSON.stringify(subUrls), 'utf-8').toString(
+    'base64url'
+  );
+  let url = `${base}/infuse-sub/${payload}/Subtitle-${isoCode}.srt`;
+  if (mediaFilename) {
+    url += `?t=${encodeURIComponent(mediaFilename.slice(0, 160))}`;
+  }
+  return url;
+}
+
+/** ISO 639-1 code (lowercase) for a subtitle's language, or `und` if unknown. */
+export function infuseSubtitleIsoCode(sub: Subtitle | undefined): string {
+  const lang = sub && normaliseLanguage(sub.lang);
+  return (lang && languageToCode(lang)?.toLowerCase()) || 'und';
+}
+
+/**
+ * Build the full `infuse://x-callback-url/play` launch URL for one media URL,
+ * with the chosen subtitle candidates wrapped in the proxy (if any).
+ */
+export function buildInfusePlayUrl(
+  baseUrl: string,
+  mediaUrl: string,
+  subs: Subtitle[],
+  mediaFilename?: string
+): string {
+  let link = `infuse://x-callback-url/play?url=${encodeURIComponent(mediaUrl)}`;
+  if (subs.length > 0) {
+    const proxied = infuseSubProxyUrl(
+      baseUrl,
+      subs.map((s) => s.url),
+      infuseSubtitleIsoCode(subs[0]),
+      mediaFilename
+    );
+    link += `&sub=${encodeURIComponent(proxied)}`;
+  }
+  if (mediaFilename) link += `&filename=${encodeURIComponent(mediaFilename)}`;
+  return link;
+}

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -8,6 +8,13 @@ import {
 } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import { getAddonName } from '../utils/general.js';
+import {
+  INFUSE_DEFAULT_TOP_N,
+  INFUSE_DEFAULT_CANDIDATES,
+  infuseTargetLanguages,
+  selectInfuseSubtitles,
+  buildInfusePlayUrl,
+} from './infuse.js';
 import { Wrapper } from './wrapper.js';
 import { PresetManager } from '../presets/index.js';
 import { FeatureControl } from '../utils/feature.js';
@@ -592,6 +599,146 @@ function emitAddonContributions(args: {
   }
 }
 
+// --- Infuse mode -------------------------------------------------------------
+// When a user enables it, each playable stream is rewritten into a direct
+// `infuse://` external-launch URL with one subtitle baked into `sub=`, so
+// playback happens in Infuse on Apple TV (which never requests subtitles
+// itself). Subtitles are resolved per-file for the top N streams and id-based
+// for the rest; the chosen upstream is served through a `.srt` proxy (see the
+// server's app.ts) that gives Infuse a language-labelled file. Stremio-only:
+// other clients (Fusion/Omni) build the Infuse launch themselves and ignore
+// this scheme.
+
+const INFUSE_PLAYABLE_TYPES = new Set<string>([
+  constants.HTTP_STREAM_TYPE,
+  constants.DEBRID_STREAM_TYPE,
+  constants.USENET_STREAM_TYPE,
+]);
+
+/**
+ * Query subtitle addons (in the user's configured order) and collect up to
+ * `limit` subtitles matching the target languages, deduped by URL. The ordered
+ * list lets the subtitle proxy fall back to the next candidate if an earlier
+ * one fails to fetch. Selection/dedup/labelling logic lives in `./infuse.ts`.
+ */
+async function collectInfuseSubtitles(
+  subtitleAddons: Addon[],
+  type: string,
+  id: string,
+  targets: string[],
+  limit: number,
+  filename?: string
+): Promise<Subtitle[]> {
+  const extras = filename
+    ? `filename=${encodeURIComponent(filename)}`
+    : undefined;
+  const out: Subtitle[] = [];
+  const seen = new Set<string>();
+  for (const addon of subtitleAddons) {
+    if (out.length >= limit) break;
+    let subs: Subtitle[] = [];
+    try {
+      subs = (await new Wrapper(addon).getSubtitles(type, id, extras)) ?? [];
+    } catch (error) {
+      logger.debug(
+        {
+          addon: getAddonName(addon),
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'infuse: subtitle addon failed'
+      );
+      continue;
+    }
+    for (const s of selectInfuseSubtitles(subs, targets, limit)) {
+      if (!seen.has(s.url)) {
+        seen.add(s.url);
+        out.push(s);
+        if (out.length >= limit) break;
+      }
+    }
+  }
+  return out;
+}
+
+async function applyInfuseTransform(
+  ctx: AIOStreamsContext,
+  type: string,
+  id: string,
+  streams: ParsedStream[]
+): Promise<void> {
+  const cfg = ctx.userData.infuse;
+  if (!cfg?.enabled) return;
+  const topN = cfg.topN ?? INFUSE_DEFAULT_TOP_N;
+  const limit = Math.max(1, cfg.candidates ?? INFUSE_DEFAULT_CANDIDATES);
+
+  // Target languages: the user's preferred subtitles (normalised, in order),
+  // falling back to English when none are set.
+  const targets = infuseTargetLanguages(ctx.userData.preferredSubtitles);
+
+  const playable = streams.filter(
+    (s) => s.url && INFUSE_PLAYABLE_TYPES.has(s.type)
+  );
+  if (playable.length === 0) return;
+
+  // Subtitle addons in the user's configured order (= provider priority).
+  const subtitleAddons = getAddonsForResource(ctx, 'subtitles', type, id);
+  if (subtitleAddons.length === 0) {
+    logger.warn(
+      'infuse: no subtitle addons configured; launching in Infuse without a subtitle'
+    );
+  }
+
+  // id-based candidates: resolved once, reused for streams beyond the top N.
+  const fallbackSubs = await collectInfuseSubtitles(
+    subtitleAddons,
+    type,
+    id,
+    targets,
+    limit
+  );
+
+  // per-file (filename-matched) candidates for the top N playable streams.
+  const subsByStreamId = new Map<string, Subtitle[]>();
+  const top = playable.slice(0, Math.max(0, topN));
+  await Promise.all(
+    top.map(async (s) => {
+      const perFile = await collectInfuseSubtitles(
+        subtitleAddons,
+        type,
+        id,
+        targets,
+        limit,
+        s.filename
+      );
+      subsByStreamId.set(s.id, perFile.length > 0 ? perFile : fallbackSubs);
+    })
+  );
+
+  for (const s of playable) {
+    const subs = subsByStreamId.get(s.id) ?? fallbackSubs;
+    const filename = s.filename || undefined;
+    s.externalUrl = buildInfusePlayUrl(
+      appConfig.bootstrap.baseUrl,
+      s.url!,
+      subs,
+      filename
+    );
+    // Stremio's transformer only emits externalUrl when type === 'external'.
+    // Keep s.url intact so background preload pinging still resolves the cache.
+    s.type = constants.EXTERNAL_STREAM_TYPE;
+  }
+
+  logger.info(
+    {
+      rewritten: playable.length,
+      perFileResolved: top.length,
+      languages: targets,
+      fallbackCandidates: fallbackSubs.length,
+    },
+    'infuse: rewrote playable streams to infuse:// launch URLs'
+  );
+}
+
 export async function getStreams(
   ctx: AIOStreamsContext,
   id: string,
@@ -838,6 +985,28 @@ export async function getStreams(
       formatterId: ctx.userData.formatter?.id ?? null,
       presetTypes,
     });
+  }
+
+  // Infuse mode: rewrite playable streams into infuse:// launch URLs with a
+  // subtitle baked in. Done last (after stats/preload selection) so it disturbs
+  // nothing upstream, and skipped during precaching.
+  if (
+    ctx.userData.infuse?.enabled &&
+    !preCaching &&
+    (type === 'movie' || type === 'series')
+  ) {
+    try {
+      await applyInfuseTransform(ctx, type, id, finalStreams);
+    } catch (error) {
+      logger.error(
+        {
+          error: error instanceof Error ? error.message : String(error),
+          type,
+          id,
+        },
+        'infuse: transform failed; returning streams unchanged'
+      );
+    }
   }
 
   logger.debug(

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -217,6 +217,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
 
   autoPlay: { label: 'Auto Play', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback' },
   areYouStillThere: { label: 'Are You Still There?', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback' },
+  infuse: { label: 'Infuse (External Player)', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'playback' },
   statistics: { label: 'Statistics', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'display' },
   hideErrors: { label: 'Hide Errors', group: 'misc', type: 'scalar', menu: 'miscellaneous', subTab: 'display' },
   hideErrorsForResources: { label: 'Hide Errors for Resources', group: 'misc', type: 'list', menu: 'miscellaneous', subTab: 'display', sectionId: 'hideErrors' },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/docs/content/docs/guides/infuse.mdx
+++ b/packages/docs/content/docs/guides/infuse.mdx
@@ -1,0 +1,57 @@
+---
+title: Infuse (External Player Subtitles)
+description: Play debrid streams in Infuse on Apple TV with subtitles auto-loaded — a fork addition.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## What it does
+
+[Infuse](https://firecore.com/infuse) is a popular external player on Apple TV. When you hand a stream off to Infuse, it plays **embedded** subtitle tracks fine (mostly English) — but it **never asks the addon for subtitles** the way Stremio's built-in player does. So for languages that aren't embedded (e.g. Arabic), you'd normally download a subtitle manually every time.
+
+**Infuse mode** fixes that. When enabled, AIOStreams rewrites each playable stream into a direct Infuse launch URL with a subtitle already baked in:
+
+```
+infuse://x-callback-url/play?url=<stream>&sub=<subtitle>&filename=<name>
+```
+
+Clicking the stream in Stremio opens Infuse with the debrid stream **and** the subtitle already loaded.
+
+<Callout type="warn">
+  This works in the **Stremio** app only. Stremio opens the addon-provided URL
+  exactly as given. Other Apple TV clients (Fusion, Omni, …) build the Infuse
+  launch themselves from the media URL and ignore both the baked scheme and the
+  stream's subtitles, so the subtitle cannot be injected there.
+</Callout>
+
+## How subtitles are chosen
+
+- **Language** comes from your **Preferred Subtitles** (Filtering menu). The highest-priority language with an available subtitle wins; if you've set none, it defaults to **English**.
+- **Provider priority** follows your configured **subtitle addon order** — put the provider you trust first.
+- **Filename matching**: the top *N* streams get a filename-matched (release-synced) lookup so the subtitle matches the exact rip; the rest reuse a faster id-based lookup.
+- **One subtitle per video**: Infuse's URL scheme supports a single external subtitle per video. AIOStreams bakes in a few *candidates* — the first that actually loads is used, the rest are silent fallbacks if it's dead.
+
+The subtitle is served through a small built-in proxy at `/infuse-sub/...Subtitle-<lang>.srt` so Infuse recognises it (by extension), labels the track by language, and fetches it from a host/cert it already trusts.
+
+## Enabling it
+
+In the configure UI: **Miscellaneous → Playback → Infuse (External Player)**. This section lives under **Advanced** mode — if you don't see it, switch the mode toggle at the top of the configure page from Basic to Advanced.
+
+- **Enable** — turn it on (off by default).
+- **Filename-matched streams (top N)** — how many top streams get release-matched subtitles (default 5; set 0 for id-based only).
+- **Subtitle candidates** — how many subtitles to bake per stream as fallbacks (default 3).
+
+Set your language(s) under **Filtering → Preferred Subtitles**, and order your subtitle addons so your preferred provider is first.
+
+<Callout type="info">
+  The subtitle and stream URLs are served by your AIOStreams instance, so the
+  device running Infuse must be able to reach your instance's `BASE_URL`. On a
+  LAN-only deployment that means same-network playback; for remote playback the
+  instance must be reachable (and `BASE_URL` correct) from the device.
+</Callout>
+
+## Notes & limitations
+
+- **Stremio + Apple TV (Infuse) only** — see the warning above.
+- **Torrent (`p2p`) streams** are skipped (no playable URL); only resolved http/debrid/usenet streams are rewritten.
+- Once playback hands off to Infuse, Stremio loses resume/scrobble for that play (Infuse tracks its own).

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "groups",
     "usenet",
+    "infuse",
     "scored-sorting",
     "seanime",
     "development"

--- a/packages/frontend/src/components/menu/miscellaneous/_components/playback-behavior.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous/_components/playback-behavior.tsx
@@ -167,6 +167,93 @@ export function PlaybackBehavior() {
           />
         </div>
       </SettingsCard>
+
+      <SettingsCard
+        title="Infuse (External Player)"
+        id="infuse"
+        description={
+          <div className="space-y-2">
+            <p>
+              Rewrites playable streams into <code>infuse://</code> launch links
+              with a subtitle baked in, so playback opens in Infuse with subs
+              already loaded (Infuse never requests subtitles itself).
+            </p>
+            <Alert intent="info-basic">
+              <p className="text-sm">
+                <strong>Subtitle language</strong> comes from{' '}
+                <strong>Filters › Subtitles › Preferred Subtitles</strong>{' '}
+                (defaults to English if none set). If you list several, they are
+                tried in priority order. The highest-priority language that has
+                an available subtitle is used. Infuse plays{' '}
+                <strong>one subtitle per video</strong>, so additional languages
+                act as fallbacks, not separate selectable tracks.{' '}
+                <strong>Provider priority</strong> follows your subtitle addon
+                order (put your preferred provider first).
+              </p>
+            </Alert>
+            <Alert intent="warning-basic">
+              <p className="text-sm">
+                <strong>Stremio app only.</strong> Other Apple TV clients (Fusion,
+                Omni, …) build the Infuse launch themselves and ignore the baked
+                subtitle, so it won&apos;t work there.
+              </p>
+            </Alert>
+          </div>
+        }
+      >
+        <Switch
+          label="Enable"
+          side="right"
+          value={userData.infuse?.enabled ?? false}
+          onValueChange={(value) => {
+            setUserData((prev) => ({
+              ...prev,
+              infuse: {
+                ...prev.infuse,
+                enabled: value,
+              },
+            }));
+          }}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <NumberInput
+            label="Filename-matched streams (top N)"
+            help="The top N streams get a filename-matched (in-sync) subtitle lookup. The rest reuse a faster id-based lookup. Set 0 to use id-based only."
+            min={0}
+            max={50}
+            defaultValue={5}
+            disabled={!userData.infuse?.enabled}
+            value={userData.infuse?.topN ?? 5}
+            onValueChange={(value) => {
+              setUserData((prev) => ({
+                ...prev,
+                infuse: {
+                  ...prev.infuse,
+                  topN: Math.min(50, Math.max(0, Number(value ?? 5))),
+                },
+              }));
+            }}
+          />
+          <NumberInput
+            label="Subtitle candidates"
+            help="How many subtitles to bake in per stream. The first that loads is used; the rest are silent fallbacks if it's dead."
+            min={1}
+            max={5}
+            defaultValue={3}
+            disabled={!userData.infuse?.enabled}
+            value={userData.infuse?.candidates ?? 3}
+            onValueChange={(value) => {
+              setUserData((prev) => ({
+                ...prev,
+                infuse: {
+                  ...prev.infuse,
+                  candidates: Math.min(5, Math.max(1, Number(value ?? 3))),
+                },
+              }));
+            }}
+          />
+        </div>
+      </SettingsCard>
     </>
   );
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -260,6 +260,89 @@ app.get('/static/*any', corsMiddleware, (req, res, next) => {
   next();
 });
 
+// Infuse-mode subtitle proxy. Serves an upstream provider subtitle from this
+// addon's own host/cert (reachable by the Apple TV), normalising the
+// content-type. Path: /infuse-sub/<payload>/<name>-<lang>.srt
+//   - payload: base64url(JSON array of candidate upstream URLs, priority order)
+//   - the trailing <name>-<lang>.srt is read by Infuse to label the track and
+//     needs the .srt extension; the server only uses <payload>.
+// Serves the FIRST candidate that fetches OK (transparent fallback). Public +
+// CORS so Infuse can fetch it.
+app.get(
+  /^\/infuse-sub\/([A-Za-z0-9_-]+)\/[^/]+\.srt$/,
+  corsMiddleware,
+  async (req, res) => {
+    try {
+      const encoded = (req.params as unknown as string[])[0];
+      const decoded = Buffer.from(encoded, 'base64url').toString('utf-8');
+      let candidates: string[];
+      try {
+        const parsed = JSON.parse(decoded);
+        candidates = Array.isArray(parsed) ? parsed : [String(parsed)];
+      } catch {
+        candidates = [decoded]; // tolerate a plain (non-JSON) URL
+      }
+      candidates = candidates.filter((u) => /^https?:\/\//i.test(u));
+      if (candidates.length === 0) {
+        res.status(400).send('no valid subtitle url');
+        return;
+      }
+      const title = typeof req.query.t === 'string' ? req.query.t : undefined;
+      const SUB_TIMEOUT_MS = 10_000;
+      const SUB_MAX_BYTES = 5_000_000; // subtitles are tiny; guard against huge/hanging upstreams
+      for (let i = 0; i < candidates.length; i++) {
+        const upstream = candidates[i];
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), SUB_TIMEOUT_MS);
+        try {
+          const upstreamRes = await fetch(upstream, {
+            redirect: 'follow',
+            signal: controller.signal,
+          });
+          if (upstreamRes.ok) {
+            const declared = Number(
+              upstreamRes.headers.get('content-length') || 0
+            );
+            if (declared > SUB_MAX_BYTES) {
+              logger.warn(
+                `infuse-sub: subtitle too large (${declared} bytes) for ${upstream}`
+              );
+              continue;
+            }
+            const buf = Buffer.from(await upstreamRes.arrayBuffer());
+            if (buf.length > SUB_MAX_BYTES) {
+              logger.warn(
+                `infuse-sub: subtitle too large (${buf.length} bytes) for ${upstream}`
+              );
+              continue;
+            }
+            res.setHeader('Content-Type', 'application/x-subrip; charset=utf-8');
+            res.setHeader('Cache-Control', 'public, max-age=86400');
+            res.send(buf);
+            logger.info(
+              `infuse-sub served: movie=${title ?? 'unknown'} | candidate ${i + 1}/${candidates.length} | url=${upstream}`
+            );
+            return;
+          }
+          logger.warn(`infuse-sub: ${upstreamRes.status} for ${upstream}`);
+        } catch (e) {
+          logger.warn(
+            `infuse-sub: fetch failed for ${upstream}: ${e instanceof Error ? e.message : String(e)}`
+          );
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      }
+      res.status(502).send('all subtitle candidates failed');
+    } catch (error) {
+      logger.error(
+        `infuse-sub error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      res.status(500).send('subtitle proxy error');
+    }
+  }
+);
+
 // legacy route handlers
 app.get(
   '{/:config}/stream/:type/:id.json',


### PR DESCRIPTION
## What & why
When playing via **Infuse** on Apple TV, Infuse plays embedded (mostly English) subtitle tracks but **never requests subtitles** the way Stremio's built-in player does — so non-embedded languages mean manual downloads every time. This adds an opt-in way to resolve a subtitle up front and bake it into the Infuse launch link.

## How it works
- **Per-user, opt-in** (`UserData.infuse { enabled, topN, candidates }`), **off by default → no behaviour change** unless enabled.
- Rewrites playable (http/debrid/usenet) streams into `infuse://x-callback-url/play?url=…&sub=…&filename=…`.
- Subtitle **language reuses the user's Preferred Subtitles** (defaults to English; multiple tried in priority order); **provider priority** follows the user's subtitle-addon order — no new hardcoded provider/language.
- A small `.srt` **subtitle proxy** serves the chosen upstream with the right extension/content-type + language-labelled filename so Infuse recognises/labels the track; N candidates give silent fallback.
- Pure helpers in `packages/core/src/main/infuse.ts` with **unit tests**; SPA control under **Miscellaneous → Playback**; docs guide added.

## Scope / safety
Default off; movie/series only; skipped during precaching; keeps `stream.url` so preload still works. **Stremio app only** (Fusion/Omni build the Infuse launch themselves — documented). One subtitle per video (Infuse scheme limit).

## Testing
Unit tests + full build (tsc + rsbuild) green; validated end-to-end on Apple TV.

Happy to adjust the config approach (per-user vs env/instance), commit layout, or test placement to match project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infuse (External Player) integration: launch streams in Infuse with automatically selected, deduplicated subtitles and optional filename inclusion.
  * New Infuse settings: enable/disable Infuse, configure filename-matched stream limit (0–50) and subtitle candidates (1–5).

* **Behaviour**
  * Streams are rewritten to Infuse launch URLs when enabled; only top-N streams resolve per-file subtitles, others reuse fallback candidates.

* **Documentation**
  * New guide describing setup, selection rules and platform limitations.

* **Infrastructure**
  * Internal subtitle proxy serves selected subtitle files via a stable URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->