### PR TITLE
fix(prowlarr): add yearless movie queries

### DIFF
--- a/packages/core/src/builtins/prowlarr/addon.ts
+++ b/packages/core/src/builtins/prowlarr/addon.ts
@@ -202,11 +202,20 @@ export class ProwlarrAddon extends BaseDebridAddon<ProwlarrAddonConfig> {
     const queries = this.buildQueries(parsedId, metadata, {
       titleLanguages: getTitleLanguagesForUrl(this.userData.url, this.id),
     });
-    if (queries.length === 0) {
+    if (parsedId.mediaType === 'movie') {
+      queries.push(
+        ...this.buildQueries(parsedId, metadata, {
+          addYear: false,
+          titleLanguages: getTitleLanguagesForUrl(this.userData.url, this.id),
+        })
+      );
+    }
+    const uniqueQueries = [...new Set(queries)];
+    if (uniqueQueries.length === 0) {
       return [];
     }
 
-    const searchPromises = queries.map((q) =>
+    const searchPromises = uniqueQueries.map((q) =>
       queryLimit(async () => {
         const start = Date.now();
         const { data } = await this.api.search({


### PR DESCRIPTION
## Summary
- include title-only Prowlarr queries for movie searches in addition to title + year
- deduplicate generated queries before dispatching searches

## Why
Some movie metadata can have an incorrect or future year compared to indexed releases. Searching only with title + year can return no usable Prowlarr results even when title-only results exist.

## Testing
- pnpm -F core run test
- pnpm -F core run build
- pnpm exec prettier --check packages/core/src/builtins/prowlarr/addon.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search handling for movies by trying an additional match variation, which can help find more results.
  * Removed duplicate search attempts and skips searching when no valid queries are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->