### PR TITLE
fix(server): return 404 for non-existent SPA routes

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -291,6 +291,27 @@ app.get('/configure', (req, res) => {
   res.redirect('/stremio/configure');
 });
 
+// SPA route validation: returns true for paths that exist in the client-side router.
+const SPA_STATIC_ROUTES = [
+  '/',
+  '/login',
+  '/oauth/callback/gdrive',
+  '/splashscreen',
+  '/stremio/configure',
+];
+
+const SPA_DYNAMIC_PATTERNS: RegExp[] = [
+  /^\/stremio\/[^/]+\/[^/]+\/configure$/,
+  /^\/dashboard(\/.*)?$/,
+];
+
+function isValidSpaRoute(routePath: string): boolean {
+  if (SPA_STATIC_ROUTES.includes(routePath)) {
+    return true;
+  }
+  return SPA_DYNAMIC_PATTERNS.some((pattern) => pattern.test(routePath));
+}
+
 // SPA fallback.
 app.get('*splat', staticRateLimiter, (req, res, next) => {
   if (req.method !== 'GET' || !req.accepts('html')) {
@@ -299,8 +320,11 @@ app.get('*splat', staticRateLimiter, (req, res, next) => {
   }
   const indexPath = path.join(frontendRoot, 'index.html');
   if (fs.existsSync(indexPath)) {
-    res.setHeader('Cache-Control', 'no-cache');
-    res.sendFile(indexPath);
+    const status = isValidSpaRoute(req.path) ? 200 : 404;
+    res
+      .status(status)
+      .setHeader('Cache-Control', 'no-cache')
+      .sendFile(indexPath);
     return;
   }
   next();


### PR DESCRIPTION
The SPA fallback previously returned 200 for all unmatched routes, including paths that don't exist in the client-side router. 

This caused routes like `/hello_world` to return `200` instead of `404`.

Add server-side route validation that checks incoming paths against the SPA route definitions before serving index.html. 

Routes that match the client router return 200 and unknown routes return 404.

This change is only for the app frontend part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SPA route validation to correctly return 404 status codes for non-existent routes, whilst still serving the application shell for valid routes. This ensures proper HTTP semantics and enhances search engine compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->