### PR TITLE
feat(builtins/nab): add configurable season pack search strategy for auto-mode series search

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -60,6 +60,8 @@ export interface SearchMetadata extends TitleMetadata {
   titlesWithLang?: MetadataTitle[];
   /** ISO 639-1 code of the content's original language (from TMDB). */
   originalLanguage?: string;
+  /** Whether the requested season is the latest season and still has an upcoming episode. */
+  ongoingSeason?: boolean;
 }
 
 export const BaseDebridConfigSchema = z.object({
@@ -689,6 +691,9 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       tmdbId: metadata.tmdbId ?? null,
       tvdbId: metadata.tvdbId ?? null,
       isAnime: animeEntry ? true : false,
+      ongoingSeason: metadata.nextAirDate && metadata.seasons?.length
+          ? Number(parsedId.season) === Math.max(...metadata.seasons.map((s) => s.season_number))
+          : undefined,
     };
 
     this.logger.debug(

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -63,7 +63,13 @@ export const NabAddonConfigSchema = BaseDebridConfigSchema.extend({
   forceQuerySearch: z.boolean().default(false),
   paginate: z.boolean().default(false),
   forceInitialLimit: z.number().min(1).max(10000).optional(),
-  seasonPackFallback: z.boolean().default(false),
+  seasonPackStrategy: z
+    .enum([
+      'episodeOnly',
+      'episodeFirstSeasonPackFallback',
+      'seasonPackFirstEpisodeFallback',
+    ])
+    .default('episodeOnly'),
 });
 export type NabAddonConfig = z.infer<typeof NabAddonConfigSchema>;
 
@@ -205,21 +211,40 @@ export abstract class BaseNabAddon<
       const allResults = await Promise.all(searchPromises);
       results = allResults.flat();
     } else {
-      results = await this.fetchResults(searchFunction, queryParams);
-      if (
-        results.length === 0 &&
-        this.userData.seasonPackFallback &&
+      const canToggleEpisodeParam =
         parsedId.mediaType === 'series' &&
         !this.userData.forceQuerySearch &&
         searchCapabilities.supportedParams.includes('season') &&
         queryParams.season &&
-        queryParams.ep
+        queryParams.ep;
+
+      if (
+        this.userData.seasonPackStrategy ===
+          'seasonPackFirstEpisodeFallback' &&
+        canToggleEpisodeParam
       ) {
-        this.logger.debug(
-          'No results for season+episode search, retrying with season only to find season packs'
-        );
         const { ep, ...seasonOnlyParams } = queryParams;
         results = await this.fetchResults(searchFunction, seasonOnlyParams);
+        if (results.length === 0) {
+          this.logger.debug(
+            'No results for season-only search, retrying with episode included'
+          );
+          results = await this.fetchResults(searchFunction, queryParams);
+        }
+      } else {
+        results = await this.fetchResults(searchFunction, queryParams);
+        if (
+          results.length === 0 &&
+          this.userData.seasonPackStrategy ===
+            'episodeFirstSeasonPackFallback' &&
+          canToggleEpisodeParam
+        ) {
+          this.logger.debug(
+            'No results for season+episode search, retrying with season only to find season packs'
+          );
+          const { ep, ...seasonOnlyParams } = queryParams;
+          results = await this.fetchResults(searchFunction, seasonOnlyParams);
+        }
       }
     }
     this.logger.info(

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -66,6 +66,7 @@ export const NabAddonConfigSchema = BaseDebridConfigSchema.extend({
   seasonPackStrategy: z
     .enum([
       'episodeOnly',
+      'dynamic',
       'episodeFirstSeasonPackFallback',
       'seasonPackFirstEpisodeFallback',
     ])
@@ -222,10 +223,16 @@ export abstract class BaseNabAddon<
       let fallbackParams: Record<string, string> | undefined;
       if (canApplySeasonPackStrategy) {
         const { ep, ...seasonOnlyParams } = queryParams;
-        if (this.userData.seasonPackStrategy === 'seasonPackFirstEpisodeFallback') {
+        let strategy = this.userData.seasonPackStrategy;
+        if (strategy === 'dynamic') {
+          strategy = metadata.ongoingSeason === true
+            ? 'episodeOnly'
+            : 'seasonPackFirstEpisodeFallback';
+        }
+        if (strategy === 'seasonPackFirstEpisodeFallback') {
           primaryParams = seasonOnlyParams;
           fallbackParams = queryParams;
-        } else if (this.userData.seasonPackStrategy === 'episodeFirstSeasonPackFallback') {
+        } else if (strategy === 'episodeFirstSeasonPackFallback') {
           fallbackParams = seasonOnlyParams;
         }
       }

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -211,40 +211,32 @@ export abstract class BaseNabAddon<
       const allResults = await Promise.all(searchPromises);
       results = allResults.flat();
     } else {
-      const canToggleEpisodeParam =
+      const canApplySeasonPackStrategy =
         parsedId.mediaType === 'series' &&
         !this.userData.forceQuerySearch &&
         searchCapabilities.supportedParams.includes('season') &&
         queryParams.season &&
         queryParams.ep;
 
-      if (
-        this.userData.seasonPackStrategy ===
-          'seasonPackFirstEpisodeFallback' &&
-        canToggleEpisodeParam
-      ) {
+      let primaryParams = queryParams;
+      let fallbackParams: Record<string, string> | undefined;
+      if (canApplySeasonPackStrategy) {
         const { ep, ...seasonOnlyParams } = queryParams;
-        results = await this.fetchResults(searchFunction, seasonOnlyParams);
-        if (results.length === 0) {
-          this.logger.debug(
-            'No results for season-only search, retrying with episode included'
-          );
-          results = await this.fetchResults(searchFunction, queryParams);
+        if (this.userData.seasonPackStrategy === 'seasonPackFirstEpisodeFallback') {
+          primaryParams = seasonOnlyParams;
+          fallbackParams = queryParams;
+        } else if (this.userData.seasonPackStrategy === 'episodeFirstSeasonPackFallback') {
+          fallbackParams = seasonOnlyParams;
         }
-      } else {
-        results = await this.fetchResults(searchFunction, queryParams);
-        if (
-          results.length === 0 &&
-          this.userData.seasonPackStrategy ===
-            'episodeFirstSeasonPackFallback' &&
-          canToggleEpisodeParam
-        ) {
-          this.logger.debug(
-            'No results for season+episode search, retrying with season only to find season packs'
-          );
-          const { ep, ...seasonOnlyParams } = queryParams;
-          results = await this.fetchResults(searchFunction, seasonOnlyParams);
-        }
+      }
+
+      results = await this.fetchResults(searchFunction, primaryParams);
+      if (results.length === 0 && fallbackParams) {
+        this.logger.debug(
+          'No results for initial search, retrying with alternate season/episode params',
+          { season: queryParams.season, episode: queryParams.ep }
+        );
+        results = await this.fetchResults(searchFunction, fallbackParams);
       }
     }
     this.logger.info(

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -63,6 +63,7 @@ export const NabAddonConfigSchema = BaseDebridConfigSchema.extend({
   forceQuerySearch: z.boolean().default(false),
   paginate: z.boolean().default(false),
   forceInitialLimit: z.number().min(1).max(10000).optional(),
+  seasonPackFallback: z.boolean().default(false),
 });
 export type NabAddonConfig = z.infer<typeof NabAddonConfigSchema>;
 
@@ -205,6 +206,21 @@ export abstract class BaseNabAddon<
       results = allResults.flat();
     } else {
       results = await this.fetchResults(searchFunction, queryParams);
+      if (
+        results.length === 0 &&
+        this.userData.seasonPackFallback &&
+        parsedId.mediaType === 'series' &&
+        !this.userData.forceQuerySearch &&
+        searchCapabilities.supportedParams.includes('season') &&
+        queryParams.season &&
+        queryParams.ep
+      ) {
+        this.logger.debug(
+          'No results for season+episode search, retrying with season only to find season packs'
+        );
+        const { ep, ...seasonOnlyParams } = queryParams;
+        results = await this.fetchResults(searchFunction, seasonOnlyParams);
+      }
     }
     this.logger.info(
       `Completed search for ${capabilities.server.title} in ${getTimeTakenSincePoint(start)}`,

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -195,21 +195,16 @@ export class NewznabPreset extends BuiltinAddonPreset {
         id: 'seasonPackStrategy',
         name: 'Season Pack Strategy',
         description:
-          'In `Auto` mode, whether to retry a series search with episode/season-only swapped if the first attempt finds nothing - useful for private trackers where season packs replace individual episodes. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+          'Controls episode vs. season-pack search order for series in `Auto` mode - useful for private trackers where season packs replace individual episodes. `Dynamic` decides based on whether the season is still airing. May include individual episodes too - pair with `Season/Episode Matching` in Filters to filter them out.',
         type: 'select',
         required: false,
         showInSimpleMode: false,
         default: 'episodeOnly',
         options: [
           { label: 'Episode Only', value: 'episodeOnly' },
-          {
-            label: 'Episode First, Season Pack Fallback',
-            value: 'episodeFirstSeasonPackFallback',
-          },
-          {
-            label: 'Season Pack First, Episode Fallback',
-            value: 'seasonPackFirstEpisodeFallback',
-          },
+          { label: 'Dynamic (Season Pack Preferred)', value: 'dynamic' },
+          { label: 'Episode First, Season Pack Fallback', value: 'episodeFirstSeasonPackFallback' },
+          { label: 'Season Pack First, Episode Fallback', value: 'seasonPackFirstEpisodeFallback' },
         ],
       },
       {

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -192,14 +192,25 @@ export class NewznabPreset extends BuiltinAddonPreset {
         showInSimpleMode: false,
       },
       {
-        id: 'seasonPackFallback',
-        name: 'Season Pack Fallback',
+        id: 'seasonPackStrategy',
+        name: 'Season Pack Strategy',
         description:
-          'In `Auto` mode, retries with season only (no episode) if nothing is found, to surface season packs - useful for private trackers. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
-        type: 'boolean',
-        default: false,
+          'In `Auto` mode, whether to retry a series search with episode/season-only swapped if the first attempt finds nothing - useful for private trackers where season packs replace individual episodes. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+        type: 'select',
         required: false,
         showInSimpleMode: false,
+        default: 'episodeOnly',
+        options: [
+          { label: 'Episode Only', value: 'episodeOnly' },
+          {
+            label: 'Episode First, Season Pack Fallback',
+            value: 'episodeFirstSeasonPackFallback',
+          },
+          {
+            label: 'Season Pack First, Episode Fallback',
+            value: 'seasonPackFirstEpisodeFallback',
+          },
+        ],
       },
       {
         id: 'useMultipleInstances',
@@ -427,7 +438,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
       proxyAuth: options.proxyAuth,
       forceQuerySearch: options.forceQuerySearch ?? false,
       paginate: options.paginate ?? false,
-      seasonPackFallback: options.seasonPackFallback ?? false,
+      seasonPackStrategy: options.seasonPackStrategy ?? 'episodeOnly',
       zyclopsHealthProxy: zyclopsHealthProxyConfig,
     };
 

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -192,6 +192,16 @@ export class NewznabPreset extends BuiltinAddonPreset {
         showInSimpleMode: false,
       },
       {
+        id: 'seasonPackFallback',
+        name: 'Season Pack Fallback',
+        description:
+          'In `Auto` mode, retries with season only (no episode) if nothing is found, to surface season packs - useful for private trackers. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+        type: 'boolean',
+        default: false,
+        required: false,
+        showInSimpleMode: false,
+      },
+      {
         id: 'useMultipleInstances',
         name: 'Use Multiple Instances',
         description:
@@ -417,6 +427,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
       proxyAuth: options.proxyAuth,
       forceQuerySearch: options.forceQuerySearch ?? false,
       paginate: options.paginate ?? false,
+      seasonPackFallback: options.seasonPackFallback ?? false,
       zyclopsHealthProxy: zyclopsHealthProxyConfig,
     };
 

--- a/packages/core/src/presets/torznab.ts
+++ b/packages/core/src/presets/torznab.ts
@@ -118,21 +118,16 @@ export class TorznabPreset extends BuiltinAddonPreset {
         id: 'seasonPackStrategy',
         name: 'Season Pack Strategy',
         description:
-          'In `Auto` mode, whether to retry a series search with episode/season-only swapped if the first attempt finds nothing - useful for private trackers where season packs replace individual episodes. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+          'Controls episode vs. season-pack search order for series in `Auto` mode - useful for private trackers where season packs replace individual episodes. `Dynamic` decides based on whether the season is still airing. May include individual episodes too - pair with `Season/Episode Matching` in Filters to filter them out.',
         type: 'select',
         required: false,
         showInSimpleMode: false,
         default: 'episodeOnly',
         options: [
           { label: 'Episode Only', value: 'episodeOnly' },
-          {
-            label: 'Episode First, Season Pack Fallback',
-            value: 'episodeFirstSeasonPackFallback',
-          },
-          {
-            label: 'Season Pack First, Episode Fallback',
-            value: 'seasonPackFirstEpisodeFallback',
-          },
+          { label: 'Dynamic (Season Pack Preferred)', value: 'dynamic' },
+          { label: 'Episode First, Season Pack Fallback', value: 'episodeFirstSeasonPackFallback' },
+          { label: 'Season Pack First, Episode Fallback', value: 'seasonPackFirstEpisodeFallback' },
         ],
       },
       {

--- a/packages/core/src/presets/torznab.ts
+++ b/packages/core/src/presets/torznab.ts
@@ -115,6 +115,16 @@ export class TorznabPreset extends BuiltinAddonPreset {
         ],
       },
       {
+        id: 'seasonPackFallback',
+        name: 'Season Pack Fallback',
+        description:
+          'In `Auto` mode, retries with season only (no episode) if nothing is found, to surface season packs - useful for private trackers. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+        type: 'boolean',
+        default: false,
+        required: false,
+        showInSimpleMode: false,
+      },
+      {
         id: 'initialLimit',
         name: 'Initial Result Limit',
         description:
@@ -248,6 +258,7 @@ export class TorznabPreset extends BuiltinAddonPreset {
       forceQuerySearch: options.forceQuerySearch ?? false,
       forceInitialLimit: options.initialLimit,
       paginate: options.paginate ?? false,
+      seasonPackFallback: options.seasonPackFallback ?? false,
     };
 
     const configString = this.base64EncodeJSON(config, 'urlSafe');

--- a/packages/core/src/presets/torznab.ts
+++ b/packages/core/src/presets/torznab.ts
@@ -115,14 +115,25 @@ export class TorznabPreset extends BuiltinAddonPreset {
         ],
       },
       {
-        id: 'seasonPackFallback',
-        name: 'Season Pack Fallback',
+        id: 'seasonPackStrategy',
+        name: 'Season Pack Strategy',
         description:
-          'In `Auto` mode, retries with season only (no episode) if nothing is found, to surface season packs - useful for private trackers. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
-        type: 'boolean',
-        default: false,
+          'In `Auto` mode, whether to retry a series search with episode/season-only swapped if the first attempt finds nothing - useful for private trackers where season packs replace individual episodes. May also return unrelated episodes, so enabling `Season/Episode Matching` in Filters is recommended.',
+        type: 'select',
         required: false,
         showInSimpleMode: false,
+        default: 'episodeOnly',
+        options: [
+          { label: 'Episode Only', value: 'episodeOnly' },
+          {
+            label: 'Episode First, Season Pack Fallback',
+            value: 'episodeFirstSeasonPackFallback',
+          },
+          {
+            label: 'Season Pack First, Episode Fallback',
+            value: 'seasonPackFirstEpisodeFallback',
+          },
+        ],
       },
       {
         id: 'initialLimit',
@@ -258,7 +269,7 @@ export class TorznabPreset extends BuiltinAddonPreset {
       forceQuerySearch: options.forceQuerySearch ?? false,
       forceInitialLimit: options.initialLimit,
       paginate: options.paginate ?? false,
-      seasonPackFallback: options.seasonPackFallback ?? false,
+      seasonPackStrategy: options.seasonPackStrategy ?? 'episodeOnly',
     };
 
     const configString = this.base64EncodeJSON(config, 'urlSafe');


### PR DESCRIPTION
without this e.g. seedpool or rockethd don't return anything for e.g. The Boroughs.

AI summary:

Adds a Season Pack Strategy option to the Torznab/Newznab presets, controlling how series searches balance episode-specific vs. season-pack results in Auto mode. Motivated by private trackers that "trump" (remove) individual episode torrents once a season pack is uploaded, causing a plain season+episode search to return zero results.

Options (default Episode Only — no behavior change unless configured):
- Episode Only — season+episode search, no fallback (current behavior).
- Dynamic (Season Pack Preferred) — auto-picks per request based on whether the season is still airing (reuses metadata already fetched, no new API calls): Episode Only if confirmed still airing, Season Pack First, Episode Fallback otherwise (covers both "confirmed finished" and "unknown" — always keeps the episode fallback, since a season being finished doesn't guarantee a pack has been uploaded yet).
- Episode First, Season Pack Fallback — season+episode first; retry season-only if empty.
- Season Pack First, Episode Fallback — season-only first; retry with episode if empty.

Season-pack modes can surface individual episodes too on indexers that don't cleanly separate them — pairing with the existing Season/Episode Matching filter is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added **“Season Pack Strategy”** to Newznab and Torznab preset/add-on settings, letting you choose how results are sourced from season-pack vs episode-pack (**default: Episode Only**).
* **Bug Fixes**
  * Improved series searching when both **season** and **episode** are provided by retrying on empty results using the selected season-pack strategy, including **dynamic** handling for ongoing seasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->