### PR TITLE
feat(screener): release keys and NDJSON interchange (1/6)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './utils/index.js';
 export * from './logging/ring-buffer.js';
 export * from './config/index.js';
 export * from './db/index.js';
+export * from './screener/index.js';
 export * from './analytics/index.js';
 export * from './analytics/repository.js';
 export * from './tasks/index.js';

--- a/packages/core/src/screener/fingerprint.test.ts
+++ b/packages/core/src/screener/fingerprint.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeFingerprint,
+  isValidFingerprint,
+  toUnixSeconds,
+} from './fingerprint.js';
+
+// Golden vectors are the faithful output of nzbdavex's WardenFingerprint.Compute
+// for the same inputs. If these change, aiostreams lists stop interchanging with
+// nzbdavex, treat any diff as a wire-compat break, not a test to "fix".
+const SIZE = 1073741824; // 1 GiB
+const POSTER = 'a@b.com';
+const DATE = 1719705600; // 2024-06-30 00:00:00 UTC
+
+describe('computeFingerprint (davex wd1 wire-compat)', () => {
+  it('matches the golden vector for size+poster+date', () => {
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, DATE),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('normalises poster case and surrounding whitespace', () => {
+    assert.equal(
+      computeFingerprint(SIZE, '  A@B.COM  ', DATE),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('matches the golden vector with date only (no poster)', () => {
+    assert.equal(
+      computeFingerprint(SIZE, null, DATE),
+      'wd1:0503cb01e09543055e408e9060dfd1ea'
+    );
+    assert.equal(computeFingerprint(SIZE, '   ', DATE), 'wd1:0503cb01e09543055e408e9060dfd1ea');
+  });
+
+  it('matches the golden vector with poster only (no date)', () => {
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, null),
+      'wd1:d18312f44c157e5c69f656a234986e23'
+    );
+  });
+
+  it('buckets the posting date to the day', () => {
+    const base = computeFingerprint(SIZE, POSTER, DATE);
+    assert.equal(computeFingerprint(SIZE, POSTER, DATE + 86399), base);
+    assert.notEqual(computeFingerprint(SIZE, POSTER, DATE + 86400), base);
+  });
+
+  it('returns null for non-identifying inputs', () => {
+    assert.equal(computeFingerprint(0, POSTER, DATE), null);
+    assert.equal(computeFingerprint(-1, POSTER, DATE), null);
+    assert.equal(computeFingerprint(SIZE, null, null), null);
+    assert.equal(computeFingerprint(SIZE, '  ', null), null);
+    assert.equal(computeFingerprint(Number.NaN, POSTER, DATE), null);
+  });
+
+  it('produces a syntactically valid fingerprint', () => {
+    assert.ok(isValidFingerprint(computeFingerprint(SIZE, POSTER, DATE)));
+    assert.ok(!isValidFingerprint('wd1:nothex'));
+    assert.ok(!isValidFingerprint('xx1:fbaefac71441d3539764427a8111b8c7'));
+    assert.ok(!isValidFingerprint(null));
+  });
+});
+
+describe('toUnixSeconds', () => {
+  it('passes through epoch seconds', () => {
+    assert.equal(toUnixSeconds(DATE), DATE);
+  });
+
+  it('downscales epoch milliseconds', () => {
+    assert.equal(toUnixSeconds(DATE * 1000), DATE);
+  });
+
+  it('parses an RFC-822 / ISO date string to the same bucket', () => {
+    const iso = toUnixSeconds('2024-06-30T00:00:00Z');
+    assert.equal(iso, DATE);
+    // A feed reporting a string and one reporting seconds agree on the fp.
+    assert.equal(
+      computeFingerprint(SIZE, POSTER, iso),
+      computeFingerprint(SIZE, POSTER, DATE)
+    );
+  });
+
+  it('accepts ISO date-only and rejects host-dependent date strings', () => {
+    // ISO date-only parses as UTC midnight on every host, so it shares the bucket.
+    assert.equal(toUnixSeconds('2024-06-30'), DATE);
+    // A zoneless time or a non-ISO date is locale-dependent; reject it to keep
+    // the wd1 bucket deterministic across servers.
+    assert.equal(toUnixSeconds('2024-06-30T00:00:00'), null);
+    assert.equal(toUnixSeconds('06/30/2024'), null);
+  });
+
+  it('returns null for junk', () => {
+    assert.equal(toUnixSeconds(''), null);
+    assert.equal(toUnixSeconds('not a date'), null);
+    assert.equal(toUnixSeconds(null), null);
+    assert.equal(toUnixSeconds(undefined), null);
+  });
+});

--- a/packages/core/src/screener/fingerprint.ts
+++ b/packages/core/src/screener/fingerprint.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Screener release fingerprint, a credential-free, provider/indexer-agnostic
+ * identity for a single Usenet release, derived only from its indexer-reported
+ * size, poster, and posting day.
+ *
+ * Wire-compatible with nzbdavex's `WardenFingerprint.Compute`
+ * (backend/Utils/WardenFingerprint.cs):
+ *
+ *   wd1: + lowercaseHex( SHA256(`{size}|{posterLower}|{dayBucket}`)[0..16] )
+ *
+ * The same dead release produces the same fingerprint on any server, indexer or
+ * provider, so dead-release lists are interchangeable between aiostreams and
+ * nzbdavex. The hash carries no credentials, titles or URLs, only a digest.
+ */
+
+const FP_PATTERN = /^wd1:[0-9a-f]{32}$/;
+const SECONDS_PER_DAY = 86400;
+
+/** True when `fp` is a syntactically valid `wd1:` fingerprint. */
+export function isValidFingerprint(
+  fp: string | null | undefined
+): fp is string {
+  return typeof fp === 'string' && FP_PATTERN.test(fp);
+}
+
+/**
+ * Compute a release fingerprint. Returns `null` when the inputs are too weak to
+ * identify a release (no size, or neither poster nor date), matching davex,
+ * which never stores or filters on a weak fingerprint.
+ *
+ * `size` must be the indexer-reported byte size (the exact release size), NOT
+ * the NZB's summed encoded segment size, that is what davex hashes, and using
+ * anything else would break cross-tool matching.
+ *
+ * @param size indexer-reported release size in bytes
+ * @param poster the release's poster / `from` header, if the indexer provided one
+ * @param usenetDateUnixSeconds posting date in unix *seconds*, if known
+ */
+export function computeFingerprint(
+  size: number,
+  poster: string | null | undefined,
+  usenetDateUnixSeconds: number | null | undefined
+): string | null {
+  // Byte sizes are exact integers; a fractional or above-2^53 (already-rounded)
+  // value would mint a wd1 for a size no other implementation derives.
+  if (!Number.isSafeInteger(size) || size <= 0) return null;
+
+  const hasPoster = typeof poster === 'string' && poster.trim() !== '';
+  const hasDate =
+    typeof usenetDateUnixSeconds === 'number' &&
+    Number.isFinite(usenetDateUnixSeconds);
+  if (!hasPoster && !hasDate) return null;
+
+  const posterNorm = hasPoster ? poster!.trim().toLowerCase() : '';
+  const dayBucket = hasDate
+    ? Math.floor(usenetDateUnixSeconds! / SECONDS_PER_DAY)
+    : 0;
+  const canonical = `${size}|${posterNorm}|${dayBucket}`;
+
+  const hash = createHash('sha256').update(canonical, 'utf8').digest();
+  return 'wd1:' + hash.subarray(0, 16).toString('hex');
+}
+
+/**
+ * Coerce an indexer-supplied date (epoch seconds, epoch millis, a `Date`, or a
+ * parseable date string such as RFC-822 `pubDate` / newznab `usenetdate`) to
+ * unix *seconds*, or `null` if it can't be parsed. Values that already look
+ * like epoch seconds are passed through so a feed reporting seconds and one
+ * reporting an equivalent ISO string land on the same day bucket.
+ */
+export function toUnixSeconds(
+  value: string | number | Date | null | undefined
+): number | null {
+  if (value == null) return null;
+
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null;
+    // Heuristic: >1e11 is almost certainly milliseconds (year ~5138 in seconds).
+    return Math.floor(value > 1e11 ? value / 1000 : value);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? Math.floor(n > 1e11 ? n / 1000 : n) : null;
+  }
+
+  // Only an ISO date-only string (parsed as UTC) or an explicitly-zoned string
+  // resolves to the same instant on every host. A tz-less time or a non-ISO date
+  // is locale-dependent and would bucket the wd1 differently, so reject it.
+  const isoDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(trimmed);
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2}|\b(?:GMT|UTC|UT)\b)/i.test(trimmed);
+  if (!isoDateOnly && !hasZone) return null;
+  const ms = Date.parse(trimmed);
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000);
+}

--- a/packages/core/src/screener/index.ts
+++ b/packages/core/src/screener/index.ts
@@ -1,0 +1,45 @@
+export {
+  type Verdict,
+  VERDICTS,
+  isVerdict,
+  moreSevere,
+  type Trust,
+  TRUSTS,
+  normaliseTrust,
+  type ReleaseKind,
+  type SourceKind,
+  LOCAL_SOURCE_ID,
+  type ScreenerEntry,
+  type ScreenerRecord,
+  type ScreenerSource,
+  type ScreenerEvalOptions,
+  type ScreenerVerdict,
+} from './types.js';
+export {
+  computeFingerprint,
+  isValidFingerprint,
+  toUnixSeconds,
+} from './fingerprint.js';
+export { torrentKey, usenetKey, keyKind, isValidKey, parseKey } from './key.js';
+export {
+  toNdjson,
+  toDavexNdjson,
+  parseNdjson,
+  dedupeRecords,
+  type ParsedNdjson,
+} from './io.js';
+export { streamReleaseKey, type KeyableStream } from './stream-key.js';
+export {
+  applyScreener,
+  isReleaseScreened,
+  type ScreenerUserOptions,
+} from './filter.js';
+export { markReleaseDead } from './feedback.js';
+export { ScreenerRemoteSourceService } from './remote.js';
+export { isUnsafeRemoteUrl } from './url-safety.js';
+export {
+  ScreenerGitHubSyncService,
+  type GitHubSyncConfig,
+  type GitHubSyncView,
+  type GitHubSyncInput,
+} from './github-sync.js';

--- a/packages/core/src/screener/io.test.ts
+++ b/packages/core/src/screener/io.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { toNdjson, toDavexNdjson, parseNdjson, dedupeRecords } from './io.js';
+import type { ScreenerRecord } from './types.js';
+
+const WD1 = 'wd1:fbaefac71441d3539764427a8111b8c7';
+const BTIH = 'btih:' + 'a'.repeat(40);
+
+const RECORDS: ScreenerRecord[] = [
+  { k: WD1, v: 'dead', n: 3, at: 1719705600, bk: ['news.example.com'] },
+  { k: BTIH, v: 'fake', n: 1, at: 1719705600 },
+];
+
+describe('native NDJSON round-trip', () => {
+  it('writes a header then one record per line', () => {
+    const text = toNdjson(RECORDS, 1719799999);
+    const lines = text.trim().split('\n');
+    assert.deepEqual(JSON.parse(lines[0]), { screener: 1, updated: 1719799999 });
+    assert.equal(lines.length, 3);
+  });
+
+  it('parses back to the same records (skipping the header)', () => {
+    const { records, invalid } = parseNdjson(toNdjson(RECORDS, 1719799999));
+    assert.equal(invalid, 0);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records[0], RECORDS[0]);
+    assert.equal(records[1].k, BTIH);
+    assert.equal(records[1].v, 'fake');
+  });
+});
+
+describe('davex bridge', () => {
+  it('exports only the dead usenet subset in davex format', () => {
+    const text = toDavexNdjson(RECORDS, 1719799999);
+    const lines = text.trim().split('\n');
+    assert.deepEqual(JSON.parse(lines[0]), { warden: 1, updated: 1719799999 });
+    // BTIH (torrent) and any non-dead are dropped; only the WD1 dead remains.
+    assert.equal(lines.length, 2);
+    assert.deepEqual(JSON.parse(lines[1]), {
+      fp: WD1,
+      bk: ['news.example.com'],
+      deadAt: 1719705600,
+      n: 3,
+    });
+  });
+
+  it('imports a davex file as dead usenet verdicts', () => {
+    const davex =
+      JSON.stringify({ warden: 1, updated: 1719799999 }) +
+      '\n' +
+      JSON.stringify({ fp: WD1, bk: ['news.example.com'], deadAt: 1719705600, n: 5 }) +
+      '\n';
+    const { records, invalid } = parseNdjson(davex);
+    assert.equal(invalid, 0);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], {
+      k: WD1,
+      v: 'dead',
+      n: 5,
+      at: 1719705600,
+      bk: ['news.example.com'],
+    });
+  });
+
+  it('round-trips aiostreams -> davex -> aiostreams losslessly for dead usenet', () => {
+    const davex = toDavexNdjson(RECORDS, 1719799999);
+    const { records } = parseNdjson(davex);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], RECORDS[0]);
+  });
+});
+
+describe('parse robustness', () => {
+  it('counts malformed lines as invalid but keeps good ones', () => {
+    const text = [
+      JSON.stringify({ screener: 1, updated: 1 }),
+      JSON.stringify({ k: WD1, v: 'dead', n: 1, at: 1719705600 }),
+      'not json',
+      JSON.stringify({ k: 'bogus-key', v: 'dead', n: 1, at: 1 }),
+      JSON.stringify({ k: BTIH, v: 'not-a-verdict', n: 1, at: 1 }),
+      '# a comment',
+      '',
+    ].join('\n');
+    const { records, invalid } = parseNdjson(text);
+    assert.equal(records.length, 1);
+    assert.equal(invalid, 3); // bad json, bad key, bad verdict
+  });
+
+  it('defaults a non-positive count to 1', () => {
+    const { records } = parseNdjson(
+      JSON.stringify({ k: BTIH, v: 'dead', n: 0, at: 5 }) + '\n'
+    );
+    assert.equal(records[0].n, 1);
+  });
+
+  it('trims backbones and drops blank ones on import', () => {
+    const { records } = parseNdjson(
+      JSON.stringify({
+        k: WD1,
+        v: 'dead',
+        n: 1,
+        at: 5,
+        bk: ['  news.a.com ', '', '   ', 'news.b.com'],
+      }) + '\n'
+    );
+    assert.deepEqual(records[0].bk, ['news.a.com', 'news.b.com']);
+  });
+});
+
+describe('dedupeRecords (export merge)', () => {
+  it('keeps the most severe verdict, sums counts, takes the newest timestamp', () => {
+    const out = dedupeRecords([
+      { k: WD1, v: 'dead', n: 2, at: 10, bk: ['a.com'] },
+      { k: WD1, v: 'mislabeled', n: 3, at: 20, bk: ['b.com'] },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].v, 'dead');
+    assert.equal(out[0].n, 5);
+    assert.equal(out[0].at, 20);
+    assert.deepEqual(out[0].bk, ['a.com', 'b.com']);
+  });
+
+  it('stays global when either side is unscoped', () => {
+    const out = dedupeRecords([
+      { k: WD1, v: 'dead', n: 1, at: 10, bk: ['a.com'] },
+      { k: WD1, v: 'dead', n: 1, at: 10 },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].bk, undefined);
+  });
+});

--- a/packages/core/src/screener/io.ts
+++ b/packages/core/src/screener/io.ts
@@ -1,0 +1,187 @@
+import { isValidKey, keyKind } from './key.js';
+import {
+  isVerdict,
+  moreSevere,
+  N_CAP,
+  type ScreenerRecord,
+  type Verdict,
+} from './types.js';
+
+/**
+ * The portable interchange format. NDJSON: a header line then one record per
+ * line. Two dialects are read transparently on import:
+ *
+ *   native (aiostreams)  header {"screener":1,"updated":<unix>}
+ *                        record {"k":"btih:...|wd1:...","v":"dead","n":1,"at":<unix>,"bk":[...]}
+ *
+ *   davex  (nzbdavex)    header {"warden":1,"updated":<unix>}
+ *                        record {"fp":"wd1:...","bk":[...],"deadAt":<unix>,"n":1}
+ *
+ * davex only carries dead usenet fingerprints, so its records import as
+ * `verdict: 'dead'`. Exporting the usenet subset back to davex (see
+ * `toDavexNdjson`) is lossless, which is what keeps the two ecosystems sharing
+ * one pool.
+ */
+
+export interface ParsedNdjson {
+  records: ScreenerRecord[];
+  /** Lines that were non-empty but not a valid record (excludes the header). */
+  invalid: number;
+}
+
+/** Serialize records as native NDJSON with a header stamped `updatedAt`. */
+export function toNdjson(
+  records: readonly ScreenerRecord[],
+  updatedAt: number
+): string {
+  const lines: string[] = [
+    JSON.stringify({ screener: 1, updated: Math.trunc(updatedAt) }),
+  ];
+  for (const r of records) {
+    const line: ScreenerRecord = { k: r.k, v: r.v, n: r.n, at: r.at };
+    if (r.bk && r.bk.length > 0) line.bk = r.bk;
+    lines.push(JSON.stringify(line));
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Serialize the usenet (`wd1:`) subset as davex-format NDJSON so the list can be
+ * consumed by an nzbdavex Warden. Non-usenet keys are dropped (davex can't use
+ * them). Only `dead` is meaningful to davex; other verdicts are dropped.
+ */
+export function toDavexNdjson(
+  records: readonly ScreenerRecord[],
+  updatedAt: number
+): string {
+  const lines: string[] = [
+    JSON.stringify({ warden: 1, updated: Math.trunc(updatedAt) }),
+  ];
+  for (const r of records) {
+    if (r.v !== 'dead' || keyKind(r.k) !== 'usenet') continue;
+    lines.push(
+      JSON.stringify({ fp: r.k, bk: r.bk ?? [], deadAt: r.at, n: r.n })
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Build a record from an already-parsed line, or null if it isn't a usable one. */
+function parseLine(obj: any): ScreenerRecord | null {
+  if (obj === null || typeof obj !== 'object') return null;
+
+  // davex record
+  if (typeof obj.fp === 'string') {
+    if (!isValidKey(obj.fp) || keyKind(obj.fp) !== 'usenet') return null;
+    const rec: ScreenerRecord = {
+      k: obj.fp,
+      v: 'dead',
+      n: toCount(obj.n),
+      at: toUnix(obj.deadAt),
+    };
+    const bk = toBk(obj.bk);
+    if (bk) rec.bk = bk;
+    return rec;
+  }
+
+  // native record
+  if (typeof obj.k === 'string') {
+    if (!isValidKey(obj.k) || !isVerdict(obj.v)) return null;
+    const rec: ScreenerRecord = {
+      k: obj.k,
+      v: obj.v as Verdict,
+      n: toCount(obj.n),
+      at: toUnix(obj.at),
+    };
+    const bk = toBk(obj.bk);
+    if (bk) rec.bk = bk;
+    return rec;
+  }
+
+  // header ({screener|warden, updated}) or unknown shape
+  return null;
+}
+
+/** Parse a whole NDJSON document (native or davex), skipping header/blank lines. */
+export function parseNdjson(text: string): ParsedNdjson {
+  const records: ScreenerRecord[] = [];
+  let invalid = 0;
+  for (const raw of text.split('\n')) {
+    const trimmed = raw.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      invalid++;
+      continue;
+    }
+    // A header line is valid input, not an invalid record, don't count it.
+    if (isHeader(obj)) continue;
+    const rec = parseLine(obj);
+    if (rec) records.push(rec);
+    else invalid++;
+  }
+  return { records, invalid };
+}
+
+function isHeader(obj: any): boolean {
+  if (!obj || typeof obj !== 'object') return false;
+  if (obj.k !== undefined || obj.fp !== undefined) return false;
+  // The version field must be a number, so a malformed first line like
+  // {"screener":"oops"} is treated as an invalid record, not a header.
+  return typeof obj.screener === 'number' || typeof obj.warden === 'number';
+}
+
+function toCount(n: unknown): number {
+  const v = Number(n);
+  // A positive but fractional count still means "seen once", never truncate it
+  // to 0 and silently drop the record's weight. Capped so a crafted import can't
+  // seed an absurd count that survives later merges.
+  return Number.isFinite(v) && v > 0
+    ? Math.min(Math.max(1, Math.trunc(v)), N_CAP)
+    : 1;
+}
+
+function toUnix(at: unknown): number {
+  const v = Number(at);
+  return Number.isFinite(v) && v > 0 ? Math.trunc(v) : 0;
+}
+
+function toBk(bk: unknown): string[] | undefined {
+  if (!Array.isArray(bk)) return undefined;
+  const out = bk
+    .filter((b): b is string => typeof b === 'string' && b.trim() !== '')
+    .map((b) => b.trim());
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Merge duplicate records (same key) across sources for export. Keeps the most
+ * severe verdict, sums counts (capped), takes the newest timestamp, and unions
+ * backbones, an empty/omitted `bk` is global and stays global rather than being
+ * narrowed by a scoped sibling.
+ */
+export function dedupeRecords(
+  records: readonly ScreenerRecord[]
+): ScreenerRecord[] {
+  const merged = new Map<string, ScreenerRecord>();
+  for (const rec of records) {
+    const existing = merged.get(rec.k);
+    if (!existing) {
+      merged.set(rec.k, { ...rec });
+      continue;
+    }
+    existing.v = moreSevere(existing.v, rec.v);
+    existing.n = Math.min(existing.n + rec.n, N_CAP);
+    existing.at = Math.max(existing.at, rec.at);
+    const existingBk = existing.bk ?? [];
+    const recBk = rec.bk ?? [];
+    if (existingBk.length === 0 || recBk.length === 0) {
+      delete existing.bk;
+    } else {
+      existing.bk = [...new Set([...existingBk, ...recBk])];
+    }
+  }
+  return [...merged.values()];
+}

--- a/packages/core/src/screener/key.test.ts
+++ b/packages/core/src/screener/key.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  torrentKey,
+  usenetKey,
+  keyKind,
+  isValidKey,
+  parseKey,
+} from './key.js';
+
+const HASH40 = 'abcdef0123456789abcdef0123456789abcdef01';
+const HASH64 = 'a'.repeat(64);
+
+describe('torrentKey', () => {
+  it('lowercases and prefixes a v1 infohash', () => {
+    assert.equal(torrentKey(HASH40.toUpperCase()), `btih:${HASH40}`);
+    assert.equal(torrentKey(`  ${HASH40}  `), `btih:${HASH40}`);
+  });
+
+  it('accepts a v2 (64-hex) infohash', () => {
+    assert.equal(torrentKey(HASH64), `btih:${HASH64}`);
+  });
+
+  it('rejects non-hex / wrong-length / empty', () => {
+    assert.equal(torrentKey('not-a-hash'), null);
+    assert.equal(torrentKey('abc'), null);
+    assert.equal(torrentKey(''), null);
+    assert.equal(torrentKey(null), null);
+  });
+});
+
+describe('usenetKey', () => {
+  it('delegates to the wd1 fingerprint', () => {
+    assert.equal(
+      usenetKey(1073741824, 'a@b.com', 1719705600),
+      'wd1:fbaefac71441d3539764427a8111b8c7'
+    );
+  });
+
+  it('returns null for non-identifying input', () => {
+    assert.equal(usenetKey(0, 'a@b.com', 1719705600), null);
+  });
+});
+
+describe('keyKind / isValidKey / parseKey', () => {
+  it('classifies torrent and usenet keys by prefix', () => {
+    assert.equal(keyKind(`btih:${HASH40}`), 'torrent');
+    assert.equal(keyKind('wd1:fbaefac71441d3539764427a8111b8c7'), 'usenet');
+  });
+
+  it('rejects malformed keys', () => {
+    assert.equal(keyKind('btih:xyz'), null);
+    assert.equal(keyKind('wd1:nothex'), null);
+    assert.equal(keyKind('plain'), null);
+    assert.equal(keyKind(null), null);
+    assert.ok(!isValidKey('btih:short'));
+  });
+
+  it('parseKey strips the btih prefix but keeps the wd1 key whole', () => {
+    assert.deepEqual(parseKey(`btih:${HASH40}`), {
+      kind: 'torrent',
+      id: HASH40,
+    });
+    assert.deepEqual(parseKey('wd1:fbaefac71441d3539764427a8111b8c7'), {
+      kind: 'usenet',
+      id: 'wd1:fbaefac71441d3539764427a8111b8c7',
+    });
+    assert.equal(parseKey('garbage'), null);
+  });
+});

--- a/packages/core/src/screener/key.ts
+++ b/packages/core/src/screener/key.ts
@@ -1,0 +1,63 @@
+import { computeFingerprint, isValidFingerprint } from './fingerprint.js';
+import type { ReleaseKind } from './types.js';
+
+/**
+ * A Screener release key is a self-describing, credential-free identity for a
+ * release, stable across indexers/providers/servers so verdicts can be shared:
+ *
+ *   torrent  ->  btih:<infohash>      (lowercase hex; bittorrent v1 or v2)
+ *   usenet   ->  wd1:<fingerprint>    (davex-compatible; size|poster|day)
+ *
+ * `releaseKind` is re-exported from types for callers that key off the prefix.
+ */
+
+export type { ReleaseKind } from './types.js';
+
+const BTIH_V1 = /^[0-9a-f]{40}$/;
+const BTIH_V2 = /^[0-9a-f]{64}$/;
+
+/** Build a torrent key from an infohash, or null if it isn't recognisable. */
+export function torrentKey(infoHash: string | null | undefined): string | null {
+  if (typeof infoHash !== 'string') return null;
+  const h = infoHash.trim().toLowerCase();
+  if (BTIH_V1.test(h) || BTIH_V2.test(h)) return `btih:${h}`;
+  return null;
+}
+
+/**
+ * Build a usenet key from indexer-reported size/poster/date. Returns the
+ * `wd1:` fingerprint (already prefix-tagged) or null for non-identifying input.
+ */
+export function usenetKey(
+  size: number,
+  poster: string | null | undefined,
+  usenetDateUnixSeconds: number | null | undefined
+): string | null {
+  return computeFingerprint(size, poster, usenetDateUnixSeconds);
+}
+
+/** The kind a key denotes, from its prefix, or null if unrecognised/invalid. */
+export function keyKind(key: string | null | undefined): ReleaseKind | null {
+  if (typeof key !== 'string') return null;
+  if (key.startsWith('btih:')) {
+    const h = key.slice(5);
+    return BTIH_V1.test(h) || BTIH_V2.test(h) ? 'torrent' : null;
+  }
+  if (key.startsWith('wd1:')) return isValidFingerprint(key) ? 'usenet' : null;
+  return null;
+}
+
+/** True when `key` is a syntactically valid release key. */
+export function isValidKey(key: string | null | undefined): key is string {
+  return keyKind(key) !== null;
+}
+
+/** Split a key into its kind and raw id (`btih:` keys lose the prefix). */
+export function parseKey(
+  key: string | null | undefined
+): { kind: ReleaseKind; id: string } | null {
+  const kind = keyKind(key);
+  if (!kind) return null;
+  const k = key as string;
+  return { kind, id: kind === 'torrent' ? k.slice(5) : k };
+}

--- a/packages/core/src/screener/stream-key.test.ts
+++ b/packages/core/src/screener/stream-key.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { streamReleaseKey } from './stream-key.js';
+
+const HASH = 'a'.repeat(40);
+const WD1 = 'wd1:fbaefac71441d3539764427a8111b8c7';
+
+describe('streamReleaseKey', () => {
+  it('derives a btih key from a torrent infohash', () => {
+    assert.equal(
+      streamReleaseKey({ type: 'debrid', torrent: { infoHash: HASH.toUpperCase() } }),
+      `btih:${HASH}`
+    );
+  });
+
+  it('derives a btih key from a top-level infohash', () => {
+    assert.equal(
+      streamReleaseKey({ type: 'debrid', infoHash: HASH.toUpperCase() }),
+      `btih:${HASH}`
+    );
+  });
+
+  it('uses a precomputed usenet key', () => {
+    assert.equal(
+      streamReleaseKey({ type: 'usenet', screenerKey: WD1 }),
+      WD1
+    );
+  });
+
+  it('prefers the infohash when both are present', () => {
+    assert.equal(
+      streamReleaseKey({ torrent: { infoHash: HASH }, screenerKey: WD1 }),
+      `btih:${HASH}`
+    );
+  });
+
+  it('returns null when nothing identifies the release', () => {
+    assert.equal(streamReleaseKey({ type: 'usenet' }), null);
+    assert.equal(streamReleaseKey({ type: 'http', torrent: null }), null);
+    assert.equal(streamReleaseKey({ screenerKey: 'not-a-key' }), null);
+    // A usenet stream must not adopt a torrent (btih) key via screenerKey.
+    assert.equal(
+      streamReleaseKey({ type: 'usenet', screenerKey: `btih:${HASH}` }),
+      null
+    );
+  });
+});

--- a/packages/core/src/screener/stream-key.ts
+++ b/packages/core/src/screener/stream-key.ts
@@ -1,0 +1,27 @@
+import { keyKind, torrentKey } from './key.js';
+
+/** The minimal shape of a stream needed to derive its Screener release key. */
+export interface KeyableStream {
+  type?: string;
+  /** Top-level infohash on raw stream objects (parsed streams nest it below). */
+  infoHash?: string | null;
+  torrent?: { infoHash?: string | null } | null;
+  /** Precomputed usenet key (`wd1:...`), set by the producing builtin. */
+  screenerKey?: string;
+}
+
+/**
+ * The release key for a stream, or null if it can't be identified. Torrents and
+ * debrid-over-torrent resolve from their infohash; usenet uses the key the
+ * builtin precomputed from size/poster/date (external usenet addons that don't
+ * provide one are simply not screened, they do their own filtering).
+ */
+export function streamReleaseKey(stream: KeyableStream): string | null {
+  const fromInfoHash = torrentKey(stream.torrent?.infoHash ?? stream.infoHash);
+  if (fromInfoHash) return fromInfoHash;
+  // screenerKey is usenet-only (wd1); a torrent key here would already have come
+  // from the infohash above.
+  const sk = stream.screenerKey;
+  if (sk && keyKind(sk) === 'usenet') return sk;
+  return null;
+}

--- a/packages/core/src/screener/types.ts
+++ b/packages/core/src/screener/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared Screener shapes. Screener is aiostreams' community-shareable filter of bad
+ * releases, keyed by a credential-free release identity (see `key.ts`). The
+ * usenet subset is wire-compatible with nzbdavex (see `io.ts`).
+ */
+
+/** The class of source a release came from, derived from its key prefix. */
+export type ReleaseKind = 'torrent' | 'usenet';
+
+/** What a source says is wrong with a release. */
+export type Verdict = 'dead' | 'fake' | 'mislabeled';
+
+export const VERDICTS: readonly Verdict[] = ['dead', 'fake', 'mislabeled'];
+
+/**
+ * Severity for merge/display when sources disagree (higher wins). All verdicts
+ * filter equally; severity only decides which label a release surfaces under.
+ */
+const VERDICT_SEVERITY: Record<Verdict, number> = {
+  fake: 3,
+  dead: 2,
+  mislabeled: 1,
+};
+
+export function isVerdict(v: string): v is Verdict {
+  return (VERDICTS as readonly string[]).includes(v);
+}
+
+/** Pick the more severe of two verdicts. */
+export function moreSevere(a: Verdict, b: Verdict): Verdict {
+  return VERDICT_SEVERITY[a] >= VERDICT_SEVERITY[b] ? a : b;
+}
+
+/**
+ * How much a source is trusted, mirroring nzbdavex:
+ *  - full        filters on its own
+ *  - corroborate filters only when >= quorum sources agree
+ *  - observe     never filters (kept for visibility only)
+ */
+export type Trust = 'full' | 'corroborate' | 'observe';
+
+export const TRUSTS: readonly Trust[] = ['full', 'corroborate', 'observe'];
+
+export function normaliseTrust(t: string | null | undefined): Trust {
+  const v = t?.trim().toLowerCase();
+  return v === 'full' || v === 'observe' ? v : 'corroborate';
+}
+
+/** The fixed id of the always-present, auto-filling local source. */
+export const LOCAL_SOURCE_ID = 'local';
+
+/** Cap on a verdict's observation count, to bound storage and merges. */
+export const N_CAP = 1_000_000_000;
+
+export type SourceKind = 'local' | 'remote' | 'imported';
+
+/** A single stored verdict for one release, from one source. */
+export interface ScreenerEntry {
+  /** Release key: `btih:<hash>` or `wd1:<fingerprint>`. */
+  key: string;
+  verdict: Verdict;
+  /** Number of times this verdict has been observed. */
+  n: number;
+  /** Last-seen, unix seconds. */
+  lastAt: number;
+  /** Usenet backbones / torrent trackers that observed it, for scoping. */
+  backbones: string[];
+}
+
+/** One line of the native NDJSON interchange format. Compact keys keep it small. */
+export interface ScreenerRecord {
+  /** key */
+  k: string;
+  /** verdict */
+  v: Verdict;
+  /** count */
+  n: number;
+  /** last-seen unix seconds */
+  at: number;
+  /** backbones / trackers */
+  bk?: string[];
+}
+
+/** A configured list a user/operator pulls verdicts from. */
+export interface ScreenerSource {
+  id: string;
+  kind: SourceKind;
+  name: string;
+  url: string | null;
+  enabled: boolean;
+  trust: Trust;
+  refreshSeconds: number;
+  lastChecked: number;
+  lastUpdated: number;
+  status: string | null;
+  /** Number of entries contributed by this source. */
+  count: number;
+}
+
+/** Per-request knobs that decide whether a key is filtered. From UserData. */
+export interface ScreenerEvalOptions {
+  /** Sources must agree this many times before a `corroborate` verdict filters. */
+  quorum: number;
+  /** Only honour remote/imported verdicts whose backbone matches one of mine. */
+  backboneScope: boolean;
+  /** My usenet backbones (root domains) / trackers, for backbone scoping. */
+  myBackbones: string[];
+  /**
+   * Extra backbones (root domains) to honour under scope even when they aren't
+   * mine, e.g. same-backbone resellers. Empty/undefined = scope by mine only.
+   */
+  trustedBackbones?: string[];
+}
+
+/** The outcome of evaluating one release key against all enabled sources. */
+export interface ScreenerVerdict {
+  filtered: boolean;
+  verdict: Verdict | null;
+  /** Short human reason, e.g. "dead (3 sources)". */
+  reason: string | null;
+}


### PR DESCRIPTION
Part 1 of the Screener feature (Warden for AIOStreams), split out from #1056 for review.

This is the release identity everything else is built on, plus the portable list format:

- `btih:<infohash>` for torrents, a nzbdavex/Warden-compatible `wd1:<fingerprint>` for usenet. The fingerprint is credential-free (`sha256(size|poster|day)`, first 16 bytes), so a shared list carries only digests, no titles/URLs/account info.
- NDJSON import/export that reads and writes both aiostreams-native and Warden lists, which is what lets the two ecosystems share one pool.

Pure functions, no pipeline wiring. Unit tests cover fingerprint/key parity with Warden and NDJSON round-trips in both dialects.

Contains only its own files, so it won't build standalone. Merge order is 1 → 6; see #1056 for the full feature.
---
**Screener, split from #1056 into 6 parts to review in passes. Merge in order:**
1. #1063 — release keys + NDJSON interchange
2. #1064 — verdict store + migrations
3. #1065 — evaluator + config
4. #1066 — pipeline filter
5. #1067 — API + remote + GitHub sync
6. #1068 — dashboard
