### PR TITLE
feat: add config for Tr4ker baguettio

### DIFF
--- a/packages/core/src/presets/baguettio.ts
+++ b/packages/core/src/presets/baguettio.ts
@@ -144,6 +144,20 @@ export class BaguettioPreset extends Preset {
         type: 'boolean',
         default: true,
       },
+      {
+        id: 'trTr4kerApiKey',
+        name: 'Tr4ker API Key',
+        description: 'API Key for Tr4ker (Optional)',
+        type: 'string',
+        required: false,
+      },
+      {
+        id: 'trTr4kerMagnetOnly',
+        name: 'Tr4ker - Magnet Only',
+        description: 'Retrieve only magnets for Tr4ker',
+        type: 'boolean',
+        default: true,
+      },
     ];
 
     return {
@@ -299,6 +313,11 @@ export class BaguettioPreset extends Preset {
     if (options.trOldSchoolApiKey) {
       config.TR_OLDSCHOOL_APIKEY = options.trOldSchoolApiKey;
       config.OLDSCHOOL_MAGNET_ONLY = options.oldSchoolMagnetOnly ?? true;
+    }
+
+    if (options.trTr4kerApiKey) {
+      config.TR_TR4KER_APIKEY = options.trTr4kerApiKey;
+      config.TR4KER_MAGNET_ONLY = options.trTr4kerMagnetOnly ?? true;
     }
 
     const configString = this.base64EncodeJSON(config, 'urlSafe');


### PR DESCRIPTION
Baguettio now supports Tr4ker, this adds the ability to configure the preset with API key and the torrent/magnet option.
Named are inspired by the other params & the baguettio config
<img width="1304" height="453" alt="image" src="https://github.com/user-attachments/assets/25179dbe-6832-40c1-9dc6-7d74b938429b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new preset options for configuring Tr4ker-related settings.
  * You can now optionally provide an API key and control whether magnet-only mode is used, with magnet-only enabled by default.

* **Bug Fixes**
  * Updated generated configuration output to include the new Tr4ker settings when provided, ensuring the resulting setup is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->