### PR TITLE
Disable deprecated addons

### DIFF
--- a/packages/core/src/presets/debridioTv.ts
+++ b/packages/core/src/presets/debridioTv.ts
@@ -129,6 +129,11 @@ export class DebridioTvPreset extends Preset {
       OPTIONS: options,
       SUPPORTED_STREAM_TYPES: [constants.LIVE_STREAM_TYPE],
       SUPPORTED_RESOURCES: supportedResources,
+      DISABLED: {
+        removed: true,
+        disabled: true,
+        reason: 'Debridio TV addon is deprecated.',
+      },
     };
   }
 

--- a/packages/core/src/presets/usaTv.ts
+++ b/packages/core/src/presets/usaTv.ts
@@ -86,6 +86,11 @@ export class USATVPreset extends Preset {
       OPTIONS: options,
       SUPPORTED_STREAM_TYPES: [LIVE_STREAM_TYPE],
       SUPPORTED_RESOURCES: supportedResources,
+      DISABLED: {
+        removed: true,
+        disabled: true,
+        reason: 'USA TV addon is deprecated.',
+      },
     };
   }
 


### PR DESCRIPTION
Disable Debridio TV and USA TV addons due to deprecation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Deprecations
* Debridio TV addon has been deprecated and is now disabled
* USA TV addon has been deprecated and is now disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->