### PR TITLE
Fix missing services in stream expressions

### DIFF
--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -1005,13 +1005,15 @@ export abstract class StreamExpressionEngine {
             'nzbdav',
             'altmount',
             'stremio_nntp',
+            'stremthru_newz',
             'easydebrid',
             'debrider',
+            'aiostreams',
           ].includes(s)
         )
       ) {
         throw new Error(
-          'Service must be a string and one of: realdebrid, debridlink, alldebrid, torbox, pikpak, seedr, offcloud, premiumize, easynews, nzbdav, altmount, easydebrid, debrider'
+          'Service must be a string and one of: realdebrid, debridlink, alldebrid, torbox, pikpak, seedr, offcloud, premiumize, easynews, nzbdav, altmount, stremio_nntp, stremthru_newz, easydebrid, debrider, aiostreams'
         );
       }
       return streams.filter((stream) =>


### PR DESCRIPTION
Fixed. The  service()  function in  streamExpression.ts  was missing  'aiostreams'  and  'stremthru_newz'  from its validation list, even though both are valid services in the canonical  SERVICES  array in  constants.ts . Added both to:
- The validation check array
- The error message string