### PR TITLE
feat(proxy): auto-proxy internal addon endpoints and subtitle URLs

### DIFF
--- a/packages/core/src/config/schema/proxy.ts
+++ b/packages/core/src/config/schema/proxy.ts
@@ -133,7 +133,7 @@ export const proxySchema = {
       default: null as string[] | null,
       label: 'Default proxied services',
       description:
-        'List of serviceIds to proxy by default. JSON array of strings.',
+        'List of serviceIds to proxy by default. Use `subtitle` to proxy subtitle URLs. JSON array of strings.',
       env: 'DEFAULT_PROXY_PROXIED_SERVICES',
       requiresRestart: false,
       secret: false,
@@ -208,7 +208,8 @@ export const proxySchema = {
       schema: proxiedServicesList,
       default: null as string[] | null,
       label: 'Forced proxied services',
-      description: 'List of serviceIds to force-proxy. JSON array of strings.',
+      description:
+        'List of serviceIds to force-proxy. Use `subtitle` to proxy subtitle URLs. JSON array of strings.',
       env: 'FORCE_PROXY_PROXIED_SERVICES',
       requiresRestart: false,
       secret: false,

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -6,6 +6,7 @@ import {
   Env,
   ExtrasParser,
   getSimpleTextHash,
+  isInternalEndpoint,
   makeUrlLogSafe,
 } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
@@ -47,6 +48,7 @@ import {
   type AnalyticsServiceBreakdown,
 } from '../analytics/index.js';
 import type { AddonDispositionMap } from '../streams/fetcher.js';
+import { createProxy } from '../proxy/index.js';
 
 const logger = createLogger('core');
 
@@ -1085,6 +1087,87 @@ export async function getSubtitles(
   );
   let allSubtitles: Subtitle[] = [];
 
+  const proxifyAddonSubtitles = async (
+    addon: Addon,
+    subtitles: Subtitle[]
+  ): Promise<Subtitle[]> => {
+    const proxy = ctx.userData.proxy;
+    if (!proxy?.enabled || !proxy.url || subtitles.length === 0) {
+      return subtitles;
+    }
+
+    let proxyUrl: URL;
+    try {
+      proxyUrl = new URL(proxy.url);
+    } catch {
+      return subtitles;
+    }
+
+    const shouldProxySubtitle = (subtitle: Subtitle): boolean => {
+      let subtitleUrl: URL;
+      try {
+        subtitleUrl = new URL(subtitle.url);
+      } catch {
+        return false;
+      }
+
+      if (subtitleUrl.host === proxyUrl.host) {
+        return false;
+      }
+
+      const isInternalHttpSubtitle =
+        subtitleUrl.protocol === 'http:' && isInternalEndpoint(subtitleUrl);
+      if (isInternalHttpSubtitle) {
+        return true;
+      }
+
+      const proxyAddon =
+        !proxy.proxiedAddons?.length ||
+        proxy.proxiedAddons.includes(addon.preset.id);
+      const proxyService =
+        !proxy.proxiedServices?.length ||
+        proxy.proxiedServices.includes('subtitle') ||
+        proxy.proxiedServices.includes('subtitles');
+
+      return proxyAddon && proxyService;
+    };
+
+    const proxyTargets = subtitles
+      .map((subtitle, index) => ({ subtitle, index }))
+      .filter(({ subtitle }) => shouldProxySubtitle(subtitle));
+
+    if (proxyTargets.length === 0) {
+      return subtitles;
+    }
+
+    const proxiedUrls = await createProxy(proxy).generateUrls(
+      proxyTargets.map(({ subtitle }) => ({
+        url: subtitle.url,
+        type: 'stream',
+      }))
+    );
+
+    if (!proxiedUrls || 'error' in proxiedUrls) {
+      errors.push({
+        title: 'Proxifier Error',
+        description:
+          proxiedUrls && 'error' in proxiedUrls
+            ? proxiedUrls.error
+            : 'Failed to proxy subtitle URLs',
+      });
+      return subtitles;
+    }
+
+    const updated = [...subtitles];
+    proxyTargets.forEach(({ index }, i) => {
+      const proxiedUrl = proxiedUrls[i];
+      if (proxiedUrl) {
+        updated[index] = { ...updated[index], url: proxiedUrl };
+      }
+    });
+    return updated;
+  };
+
   await Promise.all(
     supportedAddons.map(async (addon) => {
       try {
@@ -1093,7 +1176,10 @@ export async function getSubtitles(
           id,
           parsedExtras.toString()
         );
-        if (subtitles) allSubtitles.push(...subtitles);
+        if (subtitles) {
+          const proxiedSubtitles = await proxifyAddonSubtitles(addon, subtitles);
+          allSubtitles.push(...proxiedSubtitles);
+        }
       } catch (error) {
         errors.push({
           title: `[❌] ${getAddonName(addon)}`,

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -1140,12 +1140,28 @@ export async function getSubtitles(
       return subtitles;
     }
 
-    const proxiedUrls = await createProxy(proxy).generateUrls(
-      proxyTargets.map(({ subtitle }) => ({
-        url: subtitle.url,
-        type: 'stream',
-      }))
-    );
+    const proxiedUrls = await (async () => {
+      try {
+        return await createProxy(proxy).generateUrls(
+          proxyTargets.map(({ subtitle }) => ({
+            url: subtitle.url,
+            type: 'stream',
+          }))
+        );
+      } catch (error) {
+        // A rejected generateUrls would otherwise bubble to the addon-level
+        // catch and drop the subtitles we already fetched. Keep the originals.
+        errors.push({
+          title: 'Proxifier Error',
+          description: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    })();
+
+    if (proxiedUrls === null) {
+      return subtitles;
+    }
 
     if (!proxiedUrls || 'error' in proxiedUrls) {
       errors.push({

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -1111,7 +1111,13 @@ export async function getSubtitles(
         return false;
       }
 
-      if (subtitleUrl.host === proxyUrl.host) {
+      // Skip only URLs that are already proxy URLs (same host-match logic as
+      // evaluateProxyStream), not every URL that merely shares the proxy host —
+      // an internal subtitle URL on that host still needs proxying.
+      if (
+        subtitleUrl.host === proxyUrl.host &&
+        (proxy.id === 'mediaflow' || subtitleUrl.pathname.includes('/v0/proxy'))
+      ) {
         return false;
       }
 

--- a/packages/core/src/streams/proxifier.ts
+++ b/packages/core/src/streams/proxifier.ts
@@ -1,6 +1,6 @@
 import { config as appConfig } from '../config/index.js';
 import { ParsedStream, StreamProxyConfig, UserData } from '../db/schemas.js';
-import { constants, createLogger } from '../utils/index.js';
+import { constants, createLogger, isInternalEndpoint } from '../utils/index.js';
 import { takeBasicAuthFromUrl } from '../utils/http.js';
 import { createProxy } from '../proxy/index.js';
 import { PLAYBACK_PATH_PREFIX } from '../debrid/utils.js';
@@ -71,8 +71,13 @@ export function evaluateProxyStream(
   const proxyService =
     !proxy.proxiedServices?.length ||
     proxy.proxiedServices.includes(streamService);
+  // Auto-proxy internal/container addon endpoints (e.g. http://nzbdav:8080): an
+  // external player can't reach a container hostname or private IP, so route it
+  // through us regardless of the addon/service proxy filters.
+  const isInternalHttpStream =
+    streamUrl.protocol === 'http:' && isInternalEndpoint(streamUrl);
 
-  if (proxy.enabled && proxyAddon && proxyService) {
+  if (proxy.enabled && (isInternalHttpStream || (proxyAddon && proxyService))) {
     return 'proxy';
   }
 

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -462,6 +462,73 @@ export function resolveOverrideHeaders(
   return resolveHeaderPreset(value) ?? { 'User-Agent': value };
 }
 
+export function isInternalEndpoint(url: URL): boolean {
+  const rawHostname = url.hostname.toLowerCase();
+  const hostname =
+    rawHostname.startsWith('[') && rawHostname.endsWith(']')
+      ? rawHostname.slice(1, -1)
+      : rawHostname;
+  const ipv4Match = hostname.match(/^(\d{1,3})(?:\.(\d{1,3})){3}$/);
+  const isIpv4Literal = (() => {
+    if (!ipv4Match) return false;
+    const octets = hostname.split('.').map((v) => Number(v));
+    return octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255);
+  })();
+
+  if (
+    hostname === 'localhost' ||
+    hostname === 'host.docker.internal' ||
+    hostname.endsWith('.local')
+  ) {
+    return true;
+  }
+
+  if (isIpv4Literal) {
+    const [first, second] = hostname.split('.').map((v) => Number(v));
+    if (first === 127) {
+      return true;
+    }
+    if (first === 10) {
+      return true;
+    }
+    if (first === 192 && second === 168) {
+      return true;
+    }
+    if (first === 172 && second >= 16 && second <= 31) {
+      return true;
+    }
+    if (first === 169 && second === 254) {
+      return true;
+    }
+  }
+
+  if (hostname === '::1' || /^fe[89ab][0-9a-f]:/i.test(hostname)) {
+    return true;
+  }
+  if (/^f[cd][0-9a-f]{2}:/i.test(hostname)) {
+    return true;
+  }
+
+  // Common internal-container hostnames are often single-label (e.g. "nzbdav").
+  if (!hostname.includes('.') && !hostname.includes(':')) {
+    return true;
+  }
+
+  try {
+    const baseHost = new URL(appConfig.bootstrap.baseUrl).hostname.toLowerCase();
+    const internalHost = new URL(
+      appConfig.bootstrap.internalUrl
+    ).hostname.toLowerCase();
+    if (hostname === baseHost || hostname === internalHost) {
+      return true;
+    }
+  } catch {
+    // Ignore invalid bootstrap URLs and rely on hostname heuristics above.
+  }
+
+  return false;
+}
+
 /**
  * Pick the most specific value from a host / `[context]`-keyed override map for a
  * request. Used by the request-header overrides (`hostnameUserAgentOverrides`)

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -192,28 +192,28 @@ neither the environment variable nor a stored value is present.
 
 #### Default
 
-| Environment Variable             | UI Setting                 | Type   | Default   | Description                                                                                 |
-| -------------------------------- | -------------------------- | ------ | --------- | ------------------------------------------------------------------------------------------- |
-| `DEFAULT_PROXY_ENABLED`          | Default › Enabled          | json   | —         | When set, used as the default proxy enabled state for new users.                            |
-| `DEFAULT_PROXY_ID`               | Default › ID               | string | —         | Default proxy service identifier.                                                           |
-| `DEFAULT_PROXY_URL`              | Default › URL              | string | —         | Default proxy URL.                                                                          |
-| `DEFAULT_PROXY_PUBLIC_URL`       | Default › Public URL       | string | —         | Public-facing default proxy URL surfaced to clients (when different from the internal one). |
-| `DEFAULT_PROXY_CREDENTIALS`      | Default › Credentials      | string | _(unset)_ | Credentials for the default proxy. _(secret)_                                               |
-| `DEFAULT_PROXY_PUBLIC_IP`        | Default › Public IP        | string | —         | Public IP of the default proxy.                                                             |
-| `DEFAULT_PROXY_PROXIED_SERVICES` | Default › Proxied Services | list   | —         | List of serviceIds to proxy by default. JSON array of strings.                              |
+| Environment Variable             | UI Setting                 | Type   | Default   | Description                                                                                           |
+| -------------------------------- | -------------------------- | ------ | --------- | ----------------------------------------------------------------------------------------------------- |
+| `DEFAULT_PROXY_ENABLED`          | Default › Enabled          | json   | —         | When set, used as the default proxy enabled state for new users.                                      |
+| `DEFAULT_PROXY_ID`               | Default › ID               | string | —         | Default proxy service identifier.                                                                     |
+| `DEFAULT_PROXY_URL`              | Default › URL              | string | —         | Default proxy URL.                                                                                    |
+| `DEFAULT_PROXY_PUBLIC_URL`       | Default › Public URL       | string | —         | Public-facing default proxy URL surfaced to clients (when different from the internal one).           |
+| `DEFAULT_PROXY_CREDENTIALS`      | Default › Credentials      | string | _(unset)_ | Credentials for the default proxy. _(secret)_                                                         |
+| `DEFAULT_PROXY_PUBLIC_IP`        | Default › Public IP        | string | —         | Public IP of the default proxy.                                                                       |
+| `DEFAULT_PROXY_PROXIED_SERVICES` | Default › Proxied Services | list   | —         | List of serviceIds to proxy by default. Use `subtitle` to proxy subtitle URLs. JSON array of strings. |
 
 #### Force
 
-| Environment Variable                 | UI Setting                     | Type    | Default   | Description                                                                  |
-| ------------------------------------ | ------------------------------ | ------- | --------- | ---------------------------------------------------------------------------- |
-| `FORCE_PROXY_ENABLED`                | Force › Enabled                | json    | —         | Override user choice of whether the proxy is enabled.                        |
-| `FORCE_PROXY_ID`                     | Force › ID                     | string  | —         | Override user choice of proxy service identifier.                            |
-| `FORCE_PROXY_URL`                    | Force › URL                    | string  | —         | Override user choice of proxy URL.                                           |
-| `FORCE_PROXY_PUBLIC_URL`             | Force › Public URL             | string  | —         | Override user choice of proxy public URL.                                    |
-| `FORCE_PROXY_CREDENTIALS`            | Force › Credentials            | string  | _(unset)_ | Override user choice of proxy credentials. _(secret)_                        |
-| `FORCE_PROXY_PUBLIC_IP`              | Force › Public IP              | string  | —         | Override user choice of proxy public IP.                                     |
-| `FORCE_PROXY_DISABLE_PROXIED_ADDONS` | Force › Disable Proxied Addons | boolean | `false`   | When forcing a proxy, also disable any addons that already proxy themselves. |
-| `FORCE_PROXY_PROXIED_SERVICES`       | Force › Proxied Services       | list    | —         | List of serviceIds to force-proxy. JSON array of strings.                    |
+| Environment Variable                 | UI Setting                     | Type    | Default   | Description                                                                                      |
+| ------------------------------------ | ------------------------------ | ------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `FORCE_PROXY_ENABLED`                | Force › Enabled                | json    | —         | Override user choice of whether the proxy is enabled.                                            |
+| `FORCE_PROXY_ID`                     | Force › ID                     | string  | —         | Override user choice of proxy service identifier.                                                |
+| `FORCE_PROXY_URL`                    | Force › URL                    | string  | —         | Override user choice of proxy URL.                                                               |
+| `FORCE_PROXY_PUBLIC_URL`             | Force › Public URL             | string  | —         | Override user choice of proxy public URL.                                                        |
+| `FORCE_PROXY_CREDENTIALS`            | Force › Credentials            | string  | _(unset)_ | Override user choice of proxy credentials. _(secret)_                                            |
+| `FORCE_PROXY_PUBLIC_IP`              | Force › Public IP              | string  | —         | Override user choice of proxy public IP.                                                         |
+| `FORCE_PROXY_DISABLE_PROXIED_ADDONS` | Force › Disable Proxied Addons | boolean | `false`   | When forcing a proxy, also disable any addons that already proxy themselves.                     |
+| `FORCE_PROXY_PROXIED_SERVICES`       | Force › Proxied Services       | list    | —         | List of serviceIds to force-proxy. Use `subtitle` to proxy subtitle URLs. JSON array of strings. |
 
 #### IP
 

--- a/packages/frontend/src/components/menu/addons/_components/my-addons.tsx
+++ b/packages/frontend/src/components/menu/addons/_components/my-addons.tsx
@@ -33,6 +33,10 @@ import {
   useConfirmationDialog,
 } from '../../../shared/confirmation-dialog';
 import * as constants from '../../../../../../core/src/utils/constants';
+import {
+  applyInternalAddonProxyConfig,
+  shouldAutoProxyInternalAddon,
+} from './proxy-auto';
 
 const manifestCache = new Map<string, any>();
 
@@ -927,7 +931,7 @@ function AddonListItem({
   onRemove: () => void;
   onToggleEnabled: (v: boolean) => void;
 }) {
-  const { setUserData } = useUserData();
+  const { userData, setUserData } = useUserData();
   const [isConfigurable, setIsConfigurable] = useState(false);
   const [logo, setLogo] = useState<string | undefined>(
     preset.logo || presetMetadata?.LOGO
@@ -995,6 +999,16 @@ function AddonListItem({
   const handleManifestUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
     const std = standardiseManifestUrl(newManifestUrl);
+    const nextOptionsForDecision =
+      presetMetadata?.ID === 'custom' || presetMetadata?.ID === 'aiostreams'
+        ? { manifestUrl: std }
+        : { url: std };
+    const autoProxyDecision = shouldAutoProxyInternalAddon(nextOptionsForDecision);
+    const autoEnabledProxy =
+      autoProxyDecision.shouldAutoProxy &&
+      !!userData.proxy?.id &&
+      !!userData.proxy?.url &&
+      !!userData.proxy?.credentials;
     if (!newManifestUrl) {
       toast.error('Please enter a new manifest URL');
       return;
@@ -1003,36 +1017,57 @@ function AddonListItem({
       toast.error('Please enter a valid manifest URL');
       return;
     }
-    try {
-      setLoading(true);
-      const response = await fetch(std);
-      if (!response.ok)
-        throw new Error(`${response.status} ${response.statusText}`);
-      await response.json();
-    } catch (error: any) {
-      toast.error(`Failed to fetch or parse manifest: ${error.message}`);
-      setLoading(false);
-      return;
+    setLoading(true);
+    if (!autoProxyDecision.shouldAutoProxy) {
+      try {
+        const response = await fetch(std);
+        if (!response.ok)
+          throw new Error(`${response.status} ${response.statusText}`);
+        await response.json();
+      } catch (error: any) {
+        toast.error(`Failed to fetch or parse manifest: ${error.message}`);
+        setLoading(false);
+        return;
+      }
     }
+
     setUserData((prev) => {
       const currentPreset = prev.presets.find(
         (p) => p.instanceId === preset.instanceId
       );
-      if (!currentPreset) return prev;
+      if (!currentPreset) {
+        return prev;
+      }
+
       const options =
         presetMetadata?.ID === 'custom' || presetMetadata?.ID === 'aiostreams'
           ? { ...currentPreset.options, manifestUrl: std }
           : { ...currentPreset.options, url: std };
-      return {
+      const baseNextUserData = {
         ...prev,
         presets: prev.presets.map((p) =>
           p.instanceId === preset.instanceId ? { ...p, options } : p
         ),
       };
+      const autoProxyResult = autoProxyDecision.shouldAutoProxy
+        ? applyInternalAddonProxyConfig(baseNextUserData, preset.instanceId)
+        : null;
+      return autoProxyResult?.nextUserData ?? baseNextUserData;
     });
     setNewManifestUrl('');
     configModalOpen.close();
     toast.success('Manifest URL updated successfully');
+    if (autoProxyDecision.shouldAutoProxy) {
+      if (autoEnabledProxy) {
+        toast.info(
+          'Detected an internal HTTP addon URL. Proxy was auto-enabled and this addon was auto-routed through proxy.'
+        );
+      } else {
+        toast.info(
+          'Detected an internal HTTP addon URL. This addon was auto-targeted for proxy. Configure proxy URL and credentials to fully enable routing.'
+        );
+      }
+    }
     setLoading(false);
   };
 

--- a/packages/frontend/src/components/menu/addons/_components/proxy-auto.ts
+++ b/packages/frontend/src/components/menu/addons/_components/proxy-auto.ts
@@ -1,0 +1,112 @@
+function standardiseManifestUrl(url: string): string {
+  return url.replace(/^stremio:\/\//, 'https://').replace(/\/$/, '');
+}
+
+function extractManifestUrl(options: Record<string, any>): string | undefined {
+  const rawManifestUrl =
+    typeof options?.manifestUrl === 'string'
+      ? options.manifestUrl
+      : typeof options?.url === 'string'
+        ? options.url
+        : undefined;
+
+  if (!rawManifestUrl) {
+    return undefined;
+  }
+
+  const manifestUrl = standardiseManifestUrl(rawManifestUrl);
+  try {
+    const parsed = new URL(manifestUrl);
+    if (!parsed.pathname.endsWith('/manifest.json')) {
+      return undefined;
+    }
+    return manifestUrl;
+  } catch {
+    return undefined;
+  }
+}
+
+function isInternalEndpoint(url: URL): boolean {
+  const rawHostname = url.hostname.toLowerCase();
+  const hostname =
+    rawHostname.startsWith('[') && rawHostname.endsWith(']')
+      ? rawHostname.slice(1, -1)
+      : rawHostname;
+  const ipv4Match = hostname.match(/^(\d{1,3})(?:\.(\d{1,3})){3}$/);
+  const isIpv4Literal = (() => {
+    if (!ipv4Match) return false;
+    const octets = hostname.split('.').map((v) => Number(v));
+    return octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255);
+  })();
+
+  if (
+    hostname === 'localhost' ||
+    hostname === 'host.docker.internal' ||
+    hostname.endsWith('.local')
+  ) {
+    return true;
+  }
+
+  if (isIpv4Literal) {
+    const [first, second] = hostname.split('.').map((v) => Number(v));
+    if (first === 127) return true;
+    if (first === 10) return true;
+    if (first === 192 && second === 168) return true;
+    if (first === 172 && second >= 16 && second <= 31) return true;
+    if (first === 169 && second === 254) return true;
+  }
+
+  if (hostname === '::1' || /^fe[89ab][0-9a-f]:/i.test(hostname)) return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(hostname)) return true;
+
+  if (!hostname.includes('.') && !hostname.includes(':')) return true;
+
+  return false;
+}
+
+export function shouldAutoProxyInternalAddon(options: Record<string, any>): {
+  shouldAutoProxy: boolean;
+  manifestUrl?: string;
+} {
+  const manifestUrl = extractManifestUrl(options);
+  if (!manifestUrl) {
+    return { shouldAutoProxy: false };
+  }
+
+  try {
+    const parsed = new URL(manifestUrl);
+    if (parsed.protocol !== 'http:') {
+      return { shouldAutoProxy: false, manifestUrl };
+    }
+    return {
+      shouldAutoProxy: isInternalEndpoint(parsed),
+      manifestUrl,
+    };
+  } catch {
+    return { shouldAutoProxy: false };
+  }
+}
+
+export function applyInternalAddonProxyConfig<T extends { proxy?: any }>(
+  userData: T,
+  addonInstanceId: string
+): { nextUserData: T; autoEnabledProxy: boolean } {
+  const currentProxy = userData.proxy ?? {};
+  const canEnableProxy =
+    !!currentProxy.id && !!currentProxy.url && !!currentProxy.credentials;
+
+  const proxiedAddons = new Set<string>(currentProxy.proxiedAddons ?? []);
+  proxiedAddons.add(addonInstanceId);
+
+  return {
+    nextUserData: {
+      ...userData,
+      proxy: {
+        ...currentProxy,
+        enabled: canEnableProxy ? true : currentProxy.enabled,
+        proxiedAddons: [...proxiedAddons],
+      },
+    },
+    autoEnabledProxy: canEnableProxy,
+  };
+}

--- a/packages/frontend/src/components/menu/addons/index.tsx
+++ b/packages/frontend/src/components/menu/addons/index.tsx
@@ -30,6 +30,10 @@ import { AddonFetchingBehaviorCard } from './_components/addon-fetching-behavior
 import { CatalogSettingsCard } from './_components/catalog-settings';
 import { MergedCatalogsCard } from './_components/merged-catalogs';
 import { MyAddons } from './_components/my-addons';
+import {
+  applyInternalAddonProxyConfig,
+  shouldAutoProxyInternalAddon,
+} from './_components/proxy-auto';
 
 export function AddonsMenu() {
   return (
@@ -229,22 +233,56 @@ function Content() {
         setModalOpen(false);
         return;
       }
-      setUserData((prev) => ({
-        ...prev,
-        presets: [...prev.presets, newPreset],
-      }));
+      const autoProxyDecision = shouldAutoProxyInternalAddon(values.options);
+      const baseNext = {
+        ...userData,
+        presets: [...userData.presets, newPreset],
+      };
+      const autoProxyResult = autoProxyDecision.shouldAutoProxy
+        ? applyInternalAddonProxyConfig(baseNext, newPreset.instanceId)
+        : null;
+      const nextUserData = autoProxyResult?.nextUserData ?? baseNext;
+      const autoEnabledProxy = autoProxyResult?.autoEnabledProxy ?? false;
+      setUserData(() => nextUserData);
       toast.info('Addon installed successfully!');
+      if (autoProxyDecision.shouldAutoProxy) {
+        if (autoEnabledProxy) {
+          toast.info(
+            'Detected an internal HTTP addon URL. Proxy was auto-enabled and this addon was auto-routed through proxy.'
+          );
+        } else {
+          toast.info(
+            'Detected an internal HTTP addon URL. This addon was auto-targeted for proxy. Configure proxy URL and credentials to fully enable routing.'
+          );
+        }
+      }
       setModalOpen(false);
     } else if (modalMode === 'edit' && editingAddonId) {
-      setUserData((prev) => ({
-        ...prev,
-        presets: prev.presets.map((a) =>
-          a.instanceId === editingAddonId
-            ? { ...a, options: values.options }
-            : a
+      const autoProxyDecision = shouldAutoProxyInternalAddon(values.options);
+      const baseNext = {
+        ...userData,
+        presets: userData.presets.map((a) =>
+          a.instanceId === editingAddonId ? { ...a, options: values.options } : a
         ),
-      }));
+      };
+      const autoProxyResult = autoProxyDecision.shouldAutoProxy
+        ? applyInternalAddonProxyConfig(baseNext, editingAddonId)
+        : null;
+      const nextUserData = autoProxyResult?.nextUserData ?? baseNext;
+      const autoEnabledProxy = autoProxyResult?.autoEnabledProxy ?? false;
+      setUserData(() => nextUserData);
       toast.info('Addon updated successfully!');
+      if (autoProxyDecision.shouldAutoProxy) {
+        if (autoEnabledProxy) {
+          toast.info(
+            'Detected an internal HTTP addon URL. Proxy was auto-enabled and this addon was auto-routed through proxy.'
+          );
+        } else {
+          toast.info(
+            'Detected an internal HTTP addon URL. This addon was auto-targeted for proxy. Configure proxy URL and credentials to fully enable routing.'
+          );
+        }
+      }
       setModalOpen(false);
     }
   }

--- a/packages/frontend/src/components/menu/addons/index.tsx
+++ b/packages/frontend/src/components/menu/addons/index.tsx
@@ -234,16 +234,24 @@ function Content() {
         return;
       }
       const autoProxyDecision = shouldAutoProxyInternalAddon(values.options);
-      const baseNext = {
-        ...userData,
-        presets: [...userData.presets, newPreset],
-      };
-      const autoProxyResult = autoProxyDecision.shouldAutoProxy
-        ? applyInternalAddonProxyConfig(baseNext, newPreset.instanceId)
-        : null;
-      const nextUserData = autoProxyResult?.nextUserData ?? baseNext;
-      const autoEnabledProxy = autoProxyResult?.autoEnabledProxy ?? false;
-      setUserData(() => nextUserData);
+      // Build from the setter's latest state so a concurrent update isn't
+      // clobbered; surface whether proxy auto-enabled for the toast below.
+      let autoEnabledProxy = false;
+      setUserData((prev) => {
+        const baseNext = {
+          ...prev,
+          presets: [...prev.presets, newPreset],
+        };
+        if (!autoProxyDecision.shouldAutoProxy) {
+          return baseNext;
+        }
+        const result = applyInternalAddonProxyConfig(
+          baseNext,
+          newPreset.instanceId
+        );
+        autoEnabledProxy = result.autoEnabledProxy;
+        return result.nextUserData;
+      });
       toast.info('Addon installed successfully!');
       if (autoProxyDecision.shouldAutoProxy) {
         if (autoEnabledProxy) {
@@ -259,18 +267,25 @@ function Content() {
       setModalOpen(false);
     } else if (modalMode === 'edit' && editingAddonId) {
       const autoProxyDecision = shouldAutoProxyInternalAddon(values.options);
-      const baseNext = {
-        ...userData,
-        presets: userData.presets.map((a) =>
-          a.instanceId === editingAddonId ? { ...a, options: values.options } : a
-        ),
-      };
-      const autoProxyResult = autoProxyDecision.shouldAutoProxy
-        ? applyInternalAddonProxyConfig(baseNext, editingAddonId)
-        : null;
-      const nextUserData = autoProxyResult?.nextUserData ?? baseNext;
-      const autoEnabledProxy = autoProxyResult?.autoEnabledProxy ?? false;
-      setUserData(() => nextUserData);
+      // Build from the setter's latest state so a concurrent update isn't
+      // clobbered; surface whether proxy auto-enabled for the toast below.
+      let autoEnabledProxy = false;
+      setUserData((prev) => {
+        const baseNext = {
+          ...prev,
+          presets: prev.presets.map((a) =>
+            a.instanceId === editingAddonId
+              ? { ...a, options: values.options }
+              : a
+          ),
+        };
+        if (!autoProxyDecision.shouldAutoProxy) {
+          return baseNext;
+        }
+        const result = applyInternalAddonProxyConfig(baseNext, editingAddonId);
+        autoEnabledProxy = result.autoEnabledProxy;
+        return result.nextUserData;
+      });
       toast.info('Addon updated successfully!');
       if (autoProxyDecision.shouldAutoProxy) {
         if (autoEnabledProxy) {

--- a/packages/frontend/src/components/menu/proxy.tsx
+++ b/packages/frontend/src/components/menu/proxy.tsx
@@ -276,10 +276,10 @@ function Content() {
                 emptyMessage="No services available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams (that are detected to be) from these services and
-                selected subtitle URLs will be proxied. Select Subtitles to
-                proxy subtitle URLs. Select None to enable proxying of streams
-                that are not detected to be from a service.
+                For non-internal URLs, streams detected from these services
+                (and selected subtitle URLs) are proxied. Select Subtitles to
+                proxy subtitle URLs, or None to proxy streams with no detected
+                service. Internal HTTP URLs are always proxied regardless.
               </p>
             </div>
 
@@ -300,8 +300,9 @@ function Content() {
                 emptyMessage="No addons available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams and subtitle URLs from these addons will be
-                proxied
+                For non-internal URLs, only streams and subtitle URLs from
+                these addons are proxied. Internal HTTP URLs are always proxied
+                regardless.
               </p>
             </div>
           </SettingsCard>

--- a/packages/frontend/src/components/menu/proxy.tsx
+++ b/packages/frontend/src/components/menu/proxy.tsx
@@ -60,6 +60,11 @@ function Content() {
       textValue: service.name,
     })),
     {
+      label: 'Subtitles',
+      value: 'subtitle',
+      textValue: 'Subtitles',
+    },
+    {
       label: 'None',
       value: 'none',
       textValue: 'None',
@@ -271,9 +276,10 @@ function Content() {
                 emptyMessage="No services available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams (that are detected to be) from these services will
-                be proxied. Select None to enable proxying of streams that are
-                not detected to be from a service.
+                Only streams (that are detected to be) from these services and
+                selected subtitle URLs will be proxied. Select Subtitles to
+                proxy subtitle URLs. Select None to enable proxying of streams
+                that are not detected to be from a service.
               </p>
             </div>
 
@@ -294,7 +300,8 @@ function Content() {
                 emptyMessage="No addons available"
               />
               <p className="text-[--muted] text-sm">
-                Only streams from these addons will be proxied
+                Only streams and subtitle URLs from these addons will be
+                proxied
               </p>
             </div>
           </SettingsCard>


### PR DESCRIPTION
Makes internal addons and subtitles work through a proxy, automatically.

Two related changes:

**Auto-proxy internal addon URLs.** When an addon's stream or subtitle URL points at an internal host (a container name or private IP like `http://nzbdav:8080`), it's routed through your configured proxy automatically. A remote player can't reach a container or LAN address, so these are always proxied, regardless of the per-addon/per-service filters. Adding or editing such an addon auto-enables the proxy and targets it, with a heads-up toast.

**Proxy subtitle URLs on demand.** Subtitles can now be routed through the proxy via a `subtitle` proxied-service, selectable in proxy settings and wired to the `DEFAULT_PROXY_PROXIED_SERVICES` / `FORCE_PROXY_PROXIED_SERVICES` env vars. Same opt-in model as stream proxying.

**Why it's needed:** internal and self-hosted addons (nzbdav, altmount, LAN addons) hand back URLs a remote Stremio client simply can't open. Before this you had to hand-configure proxying per addon, and subtitle URLs couldn't be proxied at all.

**Try it** — multi-arch image built from this branch:
```
ghcr.io/ibbylabs/aiostreams:auto-proxy-http
```

Supersedes #1020 (its subtitle-URL proxying is included here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subtitle URLs can now be routed through the proxy when subtitle/subtitles are selected and matching addon/services rules apply.
  - When proxying is enabled, internal HTTP streams are eligible without allowlist gating.
  - Internal add-ons can be auto-configured to use the proxy during installation or editing, with improved notifications.
- **Bug Fixes**
  - If subtitle proxy URL generation fails, subtitle URLs remain unchanged and an error is recorded.
- **Documentation**
  - Updated Proxy configuration documentation and UI text to clarify subtitle routing via `subtitle`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
