### PR TITLE
Fix misleading latency in Usenet provider "Test connection"

### DIFF
--- a/packages/core/src/usenet/integration/dashboard/providers.ts
+++ b/packages/core/src/usenet/integration/dashboard/providers.ts
@@ -91,7 +91,11 @@ export async function saveUsenetProviders(
   await settingsStore.set('usenet.providers', merged, username);
 }
 
-/** Test a single provider connection (dial + auth + DATE health probe). */
+/** Test a single provider connection (dial + auth + DATE health probe).
+ *
+ * `latencyMs` in the result measures only the DATE command round-trip after the
+ * connection (TCP/TLS/greeting/auth) is fully established, so it reflects the
+ * true server responsiveness rather than including connection setup overhead. */
 export async function testUsenetProvider(
   provider: Partial<ProviderConfig> & { password?: string },
   signal?: AbortSignal
@@ -120,13 +124,14 @@ export async function testUsenetProvider(
     priority: provider.priority ?? 0,
   };
 
-  const start = Date.now();
   let conn: NntpConnection | undefined;
   try {
     conn = await NntpConnection.connect(config, {
       dialTimeoutMs: 15_000,
       idleConnectionMs: 60_000,
     });
+    // Measure only the DATE round-trip — connection setup is already done.
+    const start = Date.now();
     await conn.date(signal, 15_000);
     return { ok: true, latencyMs: Date.now() - start };
   } catch (err) {


### PR DESCRIPTION
The "Test connection" button on the dashboard Usenet providers page was reporting a  latencyMs  value that included the entire connection lifecycle (TCP handshake + TLS negotiation + server greeting parsing + AUTHINFO USER/PASS exchange + DATE command), inflating the number to ~6× the actual network round-trip time.
For example, a provider with 20ms network ping would show ~120ms. Naturally, users interpreted this as the server being slow.

ignore if this isn’t the intention of the test connection button.


### The fix
Moved the  const start = Date.now()  timer to after  NntpConnection.connect()  completes, so  latencyMs  now measures only the DATE command round-trip — one network round-trip on an already-established connection.
The test still validates the full path (TCP, TLS, greeting, auth all run and throw fast on failure), but the displayed latency now reflects actual server responsiveness rather than connection setup overhead.


### Changes
 packages/core/src/usenet/integration/dashboard/providers.ts  — moved the timer start inside the  try  block, after  connect()  succeeds, and updated the JSDoc to document what  latencyMs  represents.