### PR TITLE
feat: include finished group results on early exit

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -660,6 +660,7 @@ export const UserDataSchema = z.object({
         )
         .optional(),
       behaviour: z.enum(['sequential', 'parallel']).optional(),
+      includeFinishedResultsOnEarlyExit: z.boolean().optional(),
     })
     .optional(),
   sortCriteria: z.object({

--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -11,7 +11,7 @@ import { ZodError } from 'zod';
 import { PASSTHROUGH_STAGES } from '../utils/constants.js';
 import { parseBitrate } from './utils.js';
 import { createLogger } from '../logging/logger.js';
-import { ExpressionContext } from '../streams/context.js';
+import type { ExpressionContext } from '../streams/context.js';
 import { formRegexFromKeywordsSync } from '../utils/regex.js';
 
 const logger = createLogger('stream-expression');

--- a/packages/core/src/streams/fetcher.ts
+++ b/packages/core/src/streams/fetcher.ts
@@ -13,7 +13,7 @@ import {
 import StreamFilter from './filterer.js';
 import StreamPrecompute from './precomputer.js';
 import StreamDeduplicator from './deduplicator.js';
-import { StreamContext } from './context.js';
+import type { StreamContext } from './context.js';
 import {
   classifyAddonError,
   type AnalyticsDisposition,
@@ -481,6 +481,8 @@ class StreamFetcher {
       }
 
       const behaviour = this.userData.groups.behaviour || 'parallel';
+      const includeFinishedResultsOnEarlyExit =
+        this.userData.groups.includeFinishedResultsOnEarlyExit ?? false;
       let totalTimeTaken = 0;
       let previousGroupStreams: ParsedStream[] = [];
       let previousGroupTimeTaken = 0;
@@ -499,20 +501,34 @@ class StreamFetcher {
           return fetchAndProcessAddons(groupAddons);
         });
 
+        const mergedGroups = new Set<number>();
+
+        const mergeGroupResult = (
+          index: number,
+          groupResult:
+            | Awaited<ReturnType<typeof fetchAndProcessAddons>>
+            | null
+            | undefined
+        ) => {
+          if (!groupResult || mergedGroups.has(index)) return;
+          allStreams.push(...groupResult.streams);
+          allErrors.push(...groupResult.errors);
+          allStatisticStreams.push(...groupResult.statistics);
+          totalTimeTaken = Math.max(totalTimeTaken, groupResult.totalTime);
+          previousGroupStreams = groupResult.streams;
+          previousGroupTimeTaken = groupResult.totalTime;
+          mergedGroups.add(index);
+        };
+
         for (let i = 0; i < this.userData.groups.groupings.length; i++) {
           const groupPromise = groupPromises[i];
 
           if (i === 0) {
             const groupResult = await groupPromise;
-            if (!groupResult) continue;
-            allStreams.push(...groupResult.streams);
-            allErrors.push(...groupResult.errors);
-            allStatisticStreams.push(...groupResult.statistics);
-            totalTimeTaken = groupResult.totalTime;
-            previousGroupStreams = groupResult.streams;
-            previousGroupTimeTaken = groupResult.totalTime;
+            mergeGroupResult(i, groupResult);
             continue;
           }
+
           // For groups other than the first, check their condition
           const group = this.userData.groups.groupings[i];
           if (!group.condition || !group.addons.length) continue;
@@ -534,18 +550,27 @@ class StreamFetcher {
               'condition met for parallel group, awaiting results'
             );
             const groupResult = await groupPromise;
-            if (!groupResult) continue;
-            allStreams.push(...groupResult.streams);
-            allErrors.push(...groupResult.errors);
-            allStatisticStreams.push(...groupResult.statistics);
-            totalTimeTaken = Math.max(totalTimeTaken, groupResult.totalTime);
-            previousGroupStreams = groupResult.streams;
-            previousGroupTimeTaken = groupResult.totalTime;
+            mergeGroupResult(i, groupResult);
           } else {
             logger.debug(
-              { group: i + 1 },
-              'condition not met for parallel group, skipping remaining groups'
+              { group: i + 1, includeFinishedResultsOnEarlyExit },
+              'condition not met for parallel group'
             );
+
+            if (includeFinishedResultsOnEarlyExit) {
+              const settledResults = await Promise.all(
+                groupPromises
+                  .slice(i)
+                  .map((p) => Promise.race([p, Promise.resolve()]))
+              );
+
+              settledResults.forEach((result, offset) => {
+                if (!result) return;
+                const absoluteIndex = i + offset;
+                mergeGroupResult(absoluteIndex, result);
+              });
+            }
+
             // exit early.
             break;
           }

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -23,7 +23,7 @@ import { partial_ratio } from 'fuzzball';
 import { formatBitrate, formatBytes } from '../formatters/utils.js';
 import { iso6391ToLanguage } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
-import { StreamContext, ExtendedMetadata } from './context.js';
+import type { ExtendedMetadata, StreamContext } from './context.js';
 
 const logger = createLogger('filterer');
 

--- a/packages/core/src/streams/precomputer.ts
+++ b/packages/core/src/streams/precomputer.ts
@@ -10,7 +10,7 @@ import {
   StreamSelector,
   extractNamesFromExpression,
 } from '../parser/streamExpression.js';
-import { StreamContext } from './context.js';
+import type { StreamContext } from './context.js';
 
 const logger = createLogger('precomputer');
 

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -541,6 +541,7 @@ export function applyMigrations(config: any): UserData {
       enabled: config.disableGroups ? false : true,
       groupings: config.groups,
       behaviour: 'parallel',
+      includeFinishedResultsOnEarlyExit: false,
     };
   }
 

--- a/packages/docs/content/docs/guides/groups.mdx
+++ b/packages/docs/content/docs/guides/groups.mdx
@@ -26,13 +26,14 @@ The **Grouping** feature lets you control _when_ different sets of your addons a
   </Step>
   <Step>
     **Evaluate as results arrive** — as soon as Group 1 responds, AIOStreams
-    evaluates Group 2's condition: 
-      - If the condition is `false`, Group 2 (and all subsequent groups) are skipped immediately. 
+    evaluates Group 2's condition:
+      - If the condition is `false`, Group 2 (and all subsequent groups) are skipped immediately by default.
+      - If **Always add results from finished queries** is enabled, AIOStreams still exits early, but Group 2 and any subsequent groups that have already completed are included.
       - If `true`, Group 2's results are included and Group 3's condition is evaluated next.
   </Step>
   <Step>
     **Early exit** — the moment a group's condition is `false`, all pending
-    results beyond that point are discarded.
+    results beyond that point are discarded by default.
   </Step>
 </Steps>
 
@@ -91,6 +92,17 @@ queryType == "series" and count(resolution(totalStreams, '1080p')) < 2
 ```
 count(resolution(previousStreams, '2160p')) == 0 or previousGroupTimeTaken > 5000
 ```
+
+### Parallel option: finished results
+
+When using **Parallel** group behavior, you can enable **Always add results from finished queries**.
+
+With this option enabled:
+
+- AIOStreams still evaluates group conditions in order.
+- A failed condition still stops waiting for later groups.
+- The failed-condition group and any later groups that have already finished by that moment are still included.
+- Later groups that are still pending are not waited on.
 
 ---
 

--- a/packages/frontend/src/components/menu/addons/_components/addon-fetching-behavior.tsx
+++ b/packages/frontend/src/components/menu/addons/_components/addon-fetching-behavior.tsx
@@ -5,6 +5,7 @@ import { Select } from '../../../ui/select';
 import { TextInput } from '../../../ui/text-input';
 import { Combobox } from '../../../ui/combobox';
 import { IconButton } from '../../../ui/button';
+import { Switch } from '../../../ui/switch';
 import { FaPlus, FaRegTrashAlt, FaArrowUp, FaArrowDown } from 'react-icons/fa';
 import { arrayMove } from '@dnd-kit/sortable';
 
@@ -137,6 +138,25 @@ export function AddonFetchingBehaviorCard() {
                 : "Parallel: Begin fetching from all groups simultaneously. When group 1's results arrive, evaluate group 2's condition. If true, wait for group 2's results; if false, return results without waiting."
             }
           />
+
+          {userData.groups?.behaviour === 'parallel' && (
+            <Switch
+              label="Always add results from finished queries"
+              value={
+                userData.groups?.includeFinishedResultsOnEarlyExit ?? false
+              }
+              onValueChange={(value) => {
+                setUserData((prev) => ({
+                  ...prev,
+                  groups: {
+                    ...prev.groups,
+                    includeFinishedResultsOnEarlyExit: value,
+                  },
+                }));
+              }}
+              help="If a group condition fails during parallel fetching, still include results from that group or later groups if they have already finished. Unfinished groups are not waited on."
+            />
+          )}
 
           {(() => {
             const handleGroupsChange = (newGroups: any[]) => {

--- a/packages/frontend/src/context/userData.tsx
+++ b/packages/frontend/src/context/userData.tsx
@@ -75,6 +75,7 @@ export function applyMigrations(config: any): UserData {
       enabled: config.disableGroups ? false : true,
       groupings: config.groups,
       behaviour: 'parallel',
+      includeFinishedResultsOnEarlyExit: false,
     };
   }
 


### PR DESCRIPTION
## Summary
- add a parallel group option to include already-finished group queries when an early-exit condition fails
- persist/validate the new group setting and expose it in the addon fetching UI
- document the parallel finished-results behavior
- convert a few StreamContext/ExpressionContext imports to type-only imports while reviewing testability

## Suggested follow-up tests
- Core: add a focused parallel-groups test with three mocked addon timings to assert default early exit excludes settled fallback results and the new flag includes only already-settled results.
- Frontend: add a small component test for the switch only if/when the frontend has an existing React component test harness; currently typecheck/build coverage is the lightweight fit.

## Verification
- pnpm -F core run build
- pnpm -F frontend typecheck
- pnpm -F frontend run build
- git diff --check

Note: commands ran under Node v22.21.0, so pnpm printed the repo's Node >=24 engine warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added "Always add results from finished queries" option for parallel group fetching. When enabled, results from completed queries are included in the output even if a group condition fails partway through execution, rather than discarding pending results entirely.

**Documentation**
* Updated group fetching documentation to clarify behaviour when group conditions evaluate to false and explain the impact of the new finished results option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->