### PR TITLE
Restore USA TV Next manifest

### DIFF
--- a/packages/core/src/config/schema/presets.ts
+++ b/packages/core/src/config/schema/presets.ts
@@ -493,7 +493,9 @@ export const presetsSchema = {
   }),
   usaTv: basicPreset({
     label: 'USA TV',
-    default: ['https://848b3516657c-usatv.baby-beamup.club'],
+    default: [
+      'https://raw.githubusercontent.com/yowmamasita/usa-tv-next/main/manifest.json',
+    ],
     envBase: 'USA_TV_URL',
     timeoutEnv: 'DEFAULT_USA_TV_TIMEOUT',
     userAgentEnv: 'DEFAULT_USA_TV_USER_AGENT',

--- a/packages/core/src/presets/usaTv.ts
+++ b/packages/core/src/presets/usaTv.ts
@@ -59,6 +59,10 @@ export class USATVPreset extends Preset {
       constants.META_RESOURCE,
       constants.STREAM_RESOURCE,
     ];
+    const defaultUrl = appConfig.presets.usaTv.url[0] ?? '';
+    const assetBaseUrl = defaultUrl.endsWith('/manifest.json')
+      ? defaultUrl.slice(0, -'/manifest.json'.length)
+      : defaultUrl;
 
     const options: Option[] = [
       ...baseOptions(
@@ -72,7 +76,7 @@ export class USATVPreset extends Preset {
     return {
       ID: 'usa-tv',
       NAME: 'USA TV',
-      LOGO: `${appConfig.presets.usaTv.url[0] ?? ''}/public/logo.png`,
+      LOGO: `${assetBaseUrl}/public/logo.png`,
       URL: appConfig.presets.usaTv.url,
       TIMEOUT:
         appConfig.presets.usaTv.defaultTimeout ??
@@ -86,11 +90,6 @@ export class USATVPreset extends Preset {
       OPTIONS: options,
       SUPPORTED_STREAM_TYPES: [LIVE_STREAM_TYPE],
       SUPPORTED_RESOURCES: supportedResources,
-      DISABLED: {
-        removed: true,
-        disabled: true,
-        reason: 'USA TV addon is deprecated.',
-      },
     };
   }
 
@@ -105,13 +104,10 @@ export class USATVPreset extends Preset {
     userData: UserData,
     options: Record<string, any>
   ): Addon {
-    const baseUrl = options.url
-      ? new URL(options.url).origin
-      : this.DEFAULT_URL;
-
-    const url = options.url?.endsWith('/manifest.json')
-      ? options.url
-      : `${baseUrl}/manifest.json`;
+    const configuredUrl = options.url || this.DEFAULT_URL;
+    const url = configuredUrl.endsWith('/manifest.json')
+      ? configuredUrl
+      : `${options.url ? new URL(configuredUrl).origin : configuredUrl}/manifest.json`;
     return {
       name: options.name || this.METADATA.NAME,
       manifestUrl: url,

--- a/packages/core/src/presets/usaTv.ts
+++ b/packages/core/src/presets/usaTv.ts
@@ -107,7 +107,7 @@ export class USATVPreset extends Preset {
     const configuredUrl = options.url || this.DEFAULT_URL;
     const url = configuredUrl.endsWith('/manifest.json')
       ? configuredUrl
-      : `${options.url ? new URL(configuredUrl).origin : configuredUrl}/manifest.json`;
+      : `${configuredUrl.replace(/\/?$/, '')}/manifest.json`;
     return {
       name: options.name || this.METADATA.NAME,
       manifestUrl: url,

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -675,7 +675,7 @@ neither the environment variable nor a stored value is present.
 
 | Environment Variable | UI Setting | Type | Default | Description |
 | --- | --- | --- | --- | --- |
-| `USA_TV_URL` | Usa Tv › URL | list | `["https://848b3516657c-usatv.baby-beamup.club"]` | Upstream URL(s) for the USA TV addon. |
+| `USA_TV_URL` | Usa Tv › URL | list | `["https://raw.githubusercontent.com/yowmamasita/usa-tv-next/main/manifest.json"]` | Upstream URL(s) for the USA TV addon. |
 | `DEFAULT_USA_TV_TIMEOUT` | Usa Tv › Default Timeout | number | — | Default timeout for the USA TV addon (milliseconds). Falls back to the global default when unset. |
 | `DEFAULT_USA_TV_USER_AGENT` | Usa Tv › Default User Agent | string | — | Default User-Agent for the USA TV addon. Supports `{version}`/`{random}` placeholders. |
 


### PR DESCRIPTION
## Summary

- re-enable the USA TV preset by removing the deprecated/removed disable metadata
- update the default `USA_TV_URL` to the active USA TV Next manifest:
  `https://raw.githubusercontent.com/yowmamasita/usa-tv-next/main/manifest.json`
- keep derived preset URLs valid when the default is already a `manifest.json` URL, including the logo path and generated addon manifest URL
- preserve custom URL path segments when appending `/manifest.json`
- regenerate the environment-variable docs entry for `USA_TV_URL`

## Why

Commit `004e0e8f` disabled USA TV because the previous Beamup deployment was deprecated. The addon now has an active successor at `yowmamasita/usa-tv-next`, so the preset should use that manifest instead of remaining removed.

## Validation

- `pnpm -F core test` (no core test files present; exits 0 with `--passWithNoTests`)
- `pnpm -F core build`

## Notes

- Addressed CodeRabbit's comment about preserving custom URL paths when appending `/manifest.json`.
- No test files were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored the USA TV addon from disabled status to active.

* **Updates**
  * Updated the USA TV addon’s default upstream URL to the new manifest location.
  * Improved logo/asset URL handling and manifest URL generation for the USA TV preset.

* **Documentation**
  * Updated environment variable documentation (`USA_TV_URL`) to reflect the new default upstream URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->