### PR TITLE
Pre cache failover

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -808,6 +808,8 @@ export const UserDataSchema = z.object({
       /** Overall deadline before giving up and serving a static error (ms). */
       maxWaitMs: z.number().min(0).optional(),
       position: z.enum(['beforeSEL', 'beforeLimiting', 'last']).optional(),
+      /** When true, failover is also applied during background pre-caching of the next episode. Default false. */
+      precacheFailover: z.boolean().optional(),
     })
     .optional(),
   serviceWrap: z

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -681,7 +681,7 @@ export async function getStreams(
     streams,
     context,
     false,
-    ctx.userData.failover?.enabled && !preCaching
+    ctx.userData.failover?.enabled && (!preCaching || ctx.userData.failover?.precacheFailover)
       ? {
           count:
             ctx.userData.failover.count ?? constants.DEFAULT_FAILOVER_COUNT,

--- a/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
+++ b/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
@@ -183,6 +183,19 @@ export function BuiltinSettings() {
             }));
           }}
         />
+        <Switch
+          label="During Pre-cache"
+          side="right"
+          disabled={!userData.failover?.enabled}
+          help="Also apply failover when pre-caching the next episode's streams in the background. When off, pre-cache requests skip failover entirely."
+          value={userData.failover?.precacheFailover ?? false}
+          onValueChange={(value) => {
+            setUserData((prev) => ({
+              ...prev,
+              failover: { ...prev.failover, precacheFailover: value },
+            }));
+          }}
+        />
         <NumberInput
           label="Fallback Count"
           help={


### PR DESCRIPTION
Problem: When  precacheNextEpisode  is enabled and the user has failover configured, the background pre-cache of the next episode always used the primary (highest-ranked) stream. If that stream failed to resolve during actual playback, the failover chain would not be used.

Solution: Added a  precacheFailover  config option to the user's failover settings. When enabled:
1. The failover chain is built during pre-cache streams requests (via  processStreams ) just like it is for regular requests.

Changes:
-  packages/core/src/db/schemas.ts  — Added  precacheFailover: z.boolean().optional()  to the failover schema
-  packages/core/src/main/resources.ts  — Updated  getStreams  to allow failover during pre-caching when  precacheFailover  is set; replaced the temporary test block in  precacheNextEpisode  with proper force-fail logic that pings the primary first, then the chain items
-  packages/frontend/.../builtin-settings.tsx  — Added a "During Pre-cache" toggle in the failover settings UI, visible only when failover is enabled

<img width="2427" height="707" alt="image" src="https://github.com/user-attachments/assets/242d8f7b-794b-4368-9ac9-594abb545a14" />
