### PR TITLE
feat(poster/openposterdb): support custom query parameters

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -691,6 +691,10 @@ export const UserDataSchema = z.object({
     (v) => (v === '' ? undefined : v),
     z.string().url().optional()
   ),
+  openposterdbParameters: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z.string().optional()
+  ),
   posterService: z
     .enum(['rpdb', 'top-poster', 'aioratings', 'openposterdb', 'none'])
     .optional(),

--- a/packages/core/src/poster/index.ts
+++ b/packages/core/src/poster/index.ts
@@ -60,7 +60,8 @@ export function createPosterService(
       return userData.openposterdbApiKey
         ? new OpenPosterDB(
             userData.openposterdbApiKey,
-            userData.openposterdbUrl
+            userData.openposterdbUrl,
+            userData.openposterdbParameters
           )
         : null;
     default:
@@ -85,7 +86,7 @@ export function createPosterServiceFromParams(
     case 'aioratings':
       return new AIOratings(apiKey, params.profileId || 'default');
     case 'openposterdb':
-      return new OpenPosterDB(apiKey, params.baseUrl);
+      return new OpenPosterDB(apiKey, params.baseUrl, params.parameters);
     default:
       return null;
   }

--- a/packages/core/src/poster/openposterdb.ts
+++ b/packages/core/src/poster/openposterdb.ts
@@ -10,9 +10,21 @@ export class OpenPosterDB extends BasePosterService {
   readonly ownDomains: string[];
   readonly redirectPathSegment = 'openposterdb';
   private readonly baseUrl: string;
+  /**
+   * Raw query string (without the leading `?`) appended to every poster URL,
+   * e.g. `ratings_limit=2&badge_size=l&position=br`. Lets users customise the
+   * generated poster via OpenPosterDB's query parameters. Empty when unset.
+   */
+  private readonly customParameters: string;
 
-  constructor(apiKey: string, baseUrl?: string) {
+  constructor(apiKey: string, baseUrl?: string, customParameters?: string) {
     super(apiKey, 'openposterdb');
+    // Tolerate a pasted leading `?`/`&` and surrounding whitespace, and drop any
+    // `#fragment` (which is never part of the query the server receives anyway).
+    this.customParameters = (customParameters || '')
+      .trim()
+      .replace(/#.*$/s, '')
+      .replace(/^[?&]+/, '');
     const raw = (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
     try {
       const parsed = new URL(raw);
@@ -63,16 +75,23 @@ export class OpenPosterDB extends BasePosterService {
   }
 
   protected getCacheKey(type: string, id: string): string {
-    return `${type}-${id}-${this.apiKey}-${this.baseUrl}`;
+    const base = `${type}-${id}-${this.apiKey}-${this.baseUrl}`;
+    return this.customParameters ? `${base}-${this.customParameters}` : base;
   }
 
   protected buildPosterUrl(idType: string, idValue: string): string {
-    return `${this.baseUrl}/${this.apiKey}/${idType}/poster-default/${idValue}.jpg`;
+    // The `.jpg` suffix is optional on current OpenPosterDB instances; omit it
+    // so the customisation query string can be appended cleanly.
+    const url = `${this.baseUrl}/${this.apiKey}/${idType}/poster-default/${idValue}`;
+    return this.customParameters ? `${url}?${this.customParameters}` : url;
   }
 
   protected appendRedirectParams(url: URL): void {
     if (this.baseUrl !== DEFAULT_BASE_URL) {
       url.searchParams.set('baseUrl', this.baseUrl);
+    }
+    if (this.customParameters) {
+      url.searchParams.set('parameters', this.customParameters);
     }
   }
 
@@ -82,6 +101,9 @@ export class OpenPosterDB extends BasePosterService {
     const params: Record<string, string> = {};
     if (query.baseUrl) {
       params.baseUrl = query.baseUrl;
+    }
+    if (query.parameters) {
+      params.parameters = query.parameters;
     }
     return params;
   }

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -1345,7 +1345,7 @@ const PROXY_FIELDS: (keyof UserData)[] = [
 const METADATA_FIELDS: (keyof UserData)[] = [
   'tmdbApiKey', 'tmdbAccessToken', 'tvdbApiKey',
   'rpdbApiKey', 'topPosterApiKey', 'aioratingsApiKey', 'aioratingsProfileId',
-  'openposterdbApiKey', 'openposterdbUrl', 'posterService',
+  'openposterdbApiKey', 'openposterdbUrl', 'openposterdbParameters', 'posterService',
   'usePosterRedirectApi', 'usePosterServiceForMeta',
 ];
 

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -785,7 +785,10 @@ const TOP_LEVEL_OPTION_DETAILS: Record<
   | 'tvdbApiKey'
   | 'topPosterApiKey'
   | 'aioratingsApiKey'
-  | 'aioratingsProfileId',
+  | 'aioratingsProfileId'
+  | 'openposterdbApiKey'
+  | 'openposterdbUrl'
+  | 'openposterdbParameters',
   {
     name: string;
     description: string;
@@ -825,6 +828,21 @@ const TOP_LEVEL_OPTION_DETAILS: Record<
     name: 'AIOratings Profile ID',
     description:
       'Use "default" for the default profile, or enter a custom profile UUID from your AIOratings dashboard.',
+  },
+  openposterdbApiKey: {
+    name: 'OpenPosterDB API Key',
+    description:
+      'Get your API key from [here](https://openposterdb.com) for posters with ratings. Use `t0-free-rpdb` for the free public instance.',
+  },
+  openposterdbUrl: {
+    name: 'OpenPosterDB URL',
+    description:
+      'Custom base URL for a self-hosted OpenPosterDB instance. Leave empty to use the default public instance.',
+  },
+  openposterdbParameters: {
+    name: 'OpenPosterDB Custom Parameters',
+    description:
+      'Optional query string (without the leading `?`) appended to every poster to customise it, e.g. `ratings_limit=2&badge_size=l&position=br`.',
   },
 };
 

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -211,6 +211,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
   aioratingsProfileId: { label: 'AIOratings Profile ID', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
   openposterdbApiKey: { label: 'OpenPosterDB API Key', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
   openposterdbUrl: { label: 'OpenPosterDB URL', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
+  openposterdbParameters: { label: 'OpenPosterDB Custom Parameters', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
   posterService: { label: 'Poster Service', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
   usePosterRedirectApi: { label: 'Use Poster Redirect API', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },
   usePosterServiceForMeta: { label: 'Use Poster Service for Meta', group: 'metadata', type: 'scalar', menu: 'services', subTab: 'posters' },

--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -1363,6 +1363,9 @@ function Content() {
       topPosterApiKey: undefined,
       aioratingsApiKey: undefined,
       aioratingsProfileId: undefined,
+      openposterdbApiKey: undefined,
+      openposterdbUrl: undefined,
+      openposterdbParameters: undefined,
       services: clonedData?.services?.map((service) => ({
         ...service,
         credentials: {},

--- a/packages/frontend/src/components/menu/services/_components/poster-services.tsx
+++ b/packages/frontend/src/components/menu/services/_components/poster-services.tsx
@@ -172,6 +172,32 @@ export function PosterServices() {
               setUserData((prev) => ({ ...prev, openposterdbUrl: v }));
             }}
           />
+          <TextInput
+            label="OpenPosterDB Custom Parameters"
+            help={
+              <span>
+                Optional query string appended to every poster to customise it
+                (e.g. ratings, badge size and position). Enter it without the
+                leading <code>?</code>, for example{' '}
+                <code>ratings_limit=2&amp;badge_size=l&amp;position=br</code>.
+                See the{' '}
+                <a
+                  href="https://github.com/PNRxA/openposterdb#readme"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[--brand] hover:underline"
+                >
+                  available parameters
+                </a>
+                .
+              </span>
+            }
+            value={userData.openposterdbParameters || ''}
+            placeholder="ratings_limit=2&badge_size=l&position=br"
+            onValueChange={(v) => {
+              setUserData((prev) => ({ ...prev, openposterdbParameters: v }));
+            }}
+          />
         </>
       )}
 

--- a/packages/frontend/src/lib/templates/processors/index.ts
+++ b/packages/frontend/src/lib/templates/processors/index.ts
@@ -136,12 +136,20 @@ export const processTemplate = (
 
     if (placeholder.isPlaceholder) {
       const detail = constants.TOP_LEVEL_OPTION_DETAILS?.[field];
+      // Most top-level fields are API keys/tokens (secret), but a few are plain
+      // config values that should not be masked in the template input UI.
+      const type: AllowedInputType =
+        field === 'aioratingsProfileId' ||
+        field === 'openposterdbUrl' ||
+        field === 'openposterdbParameters'
+          ? 'string'
+          : 'password';
       inputs.push({
         key: `toplevel_${field}`,
         path: field,
         label: detail?.name || field,
         description: detail?.description,
-        type: 'password',
+        type,
         required: placeholder.required,
         value: userData?.[field] || '',
       });

--- a/packages/frontend/src/lib/templates/processors/index.ts
+++ b/packages/frontend/src/lib/templates/processors/index.ts
@@ -125,6 +125,9 @@ export const processTemplate = (
     'topPosterApiKey',
     'aioratingsApiKey',
     'aioratingsProfileId',
+    'openposterdbApiKey',
+    'openposterdbUrl',
+    'openposterdbParameters',
   ] as const;
 
   topLevelFields.forEach((field) => {

--- a/packages/server/src/routes/api/posters.ts
+++ b/packages/server/src/routes/api/posters.ts
@@ -19,6 +19,7 @@ const searchParams = z.object({
   apiKey: z.string(),
   profileId: z.string().optional(),
   baseUrl: z.string().optional(),
+  parameters: z.string().optional(),
 });
 
 interface PosterServiceParams {
@@ -52,12 +53,14 @@ router.get(
         return;
       }
 
-      const { id, type, fallback, apiKey, profileId, baseUrl } = data;
+      const { id, type, fallback, apiKey, profileId, baseUrl, parameters } =
+        data;
       const service = req.params.service;
 
       const posterService = createPosterServiceFromParams(service, apiKey, {
         profileId: profileId || 'default',
         ...(baseUrl ? { baseUrl } : {}),
+        ...(parameters ? { parameters } : {}),
       });
 
       if (!posterService) {


### PR DESCRIPTION
## Summary

Closes #939.

Adds an optional **Custom Parameters** field for OpenPosterDB so users can append a raw query string to every generated poster — enabling poster customisation with the free public key (`t0-free-rpdb`) / public instance, as requested in the issue.

Example input (without the leading `?`):

```
ratings_order=mc%2Clb%2Ctmdb%2Ctrakt%2Cimdb%2Crt%2Crta%2Cmal&badge_size=l&ratings_limit=2&badge_direction=h&position=br
```

## Changes

- **`packages/core/src/poster/openposterdb.ts`** — new `customParameters` constructor arg, threaded through `buildPosterUrl`, `getCacheKey`, `appendRedirectParams` and `fromQueryParams` (modelled on the existing `aioratingsProfileId` flow). The now-optional `.jpg` suffix is dropped so the query string appends cleanly. Pasted leading `?`/`&` and any `#fragment` are stripped, and the cache key only varies when parameters are actually set (no cache churn for existing users who set no parameters).
- **`packages/server/src/routes/api/posters.ts`** — accept and forward the `parameters` query param through the poster redirect API.
- **`packages/core/src/db/schemas.ts`**, **`utils/fieldMeta.ts`**, **`utils/config.ts`** — new `openposterdbParameters` user-data field + metadata.
- **`packages/frontend/.../poster-services.tsx`** — new input shown when OpenPosterDB is selected, with help text and a link to the parameter docs.

### Consistency fixes for the OpenPosterDB field group (same area)

While wiring the new field I noticed the existing OpenPosterDB fields were missing from two places that handle every other poster service; fixed both so the group is consistent (happy to split these into a separate PR if preferred):

- **`save-install.tsx` `filterCredentials`** — `openposterdbApiKey` (a password input) was **not** stripped on credential-filtered config export, unlike `rpdbApiKey` / `topPosterApiKey` / `aioratingsApiKey`. Now stripped along with `openposterdbUrl` / `openposterdbParameters`.
- **`templates/processors/index.ts`** + **`constants.ts` `TOP_LEVEL_OPTION_DETAILS`** — the OpenPosterDB fields now support template placeholders, like the other poster services.

## Verification

Verified against the live OpenPosterDB server and its source:

- `.jpg` is optional on the current server — `…/poster-default/movie-9836` and `…movie-9836.jpg` return byte-identical `200 image/jpeg` (including the `HEAD` request used by the existence check).
- The custom parameters produce a different (customised) image, confirming they take effect.
- The redirect round-trip (`appendRedirectParams` → `searchParams` → `req.query.parameters` → rebuild) preserves pre-encoded values (`%2C`, `&`, `=`) exactly.
- `pnpm -F core build`, `pnpm -F server build`, and `pnpm -F frontend typecheck` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a user-facing input to configure custom OpenPosterDB parameters.
* **Improvements**
  * Custom parameters are now propagated through configuration, template processing, API requests, URL generation and caching.
  * Export/save tooling now excludes OpenPosterDB secrets and parameters from exported configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->