### PR TITLE
feat(subtitles): proxy subtitle URLs through the configured proxy

### DIFF
--- a/packages/core/src/config/schema/proxy.ts
+++ b/packages/core/src/config/schema/proxy.ts
@@ -133,7 +133,7 @@ export const proxySchema = {
       default: null as string[] | null,
       label: 'Default proxied services',
       description:
-        'List of serviceIds to proxy by default. JSON array of strings.',
+        'List of serviceIds to proxy by default. Use `subtitle` to proxy subtitle URLs. JSON array of strings.',
       env: 'DEFAULT_PROXY_PROXIED_SERVICES',
       requiresRestart: false,
       secret: false,
@@ -208,7 +208,8 @@ export const proxySchema = {
       schema: proxiedServicesList,
       default: null as string[] | null,
       label: 'Forced proxied services',
-      description: 'List of serviceIds to force-proxy. JSON array of strings.',
+      description:
+        'List of serviceIds to force-proxy. Use `subtitle` to proxy subtitle URLs. JSON array of strings.',
       env: 'FORCE_PROXY_PROXIED_SERVICES',
       requiresRestart: false,
       secret: false,

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -12,6 +12,7 @@ import { Wrapper } from './wrapper.js';
 import { PresetManager } from '../presets/index.js';
 import { FeatureControl } from '../utils/feature.js';
 import { StreamContext, StreamUtils } from '../streams/index.js';
+import { createProxy } from '../proxy/index.js';
 import { populateNzbFallbacks } from './nzbFailover.js';
 import { resolveServiceWrappedStreams } from './serviceWrapper.js';
 import type { ServiceWrapServiceTiming } from './serviceWrapper.js';
@@ -948,7 +949,10 @@ export async function getSubtitles(
       description: error.error,
     })
   );
-  let allSubtitles: Subtitle[] = [];
+  const subtitleEntries: Array<{
+    subtitle: Subtitle;
+    addonInstanceId?: string;
+  }> = [];
 
   await Promise.all(
     supportedAddons.map(async (addon) => {
@@ -958,7 +962,14 @@ export async function getSubtitles(
           id,
           parsedExtras.toString()
         );
-        if (subtitles) allSubtitles.push(...subtitles);
+        if (subtitles?.length) {
+          subtitleEntries.push(
+            ...subtitles.map((subtitle) => ({
+              subtitle,
+              addonInstanceId: addon.instanceId,
+            }))
+          );
+        }
       } catch (error) {
         errors.push({
           title: `[❌] ${getAddonName(addon)}`,
@@ -967,6 +978,58 @@ export async function getSubtitles(
       }
     })
   );
+
+  let allSubtitles: Subtitle[] = subtitleEntries.map((entry) => entry.subtitle);
+
+  if (ctx.userData.proxy?.enabled && allSubtitles.length > 0) {
+    const subtitlesToProxy = subtitleEntries
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => {
+        const proxyService =
+          !ctx.userData.proxy?.proxiedServices?.length ||
+          ctx.userData.proxy.proxiedServices.includes('subtitle');
+
+        const proxyAddon =
+          !ctx.userData.proxy?.proxiedAddons?.length ||
+          (entry.addonInstanceId
+            ? ctx.userData.proxy.proxiedAddons.includes(entry.addonInstanceId)
+            : false);
+
+        return proxyService && proxyAddon;
+      });
+
+    if (subtitlesToProxy.length === 0) {
+      return { success: true, data: allSubtitles, errors };
+    }
+
+    try {
+      const proxy = createProxy(ctx.userData.proxy);
+      const proxiedUrls = await proxy.generateUrls(
+        subtitlesToProxy.map(({ entry }) => ({
+          url: entry.subtitle.url,
+          filename: 'subtitle',
+        }))
+      );
+      if (proxiedUrls && !('error' in proxiedUrls)) {
+        allSubtitles = allSubtitles.map((subtitle, index) => {
+          const proxiedSubtitleIndex = subtitlesToProxy.findIndex(
+            (entry) => entry.index === index
+          );
+
+          if (proxiedSubtitleIndex === -1) {
+            return subtitle;
+          }
+
+          return {
+            ...subtitle,
+            url: proxiedUrls[proxiedSubtitleIndex] ?? subtitle.url,
+          };
+        });
+      }
+    } catch (err) {
+      logger.warn({ err }, 'failed to proxy subtitle urls');
+    }
+  }
 
   return { success: true, data: allSubtitles, errors };
 }

--- a/packages/frontend/src/components/menu/proxy.tsx
+++ b/packages/frontend/src/components/menu/proxy.tsx
@@ -60,6 +60,11 @@ function Content() {
       textValue: service.name,
     })),
     {
+      label: 'Subtitles',
+      value: 'subtitle',
+      textValue: 'Subtitles',
+    },
+    {
       label: 'None',
       value: 'none',
       textValue: 'None',
@@ -268,9 +273,10 @@ function Content() {
                 emptyMessage="No services available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams (that are detected to be) from these services will
-                be proxied. Select None to enable proxying of streams that are
-                not detected to be from a service.
+                Only streams (that are detected to be) from these services and
+                selected subtitle URLs will be proxied. Select Subtitles to
+                proxy subtitle URLs. Select None to enable proxying of streams
+                that are not detected to be from a service.
               </p>
             </div>
 
@@ -291,7 +297,8 @@ function Content() {
                 emptyMessage="No addons available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams from these addons will be proxied
+                Only streams and subtitle URLs from these addons will be
+                proxied
               </p>
             </div>
           </SettingsCard>


### PR DESCRIPTION
## Closes Issue #496 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for proxying subtitle URLs. You can now enable subtitle proxying in the proxy settings menu and choose which subtitle URLs are proxied globally or per addon instance, working alongside existing stream proxying.
* **Configuration**
  * Updated proxy configuration descriptions to clarify subtitle URL proxying and how the “subtitle” service selection affects behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->