### PR TITLE
add "Delete All" button to clear the entire library

### DIFF
--- a/packages/core/src/db/repositories/usenet-library.ts
+++ b/packages/core/src/db/repositories/usenet-library.ts
@@ -387,6 +387,12 @@ export class UsenetLibraryRepository {
     usenetLibraryBus.emit('change');
   }
 
+  /** Remove every entry from the library. */
+  static async clear(): Promise<void> {
+    await getDb().exec(sql`DELETE FROM usenet_library`);
+    usenetLibraryBus.emit('change');
+  }
+
   /** The streamable file list for an entry. */
   static async getFiles(nzbHash: string): Promise<UsenetLibraryFile[]> {
     const entry = await this.get(nzbHash);

--- a/packages/frontend/src/app/dashboard/usenet/library-page.tsx
+++ b/packages/frontend/src/app/dashboard/usenet/library-page.tsx
@@ -44,6 +44,7 @@ import {
   useUsenetLibrary,
   useUsenetLibraryStream,
   useDeleteLibraryEntry,
+  useDeleteAllLibraryEntries,
   useAddNzb,
   useUploadNzb,
   usePlayUrl,
@@ -591,6 +592,7 @@ export function UsenetLibraryPage() {
     offset: (page - 1) * PAGE_SIZE,
   });
   const del = useDeleteLibraryEntry();
+  const delAll = useDeleteAllLibraryEntries();
   const pending = React.useRef<string[]>([]);
 
   const entries = query.data?.entries ?? [];
@@ -626,6 +628,26 @@ export function UsenetLibraryPage() {
           setSelectMode(false);
         }
       );
+    },
+  });
+
+  const confirmDeleteAll = useConfirmationDialog({
+    title: 'Delete all library entries',
+    description:
+      'This will remove every entry from the library, including active imports. This action cannot be undone.',
+    actionText: 'Delete all',
+    actionIntent: 'alert-subtle',
+    onConfirm: () => {
+      delAll
+        .mutateAsync(undefined)
+        .then(() => {
+          toast.success('Library cleared');
+          setSelected(new Set());
+          setSelectMode(false);
+        })
+        .catch((e: any) => {
+          toast.error(e?.message ?? 'Failed to clear library');
+        });
     },
   });
 
@@ -768,22 +790,37 @@ export function UsenetLibraryPage() {
                 >
                   Done
                 </Tooltip>
+              </>              ) : (
+              <>
+                <Tooltip
+                  trigger={
+                    <IconButton
+                      size="md"
+                      intent="alert-subtle"
+                      icon={<BiTrash />}
+                      aria-label="Delete all entries"
+                      loading={delAll.isPending}
+                      onClick={confirmDeleteAll.open}
+                    />
+                  }
+                >
+                  Delete all
+                </Tooltip>
+                <Tooltip
+                  trigger={
+                    <IconButton
+                      size="md"
+                      intent="gray-outline"
+                      icon={<BiSelectMultiple />}
+                      aria-label="Select entries"
+                      disabled={entries.length === 0}
+                      onClick={() => setSelectMode(true)}
+                    />
+                  }
+                >
+                  Select
+                </Tooltip>
               </>
-            ) : (
-              <Tooltip
-                trigger={
-                  <IconButton
-                    size="md"
-                    intent="gray-outline"
-                    icon={<BiSelectMultiple />}
-                    aria-label="Select entries"
-                    disabled={entries.length === 0}
-                    onClick={() => setSelectMode(true)}
-                  />
-                }
-              >
-                Select
-              </Tooltip>
             )}
           </div>
         </div>
@@ -868,6 +905,7 @@ export function UsenetLibraryPage() {
         onOpenChange={(o) => !o && setInfo(null)}
       />
       <ConfirmationDialog {...confirm} />
+      <ConfirmationDialog {...confirmDeleteAll} />
     </div>
   );
 }

--- a/packages/frontend/src/app/dashboard/usenet/queries.ts
+++ b/packages/frontend/src/app/dashboard/usenet/queries.ts
@@ -464,3 +464,11 @@ export function useDeleteLibraryEntry() {
     onSuccess: () => qc.invalidateQueries({ queryKey: [...ROOT, 'library'] }),
   });
 }
+
+export function useDeleteAllLibraryEntries() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api('DELETE /dashboard/usenet/library'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [...ROOT, 'library'] }),
+  });
+}

--- a/packages/server/src/routes/api/dashboard-usenet.ts
+++ b/packages/server/src/routes/api/dashboard-usenet.ts
@@ -429,6 +429,18 @@ router.get('/library/:hash/nzb', async (req, res, next) => {
   }
 });
 
+// DELETE /dashboard/usenet/library — remove every entry.
+router.delete('/library', async (_req, res, next) => {
+  try {
+    await UsenetLibraryRepository.clear();
+    res
+      .status(200)
+      .json(createResponse({ success: true, data: { cleared: true } }));
+  } catch (err) {
+    next(err);
+  }
+});
+
 // DELETE /dashboard/usenet/library/:hash — remove one entry.
 router.delete('/library/:hash', async (req, res, next) => {
   try {


### PR DESCRIPTION

Adds a destructive "Delete All" button to the Usenet library toolbar that removes every entry from the library with a single confirmation dialog, complementing the existing per-entry and multi-select delete workflows.

### Changes
 packages/core/src/db/repositories/usenet-library.ts 
- Added  UsenetLibraryRepository.clear()  — a static method that issues  DELETE FROM usenet_library  (no filter) and emits the  change  event so the dashboard SSE stream pushes the update live.
 packages/server/src/routes/api/dashboard-usenet.ts 
- Added  DELETE /dashboard/usenet/library  route (registered before the existing  DELETE /library/:hash  parametric route so Express matches the fixed path first) that delegates to  UsenetLibraryRepository.clear() .
 packages/frontend/src/app/dashboard/usenet/queries.ts 
- Added  useDeleteAllLibraryEntries()  mutation — a no-argument TanStack Query mutation hitting the new batch endpoint, with automatic cache invalidation on success.
 packages/frontend/src/app/dashboard/usenet/library-page.tsx 
- Placed a "Delete all" icon button (trash icon,  alert-subtle  intent) in the toolbar next to the "Select" button, visible outside of select mode.
- Tapping it opens a  ConfirmationDialog  with the message "This will remove every entry from the library, including active imports. This action cannot be undone.".
- On confirm, calls the batch delete mutation with proper success/error toast feedback and resets any active selection state.


Usenet library dashboard icon update for frontend UI:
<img width="2439" height="531" alt="image" src="https://github.com/user-attachments/assets/3639073a-ed3f-40ab-8e90-9deb215e95ad" />


Confirmation prompt:
<img width="520" height="176" alt="image" src="https://github.com/user-attachments/assets/b43dd119-cbd7-42f5-acaa-52691897cd30" />
