### PR TITLE
fix anime split-cour stream matching

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -6,7 +6,12 @@
   Stream,
 } from '../../db/schemas.js';
 import { z, ZodError } from 'zod';
-import { IdParser, IdType, ParsedId } from '../../utils/id-parser.js';
+import {
+  IdParser,
+  IdType,
+  ParsedId,
+  parseStremioCoordinate,
+} from '../../utils/id-parser.js';
 import {
   AnimeDatabase,
   BuiltinServiceId,
@@ -205,8 +210,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       this._searchMetadataPromise = Promise.resolve({
         primaryTitle: undefined,
         titles: [],
-        season: parsedId.season ? Number(parsedId.season) : undefined,
-        episode: parsedId.episode ? Number(parsedId.episode) : undefined,
+        season: parseStremioCoordinate(parsedId.season),
+        episode: parseStremioCoordinate(parsedId.episode),
       });
     }
 
@@ -549,8 +554,12 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     }
 
     const titlePlaceholder = '<___title___>';
-    const querySeason = metadata.logicalSeason ?? parsedId.season;
-    const queryEpisode = metadata.logicalEpisode ?? parsedId.episode;
+    const querySeason = parseStremioCoordinate(
+      metadata.logicalSeason ?? parsedId.season
+    );
+    const queryEpisode = parseStremioCoordinate(
+      metadata.logicalEpisode ?? parsedId.episode
+    );
     const externalSeason = metadata.externalSeason;
     const externalEpisode = metadata.externalEpisode;
 
@@ -577,8 +586,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     } else if (parsedId.mediaType === 'series' && addSeasonEpisode) {
       if (
         includeSeasonOnly &&
-        querySeason &&
-        (queryEpisode ? Number(queryEpisode) < 100 : true)
+        querySeason !== undefined &&
+        (queryEpisode !== undefined ? queryEpisode < 100 : true)
       ) {
         addQuery(
           `${titlePlaceholder} S${querySeason.toString().padStart(2, '0')}`
@@ -588,12 +597,12 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
         addQuery(
           `${titlePlaceholder} ${metadata.absoluteEpisode!.toString().padStart(2, '0')}`
         );
-      } else if (queryEpisode && !querySeason) {
+      } else if (queryEpisode !== undefined && querySeason === undefined) {
         addQuery(
           `${titlePlaceholder} E${queryEpisode.toString().padStart(2, '0')}`
         );
       }
-      if (includeEpisodeOnly && queryEpisode) {
+      if (includeEpisodeOnly && queryEpisode !== undefined) {
         addQuery(
           `${titlePlaceholder} ${queryEpisode.toString().padStart(2, '0')}`
         );
@@ -610,15 +619,15 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
           `${titlePlaceholder} ${metadata.relativeAbsoluteEpisode!.toString().padStart(2, '0')}`
         );
       }
-      if (querySeason && queryEpisode) {
+      if (querySeason !== undefined && queryEpisode !== undefined) {
         addQuery(
           `${titlePlaceholder} S${querySeason.toString().padStart(2, '0')}E${queryEpisode.toString().padStart(2, '0')}`
         );
       }
       if (
         includeExternalQueries &&
-        externalSeason &&
-        externalEpisode &&
+        externalSeason !== undefined &&
+        externalEpisode !== undefined &&
         (externalSeason !== querySeason || externalEpisode !== queryEpisode)
       ) {
         addExternalQuery(
@@ -645,8 +654,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       !metadata.isAnime ||
       !metadata.forceQuerySearch ||
       parsedId.mediaType !== 'series' ||
-      !metadata.logicalSeason ||
-      !metadata.logicalEpisode
+      metadata.logicalSeason === undefined ||
+      metadata.logicalEpisode === undefined
     ) {
       return [];
     }
@@ -668,8 +677,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     const animeEntry = AnimeDatabase.getInstance().getEntryById(
       parsedId.type,
       parsedId.value,
-      parsedId.season ? Number(parsedId.season) : undefined,
-      parsedId.episode ? Number(parsedId.episode) : undefined
+      parseStremioCoordinate(parsedId.season),
+      parseStremioCoordinate(parsedId.episode)
     );
 
     // Extract seasonYear from anime entry
@@ -680,25 +689,23 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       enrichParsedIdWithAnimeEntry(parsedId, animeEntry);
     }
 
-    const externalSeason = parsedId.season
-      ? Number(parsedId.season)
-      : undefined;
-    const externalEpisode = parsedId.episode
-      ? Number(parsedId.episode)
-      : undefined;
-    const logicalSeason = animeEntry
+    const externalSeason = parseStremioCoordinate(parsedId.season);
+    const externalEpisode = parseStremioCoordinate(parsedId.episode);
+    const useLogicalAnimeCoordinates = !!animeEntry && externalSeason !== 0;
+    const logicalSeason = useLogicalAnimeCoordinates
       ? extractLogicalSeasonFromTitles([
           animeEntry?.title,
           ...(animeEntry?.synonyms ?? []),
         ])
       : undefined;
-    const logicalEpisode = animeEntry
+    const logicalEpisode = useLogicalAnimeCoordinates
       ? calculateLogicalEpisode(externalEpisode, animeEntry)
       : externalEpisode;
     const isAmbiguousAnimeSeason = !!(
       animeEntry &&
-      logicalSeason &&
-      externalSeason &&
+      logicalSeason !== undefined &&
+      externalSeason !== undefined &&
+      externalSeason > 0 &&
       logicalSeason !== externalSeason
     );
 

--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -18,6 +18,11 @@ import {
   getSimpleTextHash,
   getTimeTakenSincePoint,
   SERVICE_DETAILS,
+  buildAnimeTitles,
+  calculateLogicalEpisode,
+  dedupeCleanTitles,
+  extractLogicalSeasonFromTitles,
+  buildAmbiguousAnimeQueryWaves,
 } from '../../utils/index.js';
 import { config as appConfig } from '../../config/index.js';
 import { TorrentClient } from '../../utils/torrent.js';
@@ -56,6 +61,13 @@ export interface SearchMetadata extends TitleMetadata {
   tmdbId?: number | null;
   tvdbId?: number | null;
   isAnime?: boolean;
+  logicalSeason?: number;
+  externalSeason?: number;
+  logicalEpisode?: number;
+  externalEpisode?: number;
+  externalTitle?: string;
+  externalTitles?: string[];
+  forceQuerySearch?: boolean;
   /** Full title list with language tags, used by buildQueries for language-aware scraping. */
   titlesWithLang?: MetadataTitle[];
   /** ISO 639-1 code of the content's original language (from TMDB). */
@@ -389,6 +401,10 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       episode: searchMetadata.episode,
       absoluteEpisode: searchMetadata.absoluteEpisode,
       relativeAbsoluteEpisode: searchMetadata.relativeAbsoluteEpisode,
+      logicalSeason: searchMetadata.logicalSeason,
+      externalSeason: searchMetadata.externalSeason,
+      logicalEpisode: searchMetadata.logicalEpisode,
+      externalEpisode: searchMetadata.externalEpisode,
     };
     const metadataId = getSimpleTextHash(JSON.stringify(titleMetadata));
     await metadataStore().set(
@@ -445,11 +461,31 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       /** @deprecated Use titleLanguages instead. */
       useAllTitles?: boolean;
       titleLanguages?: string[];
+      maxTitles?: number;
+      includeSeasonOnly?: boolean;
+      includeAbsoluteEpisode?: boolean;
+      includeRelativeAbsoluteEpisode?: boolean;
+      includeExternalQueries?: boolean;
+      includeEpisodeOnly?: boolean;
     }
   ): string[] {
-    const { addYear, addSeasonEpisode } = {
+    const {
+      addYear,
+      addSeasonEpisode,
+      maxTitles,
+      includeSeasonOnly,
+      includeAbsoluteEpisode,
+      includeRelativeAbsoluteEpisode,
+      includeExternalQueries,
+      includeEpisodeOnly,
+    } = {
       addYear: true,
       addSeasonEpisode: true,
+      includeSeasonOnly: true,
+      includeAbsoluteEpisode: true,
+      includeRelativeAbsoluteEpisode: true,
+      includeExternalQueries: true,
+      includeEpisodeOnly: false,
       ...options,
     };
     let queries: string[] = [];
@@ -499,39 +535,74 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     } else {
       titles = [metadata.primaryTitle];
     }
+    titles = dedupeCleanTitles(titles);
+    const cleanedPrimaryTitle = cleanTitle(metadata.primaryTitle);
+    const primaryIndex = titles.findIndex(
+      (title) => title.toLowerCase() === cleanedPrimaryTitle.toLowerCase()
+    );
+    if (primaryIndex > 0) {
+      const [primaryTitle] = titles.splice(primaryIndex, 1);
+      titles.unshift(primaryTitle);
+    }
+    if (maxTitles && maxTitles > 0) {
+      titles = titles.slice(0, maxTitles);
+    }
 
     const titlePlaceholder = '<___title___>';
+    const querySeason = metadata.logicalSeason ?? parsedId.season;
+    const queryEpisode = metadata.logicalEpisode ?? parsedId.episode;
+    const externalSeason = metadata.externalSeason;
+    const externalEpisode = metadata.externalEpisode;
+
     const addQuery = (query: string) => {
       titles.forEach((title) => {
         queries.push(query.replace(titlePlaceholder, title));
       });
     };
+    const addExternalQuery = (query: string) => {
+      const externalTitles = metadata.externalTitles?.length
+        ? metadata.externalTitles
+        : metadata.externalTitle
+          ? [metadata.externalTitle]
+          : [];
+      externalTitles.forEach((title) => {
+        queries.push(query.replace(titlePlaceholder, cleanTitle(title)));
+      });
+    };
+
     if (parsedId.mediaType === 'movie' && addYear) {
       addQuery(
         `${titlePlaceholder}${metadata.year ? ` ${metadata.year}` : ''}`
       );
     } else if (parsedId.mediaType === 'series' && addSeasonEpisode) {
       if (
-        parsedId.season &&
-        (parsedId.episode ? Number(parsedId.episode) < 100 : true)
+        includeSeasonOnly &&
+        querySeason &&
+        (queryEpisode ? Number(queryEpisode) < 100 : true)
       ) {
         addQuery(
-          `${titlePlaceholder} S${parsedId.season!.toString().padStart(2, '0')}`
+          `${titlePlaceholder} S${querySeason.toString().padStart(2, '0')}`
         );
       }
-      if (metadata.absoluteEpisode) {
+      if (includeAbsoluteEpisode && metadata.absoluteEpisode) {
         addQuery(
           `${titlePlaceholder} ${metadata.absoluteEpisode!.toString().padStart(2, '0')}`
         );
-      } else if (parsedId.episode && !parsedId.season) {
+      } else if (queryEpisode && !querySeason) {
         addQuery(
-          `${titlePlaceholder} E${parsedId.episode!.toString().padStart(2, '0')}`
+          `${titlePlaceholder} E${queryEpisode.toString().padStart(2, '0')}`
+        );
+      }
+      if (includeEpisodeOnly && queryEpisode) {
+        addQuery(
+          `${titlePlaceholder} ${queryEpisode.toString().padStart(2, '0')}`
         );
       }
       if (
+        includeRelativeAbsoluteEpisode &&
         // if relative absolute exists and is different from absoluteEpisode and episode
         metadata.relativeAbsoluteEpisode &&
-        [metadata.absoluteEpisode, parsedId.episode].every(
+        [metadata.absoluteEpisode, queryEpisode].every(
           (v) => v !== metadata.relativeAbsoluteEpisode
         )
       ) {
@@ -539,15 +610,48 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
           `${titlePlaceholder} ${metadata.relativeAbsoluteEpisode!.toString().padStart(2, '0')}`
         );
       }
-      if (parsedId.season && parsedId.episode) {
+      if (querySeason && queryEpisode) {
         addQuery(
-          `${titlePlaceholder} S${parsedId.season!.toString().padStart(2, '0')}E${parsedId.episode!.toString().padStart(2, '0')}`
+          `${titlePlaceholder} S${querySeason.toString().padStart(2, '0')}E${queryEpisode.toString().padStart(2, '0')}`
+        );
+      }
+      if (
+        includeExternalQueries &&
+        externalSeason &&
+        externalEpisode &&
+        (externalSeason !== querySeason || externalEpisode !== queryEpisode)
+      ) {
+        addExternalQuery(
+          `${titlePlaceholder} S${externalSeason.toString().padStart(2, '0')}E${externalEpisode.toString().padStart(2, '0')}`
+        );
+        addExternalQuery(
+          `${titlePlaceholder} ${externalEpisode.toString().padStart(2, '0')}`
         );
       }
     } else {
       addQuery(titlePlaceholder);
     }
-    return queries;
+    return queries.filter(
+      (query, index, array) => array.indexOf(query) === index
+    );
+  }
+
+  protected buildAmbiguousAnimeQueryWaves(
+    parsedId: ParsedId,
+    metadata: SearchMetadata,
+    options: { maxBaseTitles?: number; maxEntryTitles?: number } = {}
+  ): string[][] {
+    if (
+      !metadata.isAnime ||
+      !metadata.forceQuerySearch ||
+      parsedId.mediaType !== 'series' ||
+      !metadata.logicalSeason ||
+      !metadata.logicalEpisode
+    ) {
+      return [];
+    }
+
+    return buildAmbiguousAnimeQueryWaves(metadata, options);
   }
 
   protected abstract _searchTorrents(
@@ -575,6 +679,28 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     if (animeEntry && !parsedId.season) {
       enrichParsedIdWithAnimeEntry(parsedId, animeEntry);
     }
+
+    const externalSeason = parsedId.season
+      ? Number(parsedId.season)
+      : undefined;
+    const externalEpisode = parsedId.episode
+      ? Number(parsedId.episode)
+      : undefined;
+    const logicalSeason = animeEntry
+      ? extractLogicalSeasonFromTitles([
+          animeEntry?.title,
+          ...(animeEntry?.synonyms ?? []),
+        ])
+      : undefined;
+    const logicalEpisode = animeEntry
+      ? calculateLogicalEpisode(externalEpisode, animeEntry)
+      : externalEpisode;
+    const isAmbiguousAnimeSeason = !!(
+      animeEntry &&
+      logicalSeason &&
+      externalSeason &&
+      logicalSeason !== externalSeason
+    );
 
     const metadata = await new MetadataService({
       tmdbAccessToken: this.userData.tmdbReadAccessToken,
@@ -665,6 +791,25 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       parsedId.type === 'imdbId'
         ? parsedId.value.toString()
         : animeEntry?.mappings?.imdbId?.toString();
+    const animeTitles = isAmbiguousAnimeSeason
+      ? buildAnimeTitles(animeEntry, metadata.title, logicalSeason, seasonYear)
+      : (metadata.titles?.map((t) => t.title) ?? []);
+    const primaryTitle =
+      isAmbiguousAnimeSeason && animeEntry?.title
+        ? cleanTitle(animeEntry.title)
+        : metadata.title;
+    const titlesWithLang = isAmbiguousAnimeSeason
+      ? animeTitles.map((title, index) => {
+          const existing = metadata.titles?.find(
+            (t) => cleanTitle(t.title) === title
+          );
+          if (existing) return existing;
+          return {
+            title,
+            language: index === 0 ? metadata.originalLanguage : undefined,
+          };
+        })
+      : (metadata.titles ?? []);
     // const tmdbId =
     //   parsedId.type === 'themoviedbId'
     //     ? parsedId.value.toString()
@@ -675,20 +820,27 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
     //     : (animeEntry?.mappings?.thetvdbId?.toString() ?? null);
 
     const searchMetadata: SearchMetadata = {
-      primaryTitle: metadata.title,
-      titles: metadata.titles?.map((t) => t.title) ?? [],
-      titlesWithLang: metadata.titles ?? [],
+      primaryTitle,
+      titles: animeTitles,
+      titlesWithLang,
       originalLanguage: metadata.originalLanguage,
-      season: parsedId.season ? Number(parsedId.season) : undefined,
-      episode: parsedId.episode ? Number(parsedId.episode) : undefined,
+      season: logicalSeason ?? externalSeason,
+      logicalSeason,
+      externalSeason,
+      episode: logicalEpisode ?? externalEpisode,
+      logicalEpisode,
+      externalEpisode,
       absoluteEpisode,
       relativeAbsoluteEpisode,
-      year: metadata.year,
+      year: isAmbiguousAnimeSeason && seasonYear ? seasonYear : metadata.year,
       seasonYear,
+      externalTitle: metadata.title,
+      externalTitles: metadata.titles?.map((t) => t.title) ?? [],
       imdbId,
       tmdbId: metadata.tmdbId ?? null,
       tvdbId: metadata.tvdbId ?? null,
       isAnime: animeEntry ? true : false,
+      forceQuerySearch: isAmbiguousAnimeSeason,
     };
 
     this.logger.debug(

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -71,11 +71,48 @@ interface SearchResultMetadata {
   capabilities: Capabilities;
 }
 
+function isRateLimitError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b429\b|too many requests/i.test(message);
+}
+
 export abstract class BaseNabAddon<
   C extends NabAddonConfig,
   A extends BaseNabApi<'torznab' | 'newznab'>,
 > extends BaseDebridAddon<C> {
   abstract api: A;
+
+  private async fetchQueryBatch(
+    searchFunction: string,
+    queryParams: Record<string, string>,
+    queries: string[],
+    queryLimit: ReturnType<typeof createQueryLimit>
+  ): Promise<{
+    results: SearchResultItem<A['namespace']>[];
+    rateLimitError?: unknown;
+  }> {
+    const settled = await Promise.allSettled(
+      queries.map((q) =>
+        queryLimit(() =>
+          this.fetchResults(searchFunction, { ...queryParams, q })
+        )
+      )
+    );
+
+    const results: SearchResultItem<A['namespace']>[] = [];
+    let rateLimitError: unknown;
+    for (const item of settled) {
+      if (item.status === 'fulfilled') {
+        results.push(...item.value);
+      } else if (isRateLimitError(item.reason)) {
+        rateLimitError ??= item.reason;
+      } else {
+        throw item.reason;
+      }
+    }
+
+    return { results, rateLimitError };
+  }
 
   protected async performSearch(
     parsedId: ParsedId,
@@ -88,6 +125,8 @@ export abstract class BaseNabAddon<
     const start = Date.now();
     const queryParams: Record<string, string> = {};
     const queryLimit = createQueryLimit();
+    const preferQuerySearch =
+      this.userData.forceQuerySearch || metadata.forceQuerySearch;
     let capabilities: Capabilities;
     let searchType: SearchResultMetadata['searchType'] = 'id';
     try {
@@ -100,10 +139,16 @@ export abstract class BaseNabAddon<
 
     this.logger.debug(`Capabilities: ${JSON.stringify(capabilities)}`);
 
-    const chosenFunction = this.getSearchFunction(
+    let chosenFunction = this.getSearchFunction(
       parsedId.mediaType,
       capabilities.searching
     );
+    if (preferQuerySearch && capabilities.searching.search?.available) {
+      chosenFunction = {
+        capabilities: capabilities.searching.search,
+        function: 'search',
+      };
+    }
     if (!chosenFunction)
       throw new Error(
         `Could not find a search function for ${capabilities.server.title}`
@@ -120,7 +165,7 @@ export abstract class BaseNabAddon<
       capabilities.limits?.max?.toString() ??
       '10000';
 
-    if (this.userData.forceQuerySearch) {
+    if (preferQuerySearch) {
     } else if (
       // prefer tvdb ID over imdb ID for series
       parsedId.mediaType === 'series' &&
@@ -144,17 +189,18 @@ export abstract class BaseNabAddon<
     )
       queryParams.tvdbid = metadata.tvdbId.toString();
 
+    const requestedExternalSeason = metadata.externalSeason ?? parsedId.season;
     if (
-      ((!this.userData.forceQuerySearch &&
+      ((!preferQuerySearch &&
         searchCapabilities.supportedParams.includes('season')) ||
         forceIncludeSeasonEpInParams.includes(
           capabilities.server.title || ''
         )) &&
-      parsedId.season
+      requestedExternalSeason
     )
-      queryParams.season = parsedId.season.toString();
+      queryParams.season = requestedExternalSeason.toString();
     if (
-      ((!this.userData.forceQuerySearch &&
+      ((!preferQuerySearch &&
         searchCapabilities.supportedParams.includes('ep')) ||
         forceIncludeSeasonEpInParams.includes(
           capabilities.server.title || ''
@@ -163,7 +209,7 @@ export abstract class BaseNabAddon<
     )
       queryParams.ep = parsedId.episode.toString();
     if (
-      !this.userData.forceQuerySearch &&
+      !preferQuerySearch &&
       searchCapabilities.supportedParams.includes('year') &&
       metadata.year &&
       parsedId.mediaType === 'movie'
@@ -171,6 +217,7 @@ export abstract class BaseNabAddon<
       queryParams.year = metadata.year.toString();
 
     let queries: string[] = [];
+    let queryWaves: string[][] = [];
     if (
       !queryParams.imdbid &&
       !queryParams.tmdbid &&
@@ -178,31 +225,72 @@ export abstract class BaseNabAddon<
       searchCapabilities.supportedParams.includes('q') &&
       metadata.primaryTitle
     ) {
-      queries = this.buildQueries(parsedId, metadata, {
-        // add year if it is not already in the query params
-        addYear: !queryParams.year,
-        // add season and episode if they are not already in the query params
-        // some endpoints won't return results with season/ep in query
-        addSeasonEpisode: forceIncludeSeasonEpInParams.includes(
-          capabilities.server.title || ''
-        )
-          ? false
-          : !queryParams.season && !queryParams.ep,
-        titleLanguages: getTitleLanguagesForUrl(this.userData.url, this.id),
-      });
+      queryWaves = metadata.forceQuerySearch
+        ? this.buildAmbiguousAnimeQueryWaves(parsedId, metadata)
+        : [];
+      queries =
+        queryWaves.length > 0
+          ? []
+          : this.buildQueries(parsedId, metadata, {
+              // add year if it is not already in the query params
+              addYear: !queryParams.year,
+              // add season and episode if they are not already in the query params
+              // some endpoints won't return results with season/ep in query
+              addSeasonEpisode: forceIncludeSeasonEpInParams.includes(
+                capabilities.server.title || ''
+              )
+                ? false
+                : !queryParams.season && !queryParams.ep,
+              titleLanguages: getTitleLanguagesForUrl(
+                this.userData.url,
+                this.id
+              ),
+            });
       searchType = 'query';
+    }
+    if (
+      preferQuerySearch &&
+      !queryParams.imdbid &&
+      !queryParams.tmdbid &&
+      !queryParams.tvdbid &&
+      queries.length === 0 &&
+      queryWaves.length === 0
+    ) {
+      throw new Error(
+        `Query search was requested for ${capabilities.server.title}, but the selected search function does not support q`
+      );
     }
     queryParams.extended = '1';
     let results: SearchResultItem<A['namespace']>[] = [];
-    if (queries.length > 0) {
+    if (queryWaves.length > 0) {
+      this.logger.debug('Performing query waves', { waves: queryWaves });
+      for (const wave of queryWaves) {
+        const waveResult = await this.fetchQueryBatch(
+          searchFunction,
+          queryParams,
+          wave,
+          queryLimit
+        );
+        results.push(...waveResult.results);
+        if (results.length > 0) {
+          break;
+        }
+        if (waveResult.rateLimitError) {
+          throw waveResult.rateLimitError;
+        }
+      }
+    } else if (queries.length > 0) {
       this.logger.debug('Performing queries', { queries });
-      const searchPromises = queries.map((q) =>
-        queryLimit(() =>
-          this.fetchResults(searchFunction, { ...queryParams, q })
-        )
+      const searchResult = await this.fetchQueryBatch(
+        searchFunction,
+        queryParams,
+        queries,
+        queryLimit
       );
-      const allResults = await Promise.all(searchPromises);
-      results = allResults.flat();
+      if (searchResult.rateLimitError && searchResult.results.length === 0) {
+        throw searchResult.rateLimitError;
+      }
+      results = searchResult.results;
     } else {
       results = await this.fetchResults(searchFunction, queryParams);
     }

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -15,6 +15,7 @@ import {
 import {
   BaseNabApi,
   Capabilities,
+  NabRateLimitError,
   SearchResponse,
   SearchResultItem,
 } from './api.js';
@@ -72,8 +73,7 @@ interface SearchResultMetadata {
 }
 
 function isRateLimitError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /\b429\b|too many requests/i.test(message);
+  return error instanceof NabRateLimitError;
 }
 
 export abstract class BaseNabAddon<
@@ -196,7 +196,7 @@ export abstract class BaseNabAddon<
         forceIncludeSeasonEpInParams.includes(
           capabilities.server.title || ''
         )) &&
-      requestedExternalSeason
+      requestedExternalSeason !== undefined
     )
       queryParams.season = requestedExternalSeason.toString();
     if (

--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -24,6 +24,35 @@ export class NabApiError extends Error {
   }
 }
 
+export class NabRateLimitError extends Error {
+  constructor(
+    message: string,
+    public readonly retryAfterMs: number
+  ) {
+    super(message);
+    this.name = 'NabRateLimitError';
+  }
+}
+
+const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 10 * 60 * 1000;
+const rateLimitCooldowns = new Map<string, number>();
+
+function parseRetryAfterMs(value: string | null | undefined): number {
+  if (!value) return DEFAULT_RATE_LIMIT_COOLDOWN_MS;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.max(1000, seconds * 1000);
+  }
+
+  const date = Date.parse(value);
+  if (Number.isFinite(date)) {
+    return Math.max(1000, date - Date.now());
+  }
+
+  return DEFAULT_RATE_LIMIT_COOLDOWN_MS;
+}
+
 // --- Zod Schemas ---
 const convertString = z
   .string()
@@ -358,6 +387,34 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
     }
   }
 
+  private getRateLimitKey(): string {
+    return `${this.namespace}:${this.baseUrl}${this.apiPath}`;
+  }
+
+  private getRateLimitRemainingMs(): number {
+    const until = rateLimitCooldowns.get(this.getRateLimitKey());
+    if (!until) return 0;
+
+    const remaining = until - Date.now();
+    if (remaining <= 0) {
+      rateLimitCooldowns.delete(this.getRateLimitKey());
+      return 0;
+    }
+
+    return remaining;
+  }
+
+  private setRateLimitCooldown(retryAfterMs?: number): void {
+    const duration = Math.max(
+      1000,
+      retryAfterMs || DEFAULT_RATE_LIMIT_COOLDOWN_MS
+    );
+    rateLimitCooldowns.set(this.getRateLimitKey(), Date.now() + duration);
+    this.logger.warn(
+      `${this.namespace} endpoint rate limited, cooling down for ${Math.ceil(duration / 1000)}s`
+    );
+  }
+
   public async getCapabilities(): Promise<Capabilities> {
     const cacheKey = `${this.baseUrl}${this.apiPath}?t=caps&${JSON.stringify(this.params)}`;
     return this.capabilitiesCache.wrap(
@@ -372,6 +429,16 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
     params: Record<string, string | number | boolean> = {}
   ): Promise<SearchResponse<N>> {
     const cacheKey = `${this.baseUrl}${this.apiPath}?t=${searchFunction}&${JSON.stringify(params)}&apikey=${this.apiKey}&${JSON.stringify(this.params)}`;
+
+    if (this.getRateLimitRemainingMs() > 0) {
+      const cachedResult = await this.searchCache.get(cacheKey);
+      if (cachedResult !== undefined) {
+        this.logger.warn(
+          `${this.namespace} endpoint is cooling down after 429, returning cached search result without refresh`
+        );
+        return cachedResult;
+      }
+    }
 
     return searchWithBackgroundRefresh({
       searchCache: this.searchCache as Cache<string, SearchResponse<N>>,
@@ -407,6 +474,14 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
     params: Record<string, string | number | boolean> = {},
     timeout?: number
   ): Promise<T> {
+    const remaining = this.getRateLimitRemainingMs();
+    if (remaining > 0) {
+      throw new NabRateLimitError(
+        `429 - Too Many Requests (cooldown active for ${Math.ceil(remaining / 1000)}s)`,
+        remaining
+      );
+    }
+
     const lockKey = `${this.baseUrl}${this.apiPath}?t=${func}&${JSON.stringify(params)}&apikey=${this.apiKey}&${JSON.stringify(this.params)}`;
     const { result } = await DistributedLock.getInstance().withLock(
       lockKey,
@@ -454,6 +529,14 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
         forceProxy: this.httpProxy,
       });
 
+      if (response.status === 429) {
+        const retryAfterMs = parseRetryAfterMs(
+          response.headers?.get?.('retry-after')
+        );
+        this.setRateLimitCooldown(retryAfterMs);
+        throw new NabRateLimitError('429 - Too Many Requests', retryAfterMs);
+      }
+
       const data = await response.text();
 
       let result: any | null = null;
@@ -468,6 +551,13 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
       if (result && result.error) {
         const code = parseInt(result.error.$.code, 10);
         const description = result.error.$.description;
+        if (code === 429) {
+          this.setRateLimitCooldown(DEFAULT_RATE_LIMIT_COOLDOWN_MS);
+          throw new NabRateLimitError(
+            description || '429 - Too Many Requests',
+            DEFAULT_RATE_LIMIT_COOLDOWN_MS
+          );
+        }
         throw new NabApiError(code, description);
       }
 

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -183,6 +183,10 @@ const TitleMetadataSchema = z.object({
   episode: z.number().optional(),
   absoluteEpisode: z.number().optional(),
   relativeAbsoluteEpisode: z.number().optional(),
+  logicalSeason: z.number().optional(),
+  externalSeason: z.number().optional(),
+  logicalEpisode: z.number().optional(),
+  externalEpisode: z.number().optional(),
 });
 
 const BasePlaybackInfoSchema = z.object({

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -194,6 +194,10 @@ export interface FormatterContext {
   episodeRuntime?: number;
   absoluteEpisode?: number;
   relativeAbsoluteEpisode?: number;
+  logicalSeason?: number;
+  externalSeason?: number;
+  logicalEpisode?: number;
+  externalEpisode?: number;
   originalLanguage?: string;
   daysSinceRelease?: number;
   hasNextEpisode?: boolean;

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -144,6 +144,10 @@ export interface ParseValue {
     genres: string[] | null;
     year: number | null;
     episodeRuntime: number | null;
+    logicalSeason: number | null;
+    externalSeason: number | null;
+    logicalEpisode: number | null;
+    externalEpisode: number | null;
   };
   service?: {
     id: string | null;
@@ -569,6 +573,10 @@ export abstract class BaseFormatter {
         episodeRuntime: this.formatterContext.episodeRuntime || null,
         genres: this.formatterContext.genres || null,
         year: this.formatterContext.year || null,
+        logicalSeason: this.formatterContext.logicalSeason ?? null,
+        externalSeason: this.formatterContext.externalSeason ?? null,
+        logicalEpisode: this.formatterContext.logicalEpisode ?? null,
+        externalEpisode: this.formatterContext.externalEpisode ?? null,
       },
       addon: {
         name: stream.addon?.name || null,

--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -81,6 +81,10 @@ export abstract class StreamExpressionEngine {
     this.parser.consts.isAnime = context.isAnime ?? false;
     this.parser.consts.season = context.season ?? -1;
     this.parser.consts.episode = context.episode ?? -1;
+    this.parser.consts.logicalSeason = context.logicalSeason ?? -1;
+    this.parser.consts.externalSeason = context.externalSeason ?? -1;
+    this.parser.consts.logicalEpisode = context.logicalEpisode ?? -1;
+    this.parser.consts.externalEpisode = context.externalEpisode ?? -1;
     this.parser.consts.genres = context.genres ?? [];
     this.parser.consts.title = context.title ?? '';
     this.parser.consts.year = context.year ?? 0;

--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -7,6 +7,7 @@ import {
   AnimeEntry,
   IdParser,
   ParsedId,
+  parseStremioCoordinate,
   createLogger,
   getSeaDexInfoHashes,
   enrichParsedIdWithAnimeEntry,
@@ -153,8 +154,8 @@ export class StreamContext {
       animeEntry = animeDb.getEntryById(
         parsedId.type,
         parsedId.value,
-        parsedId.season ? Number(parsedId.season) : undefined,
-        parsedId.episode ? Number(parsedId.episode) : undefined
+        parseStremioCoordinate(parsedId.season),
+        parseStremioCoordinate(parsedId.episode)
       );
 
       // Enrich parsedId with anime entry data if available and no season specified
@@ -207,26 +208,25 @@ export class StreamContext {
           this.type as any
         );
 
-        const externalSeason = this.parsedId?.season
-          ? Number(this.parsedId.season)
-          : undefined;
-        const externalEpisode = this.parsedId?.episode
-          ? Number(this.parsedId.episode)
-          : undefined;
-        const logicalSeason = this.isAnime
+        const externalSeason = parseStremioCoordinate(this.parsedId?.season);
+        const externalEpisode = parseStremioCoordinate(this.parsedId?.episode);
+        const useLogicalAnimeCoordinates =
+          this.isAnime && externalSeason !== 0;
+        const logicalSeason = useLogicalAnimeCoordinates
           ? extractLogicalSeasonFromTitles([
               this.animeEntry?.title,
               ...(this.animeEntry?.synonyms ?? []),
             ])
           : undefined;
-        const logicalEpisode = this.isAnime
+        const logicalEpisode = useLogicalAnimeCoordinates
           ? calculateLogicalEpisode(externalEpisode, this.animeEntry)
           : externalEpisode;
         const seasonYear = this.animeEntry?.animeSeason?.year ?? undefined;
         const isAmbiguousAnimeSeason = !!(
           this.isAnime &&
-          logicalSeason &&
-          externalSeason &&
+          logicalSeason !== undefined &&
+          externalSeason !== undefined &&
+          externalSeason > 0 &&
           logicalSeason !== externalSeason
         );
 
@@ -712,10 +712,8 @@ export class StreamContext {
       type: this.type,
       isAnime: this.isAnime,
       queryType: this.queryType,
-      season: this.parsedId?.season ? Number(this.parsedId.season) : undefined,
-      episode: this.parsedId?.episode
-        ? Number(this.parsedId.episode)
-        : undefined,
+      season: parseStremioCoordinate(this.parsedId?.season),
+      episode: parseStremioCoordinate(this.parsedId?.episode),
       title: this._metadata?.title,
       titles: this._metadata?.titles?.map((t) => t.title),
       year: this._metadata?.year,
@@ -757,10 +755,8 @@ export class StreamContext {
       id: this.id,
       isAnime: this.isAnime,
       queryType: this.queryType,
-      season: this.parsedId?.season ? Number(this.parsedId.season) : undefined,
-      episode: this.parsedId?.episode
-        ? Number(this.parsedId.episode)
-        : undefined,
+      season: parseStremioCoordinate(this.parsedId?.season),
+      episode: parseStremioCoordinate(this.parsedId?.episode),
       // Metadata fields
       title: this._metadata?.title,
       titles: this._metadata?.titles?.map((t) => t.title),

--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -10,6 +10,9 @@ import {
   createLogger,
   getSeaDexInfoHashes,
   enrichParsedIdWithAnimeEntry,
+  extractLogicalSeasonFromTitles,
+  calculateLogicalEpisode,
+  buildAnimeTitles,
 } from '../utils/index.js';
 import { SeaDexResult } from '../utils/seadex.js';
 import { calculateAbsoluteEpisode } from '../builtins/utils/general.js';
@@ -24,6 +27,11 @@ export interface ExtendedMetadata extends Metadata {
   absoluteEpisode?: number;
   relativeAbsoluteEpisode?: number; // Episode number within current AniDB entry (for split entries)
   seasonYear?: number; // For anime, the year of the season (e.g., 2021 for "Winter 2021")
+  logicalSeason?: number;
+  externalSeason?: number;
+  logicalEpisode?: number;
+  externalEpisode?: number;
+  isAmbiguousAnimeSeason?: boolean;
 }
 
 export interface ExpressionContext {
@@ -42,6 +50,10 @@ export interface ExpressionContext {
   runtime?: number;
   absoluteEpisode?: number;
   relativeAbsoluteEpisode?: number; // Episode number within current AniDB entry (for split entries)
+  logicalSeason?: number;
+  externalSeason?: number;
+  logicalEpisode?: number;
+  externalEpisode?: number;
   originalLanguage?: string;
   daysSinceRelease?: number; // age in days of the movie / **episode**
   hasNextEpisode?: boolean;
@@ -195,6 +207,29 @@ export class StreamContext {
           this.type as any
         );
 
+        const externalSeason = this.parsedId?.season
+          ? Number(this.parsedId.season)
+          : undefined;
+        const externalEpisode = this.parsedId?.episode
+          ? Number(this.parsedId.episode)
+          : undefined;
+        const logicalSeason = this.isAnime
+          ? extractLogicalSeasonFromTitles([
+              this.animeEntry?.title,
+              ...(this.animeEntry?.synonyms ?? []),
+            ])
+          : undefined;
+        const logicalEpisode = this.isAnime
+          ? calculateLogicalEpisode(externalEpisode, this.animeEntry)
+          : externalEpisode;
+        const seasonYear = this.animeEntry?.animeSeason?.year ?? undefined;
+        const isAmbiguousAnimeSeason = !!(
+          this.isAnime &&
+          logicalSeason &&
+          externalSeason &&
+          logicalSeason !== externalSeason
+        );
+
         // Calculate absolute episode for anime
         let absoluteEpisode: number | undefined;
         let relativeAbsoluteEpisode: number | undefined;
@@ -277,11 +312,48 @@ export class StreamContext {
           }
         }
 
+        const preferredTitles =
+          isAmbiguousAnimeSeason && this.animeEntry
+            ? buildAnimeTitles(
+                this.animeEntry,
+                metadata.title,
+                logicalSeason,
+                seasonYear
+              )
+            : [];
+        const preferredPrimaryTitle =
+          isAmbiguousAnimeSeason && this.animeEntry?.title
+            ? this.animeEntry.title
+            : metadata.title;
+        const titlesWithLang =
+          isAmbiguousAnimeSeason && preferredTitles.length > 0
+            ? preferredTitles.map((title, index) => {
+                const existing = metadata.titles?.find(
+                  (t) => t.title === title
+                );
+                if (existing) return existing;
+                return {
+                  title,
+                  language: index === 0 ? metadata.originalLanguage : undefined,
+                  type: 'anime-entry',
+                };
+              })
+            : metadata.titles;
+
         const extendedMetadata: ExtendedMetadata = {
           ...metadata,
+          title: preferredPrimaryTitle,
+          titles: titlesWithLang,
+          year:
+            isAmbiguousAnimeSeason && seasonYear ? seasonYear : metadata.year,
           absoluteEpisode,
           relativeAbsoluteEpisode,
-          seasonYear: this.animeEntry?.animeSeason?.year ?? undefined,
+          seasonYear,
+          logicalSeason,
+          externalSeason,
+          logicalEpisode,
+          externalEpisode,
+          isAmbiguousAnimeSeason,
         };
 
         return extendedMetadata;
@@ -396,12 +468,18 @@ export class StreamContext {
           apiKey: this.userData.tmdbApiKey,
         }).getEpisodeDetails(metadata.tmdbId, seasonNumber, episodeNumber);
       } catch (error) {
-        logger.warn(
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const isIgnorableAnimeEpisodeLookupMiss =
+          this.isAnime && errorMessage.includes('Not Found');
+        logger[isIgnorableAnimeEpisodeLookupMiss ? 'debug' : 'warn'](
           {
             id: this.id,
-            err: error instanceof Error ? error.message : String(error),
+            err: errorMessage,
           },
-          'failed to fetch episode details'
+          isIgnorableAnimeEpisodeLookupMiss
+            ? 'episode details unavailable for anime lookup'
+            : 'failed to fetch episode details'
         );
         return undefined;
       }
@@ -658,6 +736,10 @@ export class StreamContext {
       latestSeason: this._metadata?.seasons
         ? Math.max(...this._metadata.seasons.map((s) => s.season_number))
         : undefined,
+      logicalSeason: this._metadata?.logicalSeason,
+      externalSeason: this._metadata?.externalSeason,
+      logicalEpisode: this._metadata?.logicalEpisode,
+      externalEpisode: this._metadata?.externalEpisode,
       anilistId: this.animeEntry?.mappings?.anilistId,
       malId: this.animeEntry?.mappings?.malId,
       hasSeaDex: !!this._seadex?.allHashes?.size,
@@ -699,6 +781,10 @@ export class StreamContext {
       latestSeason: this._metadata?.seasons
         ? Math.max(...this._metadata.seasons.map((s) => s.season_number))
         : undefined,
+      logicalSeason: this._metadata?.logicalSeason,
+      externalSeason: this._metadata?.externalSeason,
+      logicalEpisode: this._metadata?.logicalEpisode,
+      externalEpisode: this._metadata?.externalEpisode,
       // Anime entry data
       anilistId: this.animeEntry?.mappings?.anilistId,
       malId: this.animeEntry?.mappings?.malId,

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -937,11 +937,25 @@ class StreamFilterer {
       }
 
       if (!parsedId) return true;
-      const requestedSeason = Number.isInteger(Number(parsedId.season))
-        ? Number(parsedId.season)
+      const requestedSeason = Number.isInteger(
+        Number(requestedMetadata?.logicalSeason ?? parsedId.season)
+      )
+        ? Number(requestedMetadata?.logicalSeason ?? parsedId.season)
         : undefined;
-      const requestedEpisode = Number.isInteger(Number(parsedId.episode))
-        ? Number(parsedId.episode)
+      const requestedEpisode = Number.isInteger(
+        Number(requestedMetadata?.logicalEpisode ?? parsedId.episode)
+      )
+        ? Number(requestedMetadata?.logicalEpisode ?? parsedId.episode)
+        : undefined;
+      const externalSeason = Number.isInteger(
+        Number(requestedMetadata?.externalSeason)
+      )
+        ? Number(requestedMetadata?.externalSeason)
+        : undefined;
+      const externalEpisode = Number.isInteger(
+        Number(requestedMetadata?.externalEpisode)
+      )
+        ? Number(requestedMetadata?.externalEpisode)
         : undefined;
 
       if (
@@ -988,13 +1002,33 @@ class StreamFilterer {
         }
       }
 
+      const matchesLogicalSeason = !!(
+        requestedSeason &&
+        seasons &&
+        seasons.length > 0 &&
+        seasons.includes(requestedSeason)
+      );
+      const matchesExternalSeason = !!(
+        externalSeason &&
+        seasons &&
+        seasons.length > 0 &&
+        seasons.includes(externalSeason)
+      );
+
       if (
         requestedSeason &&
         seasons &&
         seasons.length > 0 &&
-        !seasons.includes(requestedSeason)
+        !matchesLogicalSeason
       ) {
         if (
+          matchesExternalSeason &&
+          externalEpisode &&
+          stream.parsedFile?.episodes?.length &&
+          stream.parsedFile.episodes.includes(externalEpisode)
+        ) {
+          // allow if explicit external season/episode tuple matches
+        } else if (
           seasons[0] === 1 &&
           stream.parsedFile?.episodes?.length &&
           requestedMetadata?.absoluteEpisode &&
@@ -1023,6 +1057,12 @@ class StreamFilterer {
         !stream.parsedFile?.episodes?.includes(requestedEpisode)
       ) {
         if (
+          matchesExternalSeason &&
+          externalEpisode &&
+          stream.parsedFile.episodes.includes(externalEpisode)
+        ) {
+          // allow if explicit external season/episode tuple matches
+        } else if (
           requestedMetadata?.absoluteEpisode &&
           stream.parsedFile?.episodes?.includes(
             requestedMetadata.absoluteEpisode

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -1002,28 +1002,36 @@ class StreamFilterer {
         }
       }
 
+      if (
+        requestedSeason === 0 &&
+        stream.parsedFile?.episodes?.length &&
+        !seasons?.includes(0)
+      ) {
+        return false;
+      }
+
       const matchesLogicalSeason = !!(
-        requestedSeason &&
+        requestedSeason !== undefined &&
         seasons &&
         seasons.length > 0 &&
         seasons.includes(requestedSeason)
       );
       const matchesExternalSeason = !!(
-        externalSeason &&
+        externalSeason !== undefined &&
         seasons &&
         seasons.length > 0 &&
         seasons.includes(externalSeason)
       );
 
       if (
-        requestedSeason &&
+        requestedSeason !== undefined &&
         seasons &&
         seasons.length > 0 &&
         !matchesLogicalSeason
       ) {
         if (
           matchesExternalSeason &&
-          externalEpisode &&
+          externalEpisode !== undefined &&
           stream.parsedFile?.episodes?.length &&
           stream.parsedFile.episodes.includes(externalEpisode)
         ) {
@@ -1052,13 +1060,13 @@ class StreamFilterer {
       }
 
       if (
-        requestedEpisode &&
+        requestedEpisode !== undefined &&
         stream.parsedFile?.episodes?.length &&
         !stream.parsedFile?.episodes?.includes(requestedEpisode)
       ) {
         if (
           matchesExternalSeason &&
-          externalEpisode &&
+          externalEpisode !== undefined &&
           stream.parsedFile.episodes.includes(externalEpisode)
         ) {
           // allow if explicit external season/episode tuple matches

--- a/packages/core/src/utils/anime-search.test.ts
+++ b/packages/core/src/utils/anime-search.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { AnimeEntry } from './anime-database.js';
+import {
+  buildAmbiguousAnimeQueryWaves,
+  buildAnimeTitles,
+  calculateLogicalEpisode,
+  extractLogicalSeasonFromTitles,
+  selectAmbiguousAnimeBaseTitles,
+  selectAmbiguousAnimeEntryTitles,
+} from './anime-search.js';
+
+describe('anime search metadata helpers', () => {
+  it('extracts logical season numbers from common anime sequel titles', () => {
+    expect(
+      extractLogicalSeasonFromTitles(['Bungo Stray Dogs 4th Season'])
+    ).toBe(4);
+    expect(extractLogicalSeasonFromTitles(['Frieren Season 2'])).toBe(2);
+    expect(extractLogicalSeasonFromTitles(['Example Anime III Season'])).toBe(
+      3
+    );
+    expect(
+      extractLogicalSeasonFromTitles(['Example Anime Final Season Part 2'])
+    ).toBeUndefined();
+  });
+
+  it('converts external episode numbers to entry-relative logical episodes', () => {
+    const animeEntry = {
+      type: 'TV',
+      tmdb: { seasonNumber: 3, seasonId: 1, fromEpisode: 14 },
+      tvdb: { seasonNumber: 3, seasonId: 1 },
+    } as unknown as AnimeEntry;
+
+    expect(calculateLogicalEpisode(14, animeEntry)).toBe(1);
+    expect(calculateLogicalEpisode(25, animeEntry)).toBe(12);
+  });
+
+  it('keeps sequel-specific titles while deriving base-title search candidates', () => {
+    const animeEntry = {
+      title: 'Bungo Stray Dogs 4th Season',
+      synonyms: ['Bungou Stray Dogs 4th Season'],
+      type: 'TV',
+      tmdb: { seasonNumber: 3, seasonId: 1 },
+      tvdb: { seasonNumber: 3, seasonId: 1 },
+    } as unknown as AnimeEntry;
+
+    const titles = buildAnimeTitles(animeEntry, 'Bungo Stray Dogs', 4, 2023);
+
+    expect(titles).toContain('Bungo Stray Dogs 4th Season');
+    expect(
+      selectAmbiguousAnimeBaseTitles({
+        primaryTitle: titles[0],
+        titles,
+        externalTitle: 'Bungo Stray Dogs',
+        logicalSeason: 4,
+        seasonYear: 2023,
+      })
+    ).toContain('Bungo Stray Dogs');
+    expect(
+      selectAmbiguousAnimeEntryTitles({
+        primaryTitle: titles[0],
+        titles,
+      })
+    ).toContain('Bungo Stray Dogs 4th Season');
+  });
+
+  it('builds bounded Bungo-style query waves for split-cour anime entries', () => {
+    const waves = buildAmbiguousAnimeQueryWaves({
+      primaryTitle: 'Bungo Stray Dogs 4th Season',
+      titles: ['Bungo Stray Dogs 4th Season', 'Bungou Stray Dogs 4th Season'],
+      externalTitle: 'Bungo Stray Dogs',
+      externalTitles: ['Bungo Stray Dogs'],
+      logicalSeason: 4,
+      logicalEpisode: 1,
+      seasonYear: 2023,
+    });
+
+    expect(waves).toEqual([
+      ['Bungo Stray Dogs S04E01', 'Bungo Stray Dogs S04'],
+      [
+        'Bungo Stray Dogs 4th Season 01',
+        'Bungo Stray Dogs 4th Season E01',
+        'Bungou Stray Dogs 4th Season 01',
+        'Bungou Stray Dogs 4th Season E01',
+      ],
+    ]);
+  });
+});

--- a/packages/core/src/utils/anime-search.test.ts
+++ b/packages/core/src/utils/anime-search.test.ts
@@ -19,6 +19,12 @@ describe('anime search metadata helpers', () => {
       3
     );
     expect(
+      extractLogicalSeasonFromTitles([
+        'Example Anime XI Season',
+        'Example Anime 4th Season',
+      ])
+    ).toBe(4);
+    expect(
       extractLogicalSeasonFromTitles(['Example Anime Final Season Part 2'])
     ).toBeUndefined();
   });
@@ -56,6 +62,17 @@ describe('anime search metadata helpers', () => {
       })
     ).toContain('Bungo Stray Dogs');
     expect(
+      selectAmbiguousAnimeBaseTitles({
+        primaryTitle: 'Bungo Stray Dogs 4th Season',
+        titles: [
+          'Bungo Stray Dogs 4th Season',
+          'Bungo Stray Dogs Season 4',
+          'Bungou Stray Dogs 4th Season',
+        ],
+        logicalSeason: 4,
+      })
+    ).toEqual(['Bungo Stray Dogs', 'Bungou Stray Dogs']);
+    expect(
       selectAmbiguousAnimeEntryTitles({
         primaryTitle: titles[0],
         titles,
@@ -75,7 +92,12 @@ describe('anime search metadata helpers', () => {
     });
 
     expect(waves).toEqual([
-      ['Bungo Stray Dogs S04E01', 'Bungo Stray Dogs S04'],
+      [
+        'Bungo Stray Dogs S04E01',
+        'Bungo Stray Dogs S04',
+        'Bungou Stray Dogs S04E01',
+        'Bungou Stray Dogs S04',
+      ],
       [
         'Bungo Stray Dogs 4th Season 01',
         'Bungo Stray Dogs 4th Season E01',

--- a/packages/core/src/utils/anime-search.test.ts
+++ b/packages/core/src/utils/anime-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { AnimeEntry } from './anime-database.js';
+import type { AnimeEntry } from '../anime-database/index.js';
 import {
   buildAmbiguousAnimeQueryWaves,
   buildAnimeTitles,

--- a/packages/core/src/utils/anime-search.ts
+++ b/packages/core/src/utils/anime-search.ts
@@ -53,7 +53,8 @@ export function extractLogicalSeasonFromTitles(
 
     const romanMatch = title.match(/\b([IVX]+)\s+season\b/i);
     if (romanMatch) {
-      return ROMAN_NUMERALS[romanMatch[1].toUpperCase()];
+      const season = ROMAN_NUMERALS[romanMatch[1].toUpperCase()];
+      if (season !== undefined) return season;
     }
   }
   return undefined;
@@ -190,7 +191,7 @@ export function selectAmbiguousAnimeBaseTitles(
   metadata: AmbiguousAnimeTitleMetadata,
   maxTitles = 2
 ): string[] {
-  return dedupeCleanTitles([
+  const stripped = dedupeCleanTitles([
     metadata.externalTitle,
     ...(metadata.externalTitles ?? []),
     metadata.primaryTitle,
@@ -203,8 +204,9 @@ export function selectAmbiguousAnimeBaseTitles(
         metadata.seasonYear
       )
     )
-    .filter(isLatinSearchTitle)
-    .slice(0, maxTitles);
+    .filter(isLatinSearchTitle);
+
+  return dedupeCleanTitles(stripped).slice(0, maxTitles);
 }
 
 export function selectAmbiguousAnimeEntryTitles(

--- a/packages/core/src/utils/anime-search.ts
+++ b/packages/core/src/utils/anime-search.ts
@@ -1,4 +1,4 @@
-import type { AnimeEntry } from './anime-database.js';
+import type { AnimeEntry } from '../anime-database/index.js';
 
 const SEASON_WORD_PATTERNS = [
   'season',

--- a/packages/core/src/utils/anime-search.ts
+++ b/packages/core/src/utils/anime-search.ts
@@ -1,0 +1,260 @@
+import type { AnimeEntry } from './anime-database.js';
+
+const SEASON_WORD_PATTERNS = [
+  'season',
+  'staffel',
+  'saison',
+  'sezon',
+  'temporada',
+];
+
+const ROMAN_NUMERALS: Record<string, number> = {
+  I: 1,
+  II: 2,
+  III: 3,
+  IV: 4,
+  V: 5,
+  VI: 6,
+  VII: 7,
+  VIII: 8,
+  IX: 9,
+  X: 10,
+};
+
+function cleanSearchTitle(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export interface AmbiguousAnimeTitleMetadata {
+  primaryTitle?: string;
+  titles?: string[];
+  externalTitle?: string;
+  externalTitles?: string[];
+  logicalSeason?: number;
+  seasonYear?: number;
+}
+
+export function extractLogicalSeasonFromTitles(
+  titles: Array<string | undefined | null>
+): number | undefined {
+  for (const rawTitle of titles) {
+    if (!rawTitle) continue;
+    const title = rawTitle.toString();
+
+    const ordinalMatch = title.match(/\b(\d+)(?:st|nd|rd|th)\s+season\b/i);
+    if (ordinalMatch) return Number(ordinalMatch[1]);
+
+    for (const seasonWord of SEASON_WORD_PATTERNS) {
+      const match = title.match(
+        new RegExp(`\\b${seasonWord}\\s+(\\d+)\\b`, 'i')
+      );
+      if (match) return Number(match[1]);
+    }
+
+    const romanMatch = title.match(/\b([IVX]+)\s+season\b/i);
+    if (romanMatch) {
+      return ROMAN_NUMERALS[romanMatch[1].toUpperCase()];
+    }
+  }
+  return undefined;
+}
+
+export function getAnimeEntryStartEpisode(
+  animeEntry?: AnimeEntry | null
+): number | undefined {
+  const raw =
+    animeEntry?.imdb?.fromEpisode ??
+    animeEntry?.tvdb?.fromEpisode ??
+    animeEntry?.tmdb?.fromEpisode;
+
+  if (raw === undefined || raw === null) return undefined;
+
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+export function calculateLogicalEpisode(
+  externalEpisode?: number,
+  animeEntry?: AnimeEntry | null
+): number | undefined {
+  if (!externalEpisode) return externalEpisode;
+
+  const fromEpisode = getAnimeEntryStartEpisode(animeEntry);
+  if (!fromEpisode || fromEpisode <= 1 || externalEpisode < fromEpisode) {
+    return externalEpisode;
+  }
+
+  return externalEpisode - fromEpisode + 1;
+}
+
+export function dedupeCleanTitles(values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const title = cleanSearchTitle(String(value ?? ''));
+    if (!title) continue;
+
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    result.push(title);
+  }
+
+  return result;
+}
+
+export function buildAnimeTitles(
+  animeEntry: AnimeEntry | null | undefined,
+  fallbackTitle: string | undefined,
+  logicalSeason?: number,
+  seasonYear?: number | null
+): string[] {
+  const titles = dedupeCleanTitles([
+    animeEntry?.title,
+    ...(animeEntry?.synonyms ?? []),
+    fallbackTitle,
+  ]);
+
+  if (!logicalSeason) return titles;
+
+  const seasonRegex = new RegExp(
+    `\\b(${logicalSeason}(?:st|nd|rd|th)?\\s+season|season\\s+${logicalSeason}|s${logicalSeason}\\b|cour\\s+${logicalSeason}|part\\s+${logicalSeason}|staffel\\s+${logicalSeason}|saison\\s+${logicalSeason}|sezon\\s+${logicalSeason}|temporada\\s+${logicalSeason})`,
+    'i'
+  );
+  const explicitTitles = titles.filter((title) => seasonRegex.test(title));
+  const yearTitles = seasonYear
+    ? titles.filter(
+        (title) =>
+          title.includes(`(${seasonYear})`) || title.includes(` ${seasonYear}`)
+      )
+    : [];
+
+  const filtered = dedupeCleanTitles([
+    animeEntry?.title,
+    ...explicitTitles,
+    ...yearTitles,
+    fallbackTitle,
+  ]);
+
+  return filtered.length > 0 ? filtered : titles;
+}
+
+export function stripAnimeSeasonQualifier(
+  title: string,
+  logicalSeason?: number,
+  seasonYear?: number
+): string {
+  let value = cleanSearchTitle(title);
+  if (!value) return '';
+
+  if (seasonYear) {
+    value = value
+      .replace(new RegExp(`\\s*\\(${seasonYear}\\)\\s*$`, 'i'), '')
+      .replace(new RegExp(`\\s+${seasonYear}\\s*$`, 'i'), '');
+  }
+
+  if (logicalSeason) {
+    const season = logicalSeason.toString();
+    const paddedSeason = season.padStart(2, '0');
+    const patterns = [
+      `\\b${season}(?:st|nd|rd|th)\\s+season\\b`,
+      `\\bseason\\s+${season}\\b`,
+      `\\bs${season}\\b`,
+      `\\bs${paddedSeason}\\b`,
+      `\\bcour\\s+${season}\\b`,
+      `\\bpart\\s+${season}\\b`,
+      `\\bstaffel\\s+${season}\\b`,
+      `\\bsaison\\s+${season}\\b`,
+      `\\bsezon\\s+${season}\\b`,
+      `\\btemporada\\s+${season}\\b`,
+    ];
+
+    for (const pattern of patterns) {
+      value = value.replace(new RegExp(pattern, 'gi'), '');
+    }
+  }
+
+  return cleanSearchTitle(
+    value.replace(/\s*[:|/\\._-]+\s*$/g, '').replace(/\s{2,}/g, ' ')
+  );
+}
+
+export function isLatinSearchTitle(title: string): boolean {
+  const folded = title.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  return /[a-z]/i.test(folded);
+}
+
+export function selectAmbiguousAnimeBaseTitles(
+  metadata: AmbiguousAnimeTitleMetadata,
+  maxTitles = 2
+): string[] {
+  return dedupeCleanTitles([
+    metadata.externalTitle,
+    ...(metadata.externalTitles ?? []),
+    metadata.primaryTitle,
+    ...(metadata.titles ?? []),
+  ])
+    .map((title) =>
+      stripAnimeSeasonQualifier(
+        title,
+        metadata.logicalSeason,
+        metadata.seasonYear
+      )
+    )
+    .filter(isLatinSearchTitle)
+    .slice(0, maxTitles);
+}
+
+export function selectAmbiguousAnimeEntryTitles(
+  metadata: AmbiguousAnimeTitleMetadata,
+  maxTitles = 2
+): string[] {
+  return dedupeCleanTitles([metadata.primaryTitle, ...(metadata.titles ?? [])])
+    .filter(isLatinSearchTitle)
+    .slice(0, maxTitles);
+}
+
+export function buildAmbiguousAnimeQueryWaves(
+  metadata: AmbiguousAnimeTitleMetadata & {
+    logicalEpisode?: number;
+  },
+  options: { maxBaseTitles?: number; maxEntryTitles?: number } = {}
+): string[][] {
+  if (!metadata.logicalSeason || !metadata.logicalEpisode) {
+    return [];
+  }
+
+  const logicalSeason = Number(metadata.logicalSeason);
+  const logicalEpisode = Number(metadata.logicalEpisode);
+  if (!Number.isFinite(logicalSeason) || !Number.isFinite(logicalEpisode)) {
+    return [];
+  }
+
+  const season = logicalSeason.toString().padStart(2, '0');
+  const episode = logicalEpisode.toString().padStart(2, '0');
+  const baseTitles = selectAmbiguousAnimeBaseTitles(
+    metadata,
+    options.maxBaseTitles ?? 2
+  );
+  const entryTitles = selectAmbiguousAnimeEntryTitles(
+    metadata,
+    options.maxEntryTitles ?? 2
+  );
+
+  const wave1 = dedupeCleanTitles(
+    baseTitles.flatMap((title) => [
+      `${title} S${season}E${episode}`,
+      `${title} S${season}`,
+    ])
+  );
+  const wave2 = dedupeCleanTitles(
+    entryTitles.flatMap((title) => [
+      `${title} ${episode}`,
+      `${title} E${episode}`,
+    ])
+  );
+
+  return [wave1, wave2].filter((wave) => wave.length > 0);
+}

--- a/packages/core/src/utils/id-parser.test.ts
+++ b/packages/core/src/utils/id-parser.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { IdParser, parseStremioCoordinate } from './id-parser.js';
+
+describe('stremio coordinate parsing', () => {
+  it('keeps season zero for Specials', () => {
+    expect(parseStremioCoordinate('0')).toBe(0);
+    expect(parseStremioCoordinate(0)).toBe(0);
+
+    const parsed = IdParser.parse('tt5679720:0:1', 'series');
+    expect(parsed?.season).toBe('0');
+    expect(parsed?.episode).toBe('1');
+  });
+
+  it('rejects malformed coordinates instead of returning NaN', () => {
+    expect(parseStremioCoordinate('*')).toBeUndefined();
+    expect(parseStremioCoordinate('abc')).toBeUndefined();
+    expect(parseStremioCoordinate('-1')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/id-parser.ts
+++ b/packages/core/src/utils/id-parser.ts
@@ -47,6 +47,15 @@ export interface ParsedId {
   ) => string;
 }
 
+export function parseStremioCoordinate(
+  value: number | string | undefined
+): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const numeric = Number(value);
+  // Stremio uses season 0 for Specials, so valid coordinates are non-negative.
+  return Number.isInteger(numeric) && numeric >= 0 ? numeric : undefined;
+}
+
 interface IdParserDefinition {
   type: IdType;
   externalType: ExternalIdType;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -23,6 +23,7 @@ export * from '../poster/index.js';
 export * from './distributed-lock.js';
 export * from './id-parser.js';
 export * from '../anime-database/index.js';
+export * from './anime-search.js';
 export * from './regex.js';
 export * from './general.js';
 export * from './seadex.js';


### PR DESCRIPTION
## Summary

Fix anime stream matching for split-cour / sequel entries where the Stremio request ID uses one external season number, but anime databases and release titles identify the requested content as a later logical season or cour.

The motivating case is *Bungo Stray Dogs*: Stremio metadata can expose three seasons, while anime trackers commonly list the same later episodes as separate 4th and 5th season entries. Requests such as `tt5679720:3:*` can therefore need streams titled `Bungo Stray Dogs 4th Season` / `Bungo Stray Dogs 5th Season`, not generic season 3 releases.

## Problem

AIOStreams currently treats `season` / `episode` as a single coordinate system. That works for most TV metadata, but it breaks when anime metadata has two valid coordinate systems:

- External request coordinates from Stremio / IMDb / TMDB / TVDB, for example `tt5679720:3:14`.
- Logical anime entry coordinates from anime mappings and release titles, for example `Bungo Stray Dogs 4th Season`, episode 1.

When those are collapsed into one value, several downstream stages can become incorrect:

- Search queries may ask indexers for the external season instead of the anime sequel title or logical season.
- Season/episode filtering may discard otherwise correct releases because parsed files contain logical season numbers.
- Broad query fanout can over-query Torznab/Newznab endpoints when the first query form does not match.
- Repeated 429 responses can continue to be retried immediately instead of backing off.

## Approach

This PR preserves both coordinate systems instead of replacing one with the other:

- `logicalSeason` / `logicalEpisode`: anime-entry numbering inferred from anime entry titles and episode offsets.
- `externalSeason` / `externalEpisode`: original request coordinates from the parsed Stremio ID.
- Stream selection and debrid metadata can use logical coordinates where that is necessary, while formatter/expression contexts expose logical and external values explicitly.

For ambiguous anime seasons, the search metadata now keeps sequel-specific anime titles and marks the request for query search. Nab-based addons then use bounded query waves:

1. Base title + logical `SxxExx` / `Sxx`.
2. Anime entry title + logical episode forms.

The second wave only runs if the first wave returns no results. This keeps the fix targeted without spraying every possible title/episode variant at indexers.

If query search is required but the selected Nab search function does not support `q`, the request now fails fast instead of issuing a broad unqualified search.

## Nab rate-limit handling

Torznab/Newznab APIs now track endpoint-level 429 cooldowns. During cooldown:

- cached search results can still be returned without refresh;
- uncached searches fail fast with a rate-limit error;
- query batches stop treating 429s as an invitation to continue fanout.

This is intentionally generic and applies to Nab endpoints broadly, not to one indexer-specific workaround.

## Filtering and expressions

Season/episode filtering now prefers logical anime coordinates while still allowing an exact external season/episode tuple when a release is parsed that way.

Formatter and expression contexts also expose the explicit logical/external values, so advanced users can reason about either coordinate system without overloading `season` and `episode`.

## Validation

Added deterministic unit coverage for the pure anime search helpers:

- extracts logical seasons from sequel titles such as `4th Season`, `Season 2`, and roman numeral forms;
- converts external episode offsets into entry-relative logical episodes;
- keeps sequel-specific titles while deriving base-title candidates for bounded query search.
- verifies Bungo-style split-cour query waves such as `Bungo Stray Dogs S04E01` and `Bungo Stray Dogs 4th Season 01`.

Validated locally with:

```bash
pnpm -F core test
pnpm -F core run build
```

No tests call live indexers or content endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved anime season/episode handling by distinguishing logical vs external numbering for more accurate ambiguous-release searches.
  * Added logical/external season/episode metadata support across parsing, formatter and expression contexts.
  * Enhanced debrid query generation with configurable season/episode query variants, deduped/cleaned titles, and bounded “max titles” behavior.
  * Upgraded NAB searching with optional prefer-query-search routing, wave-based query progression, and explicit rate-limit handling with retry timing.

* **Bug Fixes**
  * Preserved valid Stremio coordinate value `0` and improved season/episode matching when external season data is present.

* **Tests**
  * Added/extended Vitest coverage for anime search metadata helpers and Stremio coordinate parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->