### PR TITLE
fix(debrid): handle HEAD requests on playback route

### DIFF
--- a/packages/server/src/routes/api/debrid.ts
+++ b/packages/server/src/routes/api/debrid.ts
@@ -33,14 +33,60 @@ const logger = createLogger('server');
 
 router.use(corsMiddleware);
 
-// block HEAD requests
-router.use((req: Request, res: Response, next: NextFunction) => {
-  if (req.method === 'HEAD') {
-    res.status(405).send('Method not allowed');
-  } else {
-    next();
+router.head(
+  '/playback/:encryptedStoreAuth/:fileInfo/:metadataId/:filename',
+  async (req: Request<PlaybackParams>, res: Response, next: NextFunction) => {
+    try {
+      const { encryptedStoreAuth, fileInfo: encodedFileInfo } = req.params;
+
+      try {
+        FileInfoSchema.parse(JSON.parse(fromUrlSafeBase64(encodedFileInfo)));
+      } catch {
+        const stored = await fileInfoStore()?.get(encodedFileInfo);
+        if (!stored) {
+          next(
+            new APIError(
+              constants.ErrorCode.BAD_REQUEST,
+              undefined,
+              'Failed to parse file info and not found in store.'
+            )
+          );
+          return;
+        }
+      }
+
+      const decryptedStoreAuth = decryptString(encryptedStoreAuth);
+      if (!decryptedStoreAuth.success) {
+        next(
+          new APIError(
+            constants.ErrorCode.BAD_REQUEST,
+            undefined,
+            'Failed to decrypt store auth'
+          )
+        );
+        return;
+      }
+
+      try {
+        ServiceAuthSchema.parse(JSON.parse(decryptedStoreAuth.data));
+      } catch {
+        next(
+          new APIError(
+            constants.ErrorCode.BAD_REQUEST,
+            undefined,
+            'Failed to parse store auth'
+          )
+        );
+        return;
+      }
+
+      res.setHeader('Content-Type', 'video/mp4');
+      res.status(200).end();
+    } catch (error: any) {
+      next(error);
+    }
   }
-});
+);
 
 interface PlaybackParams {
   encryptedStoreAuth: string;

--- a/packages/server/src/routes/api/debrid.ts
+++ b/packages/server/src/routes/api/debrid.ts
@@ -37,10 +37,18 @@ router.head(
   '/playback/:encryptedStoreAuth/:fileInfo/:metadataId/:filename',
   async (req: Request<PlaybackParams>, res: Response, next: NextFunction) => {
     try {
-      const { encryptedStoreAuth, fileInfo: encodedFileInfo } = req.params;
+      const {
+        encryptedStoreAuth,
+        fileInfo: encodedFileInfo,
+        metadataId,
+      } = req.params;
+
+      let fileInfo: FileInfo;
 
       try {
-        FileInfoSchema.parse(JSON.parse(fromUrlSafeBase64(encodedFileInfo)));
+        fileInfo = FileInfoSchema.parse(
+          JSON.parse(fromUrlSafeBase64(encodedFileInfo))
+        );
       } catch {
         const stored = await fileInfoStore()?.get(encodedFileInfo);
         if (!stored) {
@@ -49,6 +57,21 @@ router.head(
               constants.ErrorCode.BAD_REQUEST,
               undefined,
               'Failed to parse file info and not found in store.'
+            )
+          );
+          return;
+        }
+        fileInfo = stored;
+      }
+
+      if (!fileInfo.serviceItemId) {
+        const metadata = await metadataStore().get(metadataId);
+        if (!metadata) {
+          next(
+            new APIError(
+              constants.ErrorCode.BAD_REQUEST,
+              undefined,
+              'Metadata not found'
             )
           );
           return;


### PR DESCRIPTION
Replace the blanket 405 for all HEAD requests with a lightweight HEAD handler on the playback route that validates the encrypted token and file info without hitting the debrid provider, then returns 200 with Content-Type: video/mp4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HEAD requests to the playback endpoint now undergo the same validation as GET and receive a 200 with video content-type when valid, allowing clients to probe resource metadata without starting playback or being rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->