### PR TITLE
fix(easynews): accept numeric dlFarm in search response schema

### DIFF
--- a/packages/core/src/builtins/easynews-search/api.ts
+++ b/packages/core/src/builtins/easynews-search/api.ts
@@ -86,7 +86,7 @@ const EasynewsSearchResponseSchema = z.object({
   perPage: z.union([z.string(), z.number()]).optional(),
   thumbURL: z.string().optional(),
   thumbUrl: z.string().optional(),
-  dlFarm: z.string().optional(),
+  dlFarm: z.union([z.string(), z.number()]).optional(),
   dlPort: z.union([z.string(), z.number()]).optional(),
   downURL: z.string().optional(),
 });
@@ -465,7 +465,7 @@ export class EasynewsApi {
       numPages: response.numPages,
       currentPage: response.page ?? 1,
       downloadInfo: {
-        dlFarm: response.dlFarm ?? '',
+        dlFarm: String(response.dlFarm ?? ''),
         dlPort: String(response.dlPort ?? ''),
         downURL: response.downURL ?? `${EASYNEWS_BASE}/dl`,
       },


### PR DESCRIPTION
## Problem

Easynews search can fail with:

`warn: Failed to parse Easynews response: dlFarm: Invalid input: expected string, received number (invalid_type)`

The Easynews API can return `dlFarm` (the download-farm id) as a **number**, but `EasynewsSearchResponseSchema` declares it as `z.string()`. When that happens, Zod rejects the entire response, so the user gets **zero Easynews results** with no obvious cause.

The neighbouring `dlPort` and `perPage` fields already handle this correctly with a `z.union([z.string(), z.number()])`; `dlFarm` was simply missed.

## Fix

Mirror exactly how `dlPort` is already handled:

1. Schema accepts `string | number`:
   `dlFarm: z.union([z.string(), z.number()]).optional()`
2. Normalize to a string when building `downloadInfo` (interface expects `string`,
   and the download-URL builder concatenates it):
   `dlFarm: String(response.dlFarm ?? '')`

No interface or downstream change needed — `EasynewsDownloadInfo.dlFarm` stays `string`.

## Testing

Verified on a live instance: after the change, the parse error no longer appears and Easynews search returns results normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Easynews search results handling so responses are accepted when `dlFarm` is returned as either a number or a string.
  * Standardised the displayed/stored `dlFarm` value to a string for more consistent behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->