### PR TITLE
fix(presets): correct mojibake-encoded emojis in newznab

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -20,7 +20,7 @@ class NewznabStreamParser extends BuiltinStreamParser {
         ? stream.zyclopsHealth
         : undefined;
     if (zyclopsHealth) {
-      return 'NZB Health: ' + zyclopsHealth.replace('healthy', 'ðŸ§');
+      return 'NZB Health: ' + zyclopsHealth.replace('healthy', '🧝');
     }
     return undefined;
   }
@@ -202,7 +202,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
       },
       {
         id: 'zyclopsHealthProxy',
-        name: 'ðŸ§ Zyclops Health Proxy',
+        name: '🧝 Zyclops Health Proxy',
         description:
           'Route searches through ElfHosted\'s Zyclops "magic" 🔮 crowdsourced health database to return only known-healthy releases for your backbone/provider ([learn more](https://zyclops.elfhosted.com)).',
         type: 'subsection',
@@ -212,7 +212,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
             id: 'enabled',
             name: 'Enable',
             description:
-              'Enable Zyclops health filtering. âš ï¸ Sends your indexer URL/API key with the proxy request and submits the newest untested NZB to enrich the health database. Many indexers prohibit this (*some prohibit Stremio altogether!*), proceed at **your own risk**. The health database is further directly searchable via Newznab on private ElfHosted instances only.',
+              'Enable Zyclops health filtering. ⚠️ Sends your indexer URL/API key with the proxy request and submits the newest untested NZB to enrich the health database. Many indexers prohibit this (*some prohibit Stremio altogether!*), proceed at **your own risk**. The health database is further directly searchable via Newznab on private ElfHosted instances only.',
             type: 'boolean',
           },
           {


### PR DESCRIPTION
## What

The 🧝 and ⚠️ emojis in the **Zyclops Health Proxy** preset option — and the 🧝 used in the NZB health-status stream description — are currently stored as mojibake: UTF-8 bytes that were re-decoded as Latin-1, producing `ðŸ§` and `âš ï¸`. This renders as garbled text in the config UI and stream descriptions.

| Location | Before | After |
|---|---|---|
| `zyclopsHealthProxy` option name | `ðŸ§ Zyclops Health Proxy` | `🧝 Zyclops Health Proxy` |
| `enabled` description | `âš ï¸ Sends your indexer URL/API key…` | `⚠️ Sends your indexer URL/API key…` |
| NZB health stream description | `healthy` → `ðŸ§` | `healthy` → `🧝` |

## Scope

Three lines in `packages/core/src/presets/newznab.ts` — the only mojibake-affected strings in `packages/core/src` (verified by scan). No behavioural change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated health-related UI text to display the correct emoji characters.
  - Replaced previously garbled or mis-encoded symbols in the Newznab NZB Health message and Zyclops Health Proxy labels.
  - Kept all other wording unchanged for a consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->