### PR TITLE
feat(screener): verdict store and migrations (2/6)

### DIFF
--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -26,6 +26,7 @@ export {
   type UsenetProviderRollup,
   type UsenetMetricBucket,
 } from './repositories/usenet-metrics.js';
+export { ScreenerStore } from './repositories/screener.js';
 export * from './schemas.js';
 
 export { sql, raw, join, SqlFragment } from './sql.js';

--- a/packages/core/src/db/migrations/0012_screener.ts
+++ b/packages/core/src/db/migrations/0012_screener.ts
@@ -1,0 +1,116 @@
+import type { Migration } from './types.js';
+
+/**
+ * Screener: aiostreams' community-shareable filter of bad releases. Two tables,
+ * both instance-global (one shared store per instance; per-user toggles live in
+ * UserData):
+ *
+ *   screener_sources  configured lists a verdict can come from. Always seeded
+ *                     with the 'local' source, which auto-fills from this
+ *                     instance's own playback failures / STAT dead-aborts.
+ *                     Remote sources are URL subscriptions; imported sources are
+ *                     one-off file imports. trust = full | corroborate | observe.
+ *
+ *   screener_entries  one verdict per (source, release key). `k` is a
+ *                     self-describing release key (`btih:<hash>` for torrents,
+ *                     `wd1:<fingerprint>` for usenet, the latter
+ *                     wire-compatible with nzbdavex). `kind` is derived from the
+ *                     prefix so usenet entries can be exported in davex format
+ *                     and torrent/usenet filtering can be scoped independently.
+ *
+ * Unix-second columns use sqlite INTEGER (64-bit) / postgres BIGINT to stay
+ * 2038-safe.
+ */
+export const screener: Migration = {
+  id: 12,
+  name: 'screener',
+  up: {
+    sqlite: `
+      CREATE TABLE IF NOT EXISTS screener_sources (
+        id            TEXT PRIMARY KEY,
+        kind          TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        url           TEXT,
+        enabled       INTEGER NOT NULL DEFAULT 1,
+        trust         TEXT NOT NULL DEFAULT 'corroborate',
+        refresh_hours INTEGER NOT NULL DEFAULT 24,
+        last_checked  INTEGER NOT NULL DEFAULT 0,
+        last_updated  INTEGER NOT NULL DEFAULT 0,
+        etag          TEXT,
+        status        TEXT,
+        sort          INTEGER NOT NULL DEFAULT 0,
+        CHECK (kind IN ('local', 'remote', 'imported')),
+        CHECK (enabled IN (0, 1)),
+        CHECK (trust IN ('full', 'corroborate', 'observe')),
+        CHECK (refresh_hours > 0),
+        CHECK (kind <> 'remote' OR (url IS NOT NULL AND trim(url) <> ''))
+      );
+
+      CREATE TABLE IF NOT EXISTS screener_entries (
+        source_id TEXT NOT NULL REFERENCES screener_sources(id) ON DELETE CASCADE,
+        k         TEXT NOT NULL,
+        kind      TEXT NOT NULL,
+        verdict   TEXT NOT NULL,
+        n         INTEGER NOT NULL DEFAULT 1,
+        last_at   INTEGER NOT NULL DEFAULT 0,
+        backbones TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (source_id, k),
+        CHECK ((kind = 'torrent' AND substr(k, 1, 5) = 'btih:') OR (kind = 'usenet' AND substr(k, 1, 4) = 'wd1:')),
+        CHECK (verdict IN ('dead', 'fake', 'mislabeled')),
+        CHECK (n >= 0),
+        CHECK (last_at >= 0)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_screener_entries_k
+        ON screener_entries (k);
+
+      INSERT OR IGNORE INTO screener_sources
+        (id, kind, name, url, enabled, trust, refresh_hours)
+        VALUES ('local', 'local', 'This instance', NULL, 1, 'full', 24);
+    `,
+    postgres: `
+      CREATE TABLE IF NOT EXISTS screener_sources (
+        id            TEXT PRIMARY KEY,
+        kind          TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        url           TEXT,
+        enabled       INTEGER NOT NULL DEFAULT 1,
+        trust         TEXT NOT NULL DEFAULT 'corroborate',
+        refresh_hours INTEGER NOT NULL DEFAULT 24,
+        last_checked  BIGINT NOT NULL DEFAULT 0,
+        last_updated  BIGINT NOT NULL DEFAULT 0,
+        etag          TEXT,
+        status        TEXT,
+        sort          INTEGER NOT NULL DEFAULT 0,
+        CHECK (kind IN ('local', 'remote', 'imported')),
+        CHECK (enabled IN (0, 1)),
+        CHECK (trust IN ('full', 'corroborate', 'observe')),
+        CHECK (refresh_hours > 0),
+        CHECK (kind <> 'remote' OR (url IS NOT NULL AND trim(url) <> ''))
+      );
+
+      CREATE TABLE IF NOT EXISTS screener_entries (
+        source_id TEXT NOT NULL REFERENCES screener_sources(id) ON DELETE CASCADE,
+        k         TEXT NOT NULL,
+        kind      TEXT NOT NULL,
+        verdict   TEXT NOT NULL,
+        n         BIGINT NOT NULL DEFAULT 1,
+        last_at   BIGINT NOT NULL DEFAULT 0,
+        backbones TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (source_id, k),
+        CHECK ((kind = 'torrent' AND substr(k, 1, 5) = 'btih:') OR (kind = 'usenet' AND substr(k, 1, 4) = 'wd1:')),
+        CHECK (verdict IN ('dead', 'fake', 'mislabeled')),
+        CHECK (n >= 0),
+        CHECK (last_at >= 0)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_screener_entries_k
+        ON screener_entries (k);
+
+      INSERT INTO screener_sources
+        (id, kind, name, url, enabled, trust, refresh_hours)
+        VALUES ('local', 'local', 'This instance', NULL, 1, 'full', 24)
+        ON CONFLICT (id) DO NOTHING;
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/0013_screener_refresh_seconds.ts
+++ b/packages/core/src/db/migrations/0013_screener_refresh_seconds.ts
@@ -1,0 +1,26 @@
+import type { Migration } from './types.js';
+
+/**
+ * Store Screener's remote-source refresh interval in seconds rather than
+ * hours, so it accepts fine-grained durations (matching the rest of the config).
+ * Renames the column and scales existing values in place; `RENAME COLUMN`
+ * carries the column's CHECK constraint over on both SQLite (3.25+) and Postgres.
+ */
+export const screenerRefreshSeconds: Migration = {
+  id: 13,
+  name: 'screener_refresh_seconds',
+  up: {
+    sqlite: `
+      ALTER TABLE screener_sources RENAME COLUMN refresh_hours TO refresh_seconds;
+      UPDATE screener_sources SET refresh_seconds = refresh_seconds * 3600;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_screener_sources_one_local
+        ON screener_sources (kind) WHERE kind = 'local';
+    `,
+    postgres: `
+      ALTER TABLE screener_sources RENAME COLUMN refresh_hours TO refresh_seconds;
+      UPDATE screener_sources SET refresh_seconds = refresh_seconds * 3600;
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_screener_sources_one_local
+        ON screener_sources (kind) WHERE kind = 'local';
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -9,6 +9,8 @@ import { usenetMetrics } from './0008_usenet_metrics.js';
 import { usenetLibraryExt } from './0009_usenet_library_ext.js';
 import { usenetLibraryPassword } from './0010_usenet_library_password.js';
 import { usenetSpeed } from './0011_usenet_speed.js';
+import { screener } from './0012_screener.js';
+import { screenerRefreshSeconds } from './0013_screener_refresh_seconds.js';
 import type { Migration } from './types.js';
 
 export const MIGRATIONS: readonly Migration[] = [
@@ -23,6 +25,8 @@ export const MIGRATIONS: readonly Migration[] = [
   usenetLibraryExt,
   usenetLibraryPassword,
   usenetSpeed,
+  screener,
+  screenerRefreshSeconds,
 ];
 
 export type { Migration } from './types.js';

--- a/packages/core/src/db/repositories/screener.sql.test.ts
+++ b/packages/core/src/db/repositories/screener.sql.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import { screener } from '../migrations/0012_screener.js';
+import { screenerRefreshSeconds } from '../migrations/0013_screener_refresh_seconds.js';
+import { evaluateKey, type SourceVerdict } from '../../screener/evaluate.js';
+import { dedupeRecords } from '../../screener/io.js';
+import { N_CAP, type ScreenerRecord } from '../../screener/types.js';
+
+/**
+ * Validates the exact SQL ScreenerStore emits against a real sqlite engine. The
+ * store itself can't be imported here (it pulls db.js -> logger, a module-graph
+ * cycle that only resolves from the app entry), so these statements mirror the
+ * store's; keep them in sync. The export merge is the store's real `dedupeRecords`
+ * run over raw rows, so that half can't drift. End-to-end store coverage happens
+ * at app runtime.
+ */
+
+const DB_PATH = `${tmpdir()}/screener-sql-${process.pid}.db`;
+const TORRENT = 'btih:' + 'a'.repeat(40);
+const USENET = 'wd1:' + 'b'.repeat(32);
+
+let db: Database.Database;
+
+const SEV = `CASE %COL% WHEN 'fake' THEN 3 WHEN 'dead' THEN 2 WHEN 'mislabeled' THEN 1 ELSE 0 END`;
+const sev = (col: string) => SEV.replace('%COL%', col);
+
+// Mirrors ScreenerStore.markVerdict: a single atomic upsert, all merges computed
+// against the live row (no stale pre-read).
+const MARK = `
+  INSERT INTO screener_entries (source_id, k, kind, verdict, n, last_at, backbones)
+  VALUES (?, ?, ?, ?, 1, ?, ?)
+  ON CONFLICT (source_id, k) DO UPDATE SET
+    verdict = CASE WHEN (${sev('excluded.verdict')}) >= (${sev('verdict')})
+                   THEN excluded.verdict ELSE verdict END,
+    n = CASE WHEN n + 1 > ${N_CAP} THEN ${N_CAP} ELSE n + 1 END,
+    last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+    backbones = CASE
+      WHEN backbones = '' OR excluded.backbones = '' THEN ''
+      WHEN backbones = excluded.backbones THEN backbones
+      ELSE backbones || ',' || excluded.backbones END`;
+
+// Mirrors ScreenerStore.bulkUpsert.
+const BULK = `
+  INSERT INTO screener_entries (source_id, k, kind, verdict, n, last_at, backbones)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (source_id, k) DO UPDATE SET
+    verdict = CASE WHEN (${sev('excluded.verdict')}) >= (${sev('verdict')})
+                   THEN excluded.verdict ELSE verdict END,
+    n = CASE WHEN n + excluded.n > ${N_CAP} THEN ${N_CAP} ELSE n + excluded.n END,
+    last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+    backbones = CASE
+      WHEN backbones = '' OR excluded.backbones = '' THEN ''
+      WHEN backbones = excluded.backbones THEN backbones
+      ELSE backbones || ',' || excluded.backbones END`;
+
+const JOIN = `
+  SELECT e.k AS k, e.verdict AS verdict, e.backbones AS backbones, s.id AS source_id, s.trust AS trust
+  FROM screener_entries e JOIN screener_sources s ON s.id = e.source_id
+  WHERE e.k = ? AND s.enabled = 1 AND s.trust IN ('full', 'corroborate')`;
+
+function rowsFor(key: string): SourceVerdict[] {
+  return db
+    .prepare(JOIN)
+    .all(key)
+    .map((r: any) => ({
+      isLocal: r.source_id === 'local',
+      trust: r.trust,
+      verdict: r.verdict,
+      backbones: r.backbones ? String(r.backbones).split(',').filter(Boolean) : [],
+    }));
+}
+
+// Mirrors ScreenerStore.getEntries(..., true): raw select -> records -> the real
+// dedupeRecords, so the export merge under test is the live code, not a copy.
+function exportRecords(ids: string[]): ScreenerRecord[] {
+  const inList = ids.map(() => '?').join(',');
+  const rows = db
+    .prepare(
+      `SELECT k, verdict, last_at, n, backbones FROM screener_entries WHERE source_id IN (${inList}) ORDER BY k, verdict, source_id`
+    )
+    .all(...ids);
+  const records = rows
+    .filter((r: any) => ['dead', 'fake', 'mislabeled'].includes(r.verdict))
+    .map((r: any): ScreenerRecord => {
+      const bk = r.backbones ? String(r.backbones).split(',').filter(Boolean) : [];
+      return {
+        k: r.k,
+        v: r.verdict,
+        n: Number(r.n),
+        at: Number(r.last_at),
+        ...(bk.length ? { bk } : {}),
+      };
+    });
+  return dedupeRecords(records);
+}
+
+function addSrc(id: string, trust = 'corroborate'): void {
+  db.prepare(
+    `INSERT INTO screener_sources (id, kind, name, url, enabled, trust, refresh_seconds)
+     VALUES (?, 'remote', ?, ?, 1, ?, 86400)`
+  ).run(id, id, `https://example.test/${id}`, trust);
+}
+
+const OPTS = { quorum: 2, backboneScope: false, myBackbones: [] as string[] };
+
+before(() => {
+  db = new Database(DB_PATH);
+  db.pragma('foreign_keys = ON');
+  db.exec(screener.up.sqlite);
+  db.exec(screenerRefreshSeconds.up.sqlite);
+});
+after(() => {
+  db.close();
+  for (const s of ['', '-wal', '-shm']) {
+    try {
+      rmSync(DB_PATH + s);
+    } catch {
+      /* ignore */
+    }
+  }
+});
+// Reset to the freshly-migrated state before each case so tests are independent
+// and order-free. Entries first to respect the FK.
+beforeEach(() => {
+  db.exec(`DELETE FROM screener_entries; DELETE FROM screener_sources WHERE id != 'local';`);
+});
+
+describe('migration DDL', () => {
+  it('seeds the local full-trust source', () => {
+    const row: any = db
+      .prepare(`SELECT kind, trust FROM screener_sources WHERE id = 'local'`)
+      .get();
+    assert.equal(row.kind, 'local');
+    assert.equal(row.trust, 'full');
+  });
+});
+
+describe('mark upsert (local auto-fill)', () => {
+  const at = 1719705600;
+
+  it('upgrades to the more severe verdict and bumps the count', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'fake', at, '');
+    const row: any = db
+      .prepare(`SELECT verdict, n FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(TORRENT);
+    assert.equal(row.verdict, 'fake'); // fake(3) >= dead(2)
+    assert.equal(row.n, 2);
+  });
+
+  it('never downgrades an already-stronger verdict', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'fake', at, '');
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    const row: any = db
+      .prepare(`SELECT verdict FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(TORRENT);
+    assert.equal(row.verdict, 'fake'); // dead(2) < fake(3), so it stays
+  });
+
+  it('keeps a global verdict global when re-marked with a scope', () => {
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, ''); // global
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    const row: any = db
+      .prepare(`SELECT backbones FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(USENET);
+    assert.equal(row.backbones, '');
+  });
+
+  it("doesn't grow backbones when an unchanged scope is re-marked", () => {
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    db.prepare(MARK).run('local', USENET, 'usenet', 'dead', at, 'news.a.com');
+    const row: any = db
+      .prepare(`SELECT backbones FROM screener_entries WHERE source_id='local' AND k=?`)
+      .get(USENET);
+    assert.equal(row.backbones, 'news.a.com');
+  });
+
+  it('a local (full) verdict filters on its own', () => {
+    db.prepare(MARK).run('local', TORRENT, 'torrent', 'dead', at, '');
+    const v = evaluateKey(rowsFor(TORRENT), OPTS);
+    assert.equal(v.filtered, true);
+    assert.equal(v.verdict, 'dead');
+  });
+});
+
+describe('bulk upsert (import / remote) with severity CASE', () => {
+  it('keeps the more severe verdict and sums counts on conflict', () => {
+    addSrc('src_a');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'mislabeled', 1, 1719705600, '');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 2, 1719792000, '');
+    const row: any = db
+      .prepare(`SELECT verdict, n, last_at FROM screener_entries WHERE source_id='src_a' AND k=?`)
+      .get(USENET);
+    assert.equal(row.verdict, 'dead'); // dead(2) > mislabeled(1)
+    assert.equal(row.n, 3); // 1 + 2
+    assert.equal(row.last_at, 1719792000); // max
+  });
+
+  it('one corroborate source does not meet quorum 2', () => {
+    addSrc('src_a');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    assert.equal(evaluateKey(rowsFor(USENET), OPTS).filtered, false);
+  });
+
+  it('a second corroborate source meets quorum 2', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, '');
+    assert.equal(evaluateKey(rowsFor(USENET), OPTS).filtered, true);
+  });
+});
+
+describe('dedup export (mirrors getEntries JS merge)', () => {
+  it('merges across sources: union backbones, sum counts, newest timestamp', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 3, 1719792000, 'news.a.com');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, 'news.b.com');
+    const recs = exportRecords(['src_a', 'src_b']);
+    assert.equal(recs.length, 1);
+    assert.equal(recs[0].v, 'dead');
+    assert.equal(recs[0].n, 4); // 3 + 1
+    assert.equal(recs[0].at, 1719792000); // max
+    assert.deepEqual(recs[0].bk, ['news.a.com', 'news.b.com']);
+  });
+
+  it('stays global when any contributing source is unscoped', () => {
+    addSrc('src_a');
+    addSrc('src_b');
+    db.prepare(BULK).run('src_a', USENET, 'usenet', 'dead', 1, 1719705600, 'news.a.com');
+    db.prepare(BULK).run('src_b', USENET, 'usenet', 'dead', 1, 1719705600, ''); // global
+    const recs = exportRecords(['src_a', 'src_b']);
+    assert.equal(recs.length, 1);
+    assert.equal(recs[0].bk, undefined); // empty-bk means global, and global wins
+  });
+});

--- a/packages/core/src/db/repositories/screener.ts
+++ b/packages/core/src/db/repositories/screener.ts
@@ -1,0 +1,506 @@
+import { randomUUID } from 'node:crypto';
+import { getDb } from '../db.js';
+import { sql, raw, join, type SqlFragment } from '../sql.js';
+import { createLogger } from '../../logging/logger.js';
+import { keyKind } from '../../screener/key.js';
+import {
+  evaluateKey,
+  rootDomain,
+  type SourceVerdict,
+} from '../../screener/evaluate.js';
+import { dedupeRecords } from '../../screener/io.js';
+import {
+  LOCAL_SOURCE_ID,
+  N_CAP,
+  isVerdict,
+  normaliseTrust,
+  type ScreenerEvalOptions,
+  type ScreenerRecord,
+  type ScreenerSource,
+  type ScreenerVerdict,
+  type SourceKind,
+  type Trust,
+  type Verdict,
+} from '../../screener/types.js';
+
+const logger = createLogger('screener-store');
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+const KEY_CHUNK = 500;
+
+/** SQL `CASE` mapping a verdict column to its severity (fake > dead > mislabeled). */
+function severity(col: string): SqlFragment {
+  return raw(
+    `CASE ${col} WHEN 'fake' THEN 3 WHEN 'dead' THEN 2 WHEN 'mislabeled' THEN 1 ELSE 0 END`
+  );
+}
+
+function csvToList(csv: unknown): string[] {
+  if (typeof csv !== 'string' || csv === '') return [];
+  return [
+    ...new Set(
+      csv
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== '')
+    ),
+  ];
+}
+
+function mergeCsv(existing: unknown, add: readonly string[]): string {
+  const set = new Set(csvToList(existing));
+  for (const b of add) {
+    const t = b.trim();
+    if (t !== '') set.add(t);
+  }
+  return [...set].join(',');
+}
+
+interface EntryJoinRow {
+  k: string;
+  verdict: string;
+  backbones: string | null;
+  source_id: string;
+  trust: string;
+  [col: string]: unknown;
+}
+
+interface SourceRow {
+  id: string;
+  kind: string;
+  name: string;
+  url: string | null;
+  enabled: number;
+  trust: string;
+  refresh_seconds: number;
+  last_checked: number;
+  last_updated: number;
+  status: string | null;
+  count: number;
+  [col: string]: unknown;
+}
+
+/**
+ * Instance-global store behind Screener: the dead/fake/mislabeled
+ * release verdicts and the sources they come from. Per-user filtering knobs
+ * (quorum, backbone scope) are passed in per call, not read from here.
+ */
+export class ScreenerStore {
+  // --- presence cache -------------------------------------------------------
+  // Lets the request-path filter skip all work on instances with an empty store
+  // without a query per request. Invalidated whenever entries change.
+  private static presence: { at: number; value: boolean } | null = null;
+  private static readonly PRESENCE_TTL_MS = 30_000;
+
+  /** Cheap, cached check for whether the store holds any entries at all. */
+  static async hasEntries(): Promise<boolean> {
+    const now = Date.now();
+    if (this.presence && now - this.presence.at < this.PRESENCE_TTL_MS) {
+      return this.presence.value;
+    }
+    try {
+      const total = await getDb().count(
+        sql`SELECT COUNT(*) FROM screener_entries`
+      );
+      this.presence = { at: now, value: total > 0 };
+      return this.presence.value;
+    } catch (err) {
+      // Never cache a DB-error "empty": a transient blip would otherwise disable
+      // filtering for the whole TTL. Fall back to the last known value.
+      logger.debug(`screener presence check failed: ${err}`);
+      return this.presence?.value ?? false;
+    }
+  }
+
+  private static invalidatePresence(): void {
+    this.presence = null;
+  }
+
+  /**
+   * Is this release recorded dead by THIS instance (the local source)? Used at
+   * resolve time to skip re-inspecting a release we already proved gone. Local
+   * marks are full-trust and from our own backbone, so no quorum/scope check is
+   * needed (they always satisfy the user's filter rules).
+   */
+  static async isLocallyDead(key: string): Promise<boolean> {
+    if (keyKind(key) === null) return false;
+    const row = await getDb().maybeOne<{ x: number }>(
+      sql`SELECT 1 AS x FROM screener_entries
+          WHERE source_id = ${LOCAL_SOURCE_ID} AND k = ${key} AND verdict = 'dead'
+          LIMIT 1`
+    );
+    return !!row;
+  }
+
+  // --- auto-fill (local source) ---------------------------------------------
+
+  /**
+   * Record a verdict for a release on the local source. Idempotent-ish: repeat
+   * calls bump the count, keep the most severe verdict, and union backbones.
+   */
+  static async markVerdict(
+    key: string,
+    verdict: Verdict,
+    backbones: readonly string[] = []
+  ): Promise<void> {
+    const kind = keyKind(key);
+    if (!kind || !isVerdict(verdict)) return;
+    // Empty backbones == "global" (applies on any backbone); a fresh mark adopts
+    // ours, or '' when this instance has none.
+    const addCsv = mergeCsv('', backbones);
+    const at = nowSec();
+    const db = getDb();
+    try {
+      // Single atomic upsert: the verdict/count/backbone merge happens in the
+      // DO UPDATE against the live row, so racing marks can't downgrade a
+      // stronger verdict or re-narrow a global backbone set from a stale read.
+      // Backbones stay global if either side is global, and don't grow when an
+      // unchanged scope is re-marked.
+      await db.exec(
+        sql`INSERT INTO screener_entries
+              (source_id, k, kind, verdict, n, last_at, backbones)
+            VALUES (${LOCAL_SOURCE_ID}, ${key}, ${kind}, ${verdict}, 1, ${at}, ${addCsv})
+            ON CONFLICT (source_id, k) DO UPDATE SET
+              verdict = CASE WHEN (${severity('excluded.verdict')}) >= (${severity('verdict')})
+                             THEN excluded.verdict ELSE verdict END,
+              n = ${raw('CASE WHEN n + 1 > ' + N_CAP + ' THEN ' + N_CAP + ' ELSE n + 1 END')},
+              last_at = ${raw('CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END')},
+              backbones = CASE
+                WHEN backbones = '' OR excluded.backbones = '' THEN ''
+                WHEN backbones = excluded.backbones THEN backbones
+                ELSE backbones || ',' || excluded.backbones END`
+      );
+      ScreenerStore.invalidatePresence();
+    } catch (err) {
+      // Auto-mark callers are fire-and-forget (they .catch); the /mark route
+      // awaits, so surface the failure instead of reporting a fake success.
+      logger.debug(`screener mark failed: ${err}`);
+      throw err;
+    }
+  }
+
+  // --- filtering ------------------------------------------------------------
+
+  /**
+   * Evaluate a batch of release keys against all enabled sources. Returns a map
+   * of key -> verdict for every key that had at least one contributing source
+   * row; keys absent from the map are not flagged. `.filtered` says whether the
+   * caller should actually hide it.
+   */
+  static async evaluateKeys(
+    keys: readonly string[],
+    opts: ScreenerEvalOptions
+  ): Promise<Map<string, ScreenerVerdict>> {
+    const out = new Map<string, ScreenerVerdict>();
+    const unique = [...new Set(keys.filter((k) => keyKind(k) !== null))];
+    if (unique.length === 0) return out;
+    const db = getDb();
+
+    for (let i = 0; i < unique.length; i += KEY_CHUNK) {
+      const slice = unique.slice(i, i + KEY_CHUNK);
+      const inList = join(slice.map((k) => sql`${k}`));
+      // Let a query failure propagate. The request-path caller (applyScreener)
+      // fails open as a whole; swallowing here would instead make this chunk's
+      // keys look clean and let flagged releases through silently.
+      const rows = await db.query<EntryJoinRow>(
+        sql`SELECT e.k AS k, e.verdict AS verdict, e.backbones AS backbones,
+                   s.id AS source_id, s.trust AS trust
+            FROM screener_entries e
+            JOIN screener_sources s ON s.id = e.source_id
+            WHERE e.k IN (${inList})
+              AND s.enabled = 1
+              AND s.trust IN ('full', 'corroborate')`
+      );
+
+      const byKey = new Map<string, SourceVerdict[]>();
+      for (const r of rows) {
+        if (!isVerdict(r.verdict)) continue;
+        const list = byKey.get(r.k) ?? [];
+        list.push({
+          isLocal: r.source_id === LOCAL_SOURCE_ID,
+          trust: normaliseTrust(r.trust),
+          verdict: r.verdict,
+          backbones: csvToList(r.backbones),
+        });
+        byKey.set(r.k, list);
+      }
+      for (const [k, list] of byKey) {
+        out.set(k, evaluateKey(list, opts));
+      }
+    }
+    return out;
+  }
+
+  // --- counts ---------------------------------------------------------------
+
+  static async getCounts(): Promise<{ total: number; local: number }> {
+    const db = getDb();
+    const total = await db.count(sql`SELECT COUNT(*) FROM screener_entries`);
+    const local = await db.count(
+      sql`SELECT COUNT(*) FROM screener_entries WHERE source_id = ${LOCAL_SOURCE_ID}`
+    );
+    return { total, local };
+  }
+
+  /**
+   * Distinct backbone root domains observed across all entries, for the
+   * trusted-backbones picker. Splits each entry's CSV, normalises to root
+   * domains, drops unknowns, and sorts.
+   */
+  static async getDistinctBackbones(): Promise<string[]> {
+    const rows = await getDb().query<{ backbones: string | null }>(
+      sql`SELECT DISTINCT backbones FROM screener_entries
+          WHERE backbones IS NOT NULL AND backbones <> ''`
+    );
+    const set = new Set<string>();
+    for (const r of rows) {
+      for (const b of csvToList(r.backbones)) {
+        const root = rootDomain(b);
+        if (root !== 'unknown') set.add(root);
+      }
+    }
+    return [...set].sort();
+  }
+
+  // --- sources --------------------------------------------------------------
+
+  static async getSources(): Promise<ScreenerSource[]> {
+    const db = getDb();
+    const rows = await db.query<SourceRow>(
+      sql`SELECT s.id, s.kind, s.name, s.url, s.enabled, s.trust, s.refresh_seconds,
+                 s.last_checked, s.last_updated, s.status,
+                 (SELECT COUNT(*) FROM screener_entries e WHERE e.source_id = s.id) AS count
+          FROM screener_sources s
+          ORDER BY CASE WHEN s.id = ${LOCAL_SOURCE_ID} THEN 0 ELSE 1 END, s.sort, s.name`
+    );
+    return rows.map(rowToSource);
+  }
+
+  static async addSource(
+    kind: Exclude<SourceKind, 'local'>,
+    name: string,
+    url: string | null,
+    trust: Trust,
+    refreshSeconds: number
+  ): Promise<string> {
+    const trimmedUrl = url?.trim() || null;
+    if (kind === 'remote' && !trimmedUrl) {
+      throw new Error('A remote source requires a URL.');
+    }
+    const id = 'src_' + randomUUID().replace(/-/g, '').slice(0, 12);
+    const db = getDb();
+    await db.exec(
+      sql`INSERT INTO screener_sources
+            (id, kind, name, url, enabled, trust, refresh_seconds, last_checked, last_updated, status, sort)
+          VALUES (${id}, ${kind}, ${name.trim() || 'Untitled'}, ${trimmedUrl},
+                  1, ${normaliseTrust(trust)}, ${clampRefreshSeconds(refreshSeconds)}, 0, 0, NULL,
+                  ${raw('(SELECT COALESCE(MAX(sort), 0) + 1 FROM screener_sources)')})`
+    );
+    return id;
+  }
+
+  static async updateSource(
+    id: string,
+    fields: {
+      enabled?: boolean;
+      trust?: Trust;
+      refreshSeconds?: number;
+      name?: string;
+    }
+  ): Promise<void> {
+    if (id === LOCAL_SOURCE_ID) return;
+    const sets: SqlFragment[] = [];
+    if (fields.enabled !== undefined)
+      sets.push(sql`enabled = ${fields.enabled ? 1 : 0}`);
+    if (fields.trust !== undefined)
+      sets.push(sql`trust = ${normaliseTrust(fields.trust)}`);
+    if (fields.refreshSeconds !== undefined)
+      sets.push(sql`refresh_seconds = ${clampRefreshSeconds(fields.refreshSeconds)}`);
+    if (fields.name !== undefined)
+      sets.push(sql`name = ${fields.name.trim() || 'Untitled'}`);
+    if (sets.length === 0) return;
+    await getDb().exec(
+      sql`UPDATE screener_sources SET ${join(sets)} WHERE id = ${id}`
+    );
+  }
+
+  /** Delete a non-local source and its entries. Returns false for 'local'. */
+  static async removeSource(id: string): Promise<boolean> {
+    if (id === LOCAL_SOURCE_ID) return false;
+    const db = getDb();
+    await db.tx(async (tx) => {
+      await tx.exec(
+        sql`DELETE FROM screener_entries WHERE source_id = ${id}`
+      );
+      await tx.exec(sql`DELETE FROM screener_sources WHERE id = ${id}`);
+    });
+    ScreenerStore.invalidatePresence();
+    return true;
+  }
+
+  /** Empty a source's entries (keeps the source row). Returns rows removed. */
+  static async clearSource(id: string): Promise<number> {
+    const res = await getDb().exec(
+      sql`DELETE FROM screener_entries WHERE source_id = ${id}`
+    );
+    ScreenerStore.invalidatePresence();
+    return res.rowCount;
+  }
+
+  static async setSourceStatus(
+    id: string,
+    etag: string | null,
+    lastChecked: number,
+    lastUpdated: number,
+    status: string | null
+  ): Promise<void> {
+    await getDb().exec(
+      sql`UPDATE screener_sources
+          SET etag = ${etag}, last_checked = ${lastChecked},
+              last_updated = ${lastUpdated}, status = ${status}
+          WHERE id = ${id}`
+    );
+  }
+
+  static async touchChecked(
+    id: string,
+    when: number,
+    status: string | null
+  ): Promise<void> {
+    await getDb().exec(
+      sql`UPDATE screener_sources SET last_checked = ${when}, status = ${status} WHERE id = ${id}`
+    );
+  }
+
+  static async getSourceEtag(id: string): Promise<string | null> {
+    const row = await getDb().maybeOne<{ etag: string | null }>(
+      sql`SELECT etag FROM screener_sources WHERE id = ${id}`
+    );
+    return row?.etag ?? null;
+  }
+
+  // --- bulk import / export -------------------------------------------------
+
+  /**
+   * Upsert records into a source. With `replace`, the source's existing entries
+   * are cleared first. Invalid keys/verdicts are skipped. Returns rows written.
+   */
+  static async bulkUpsert(
+    sourceId: string,
+    records: readonly ScreenerRecord[],
+    opts: { replace?: boolean } = {}
+  ): Promise<number> {
+    const db = getDb();
+    const now = nowSec();
+    let written = 0;
+    const valid = records.filter((rec) => keyKind(rec.k) && isVerdict(rec.v));
+    // Block a replace whose payload had records but none survived validation (a
+    // garbage feed would otherwise wipe the source). An intentionally empty
+    // payload (no records at all) is allowed through to clear the source.
+    if (opts.replace && records.length > 0 && valid.length === 0) {
+      throw new Error('Refusing to replace a source with only invalid entries.');
+    }
+    await db.tx(async (tx) => {
+      if (opts.replace) {
+        await tx.exec(
+          sql`DELETE FROM screener_entries WHERE source_id = ${sourceId}`
+        );
+      }
+      for (const rec of valid) {
+        const kind = keyKind(rec.k)!;
+        const n =
+          Number.isFinite(rec.n) && rec.n > 0
+            ? Math.min(Math.trunc(rec.n), N_CAP)
+            : 1;
+        const at = Number.isFinite(rec.at)
+          ? Math.min(Math.max(Math.trunc(rec.at), 0), now + 86400)
+          : 0;
+        const bk = [
+          ...new Set((rec.bk ?? []).map((b) => b.trim()).filter((b) => b !== '')),
+        ].join(',');
+        await tx.exec(
+          sql`INSERT INTO screener_entries
+                (source_id, k, kind, verdict, n, last_at, backbones)
+              VALUES (${sourceId}, ${rec.k}, ${kind}, ${rec.v}, ${n}, ${at}, ${bk})
+              ON CONFLICT (source_id, k) DO UPDATE SET
+                verdict = CASE WHEN ${severity('excluded.verdict')} >= ${severity('verdict')}
+                               THEN excluded.verdict ELSE verdict END,
+                n = ${raw('CASE WHEN n + excluded.n > ' + N_CAP + ' THEN ' + N_CAP + ' ELSE n + excluded.n END')},
+                last_at = CASE WHEN excluded.last_at > last_at THEN excluded.last_at ELSE last_at END,
+                backbones = CASE
+                  WHEN backbones = '' OR excluded.backbones = '' THEN ''
+                  WHEN backbones = excluded.backbones THEN backbones
+                  ELSE backbones || ',' || excluded.backbones
+                END`
+        );
+        written++;
+      }
+    });
+    ScreenerStore.invalidatePresence();
+    return written;
+  }
+
+  /**
+   * Read entries for export. With `dedup`, same-key rows across the given
+   * sources are merged into one record: most severe verdict, summed n, latest
+   * timestamp, and unioned backbones. Backbones are preserved either way so the
+   * export round-trips back through import.
+   */
+  static async getEntries(
+    sourceIds: readonly string[],
+    dedup: boolean
+  ): Promise<ScreenerRecord[]> {
+    const ids = sourceIds.length === 0 ? [LOCAL_SOURCE_ID] : sourceIds;
+    const inList = join(ids.map((id) => sql`${id}`));
+    const db = getDb();
+    const rows = await db.query<{
+      k: string;
+      verdict: string;
+      last_at: number;
+      n: number;
+      backbones: string | null;
+    }>(
+      sql`SELECT k, verdict, last_at, n, backbones
+          FROM screener_entries WHERE source_id IN (${inList})
+          ORDER BY k, verdict, source_id`
+    );
+
+    const records = rows
+      .filter((r) => isVerdict(r.verdict))
+      .map((r): ScreenerRecord => {
+        const bk = csvToList(r.backbones);
+        return {
+          k: r.k,
+          v: r.verdict as Verdict,
+          n: Number(r.n),
+          at: Number(r.last_at),
+          ...(bk.length ? { bk } : {}),
+        };
+      });
+    if (!dedup) return records;
+    return dedupeRecords(records);
+  }
+}
+
+function rowToSource(r: SourceRow): ScreenerSource {
+  return {
+    id: r.id,
+    kind: (['local', 'remote', 'imported'].includes(r.kind)
+      ? r.kind
+      : 'imported') as SourceKind,
+    name: r.name,
+    url: r.url,
+    enabled: Number(r.enabled) !== 0,
+    trust: normaliseTrust(r.trust),
+    refreshSeconds: Number(r.refresh_seconds),
+    lastChecked: Number(r.last_checked),
+    lastUpdated: Number(r.last_updated),
+    status: r.status,
+    count: Number(r.count),
+  };
+}
+
+function clampRefreshSeconds(seconds: number): number {
+  if (!Number.isFinite(seconds)) return 86400;
+  return Math.min(Math.max(Math.trunc(seconds), 60), 30 * 86400);
+}

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -275,6 +275,14 @@ const DeduplicatorOptions = z.object({
     .optional(),
 });
 
+// Per-user knobs for Screener (the instance-global shared filter of bad
+// releases). Sources and their trust are operator-managed; these are the
+// per-user filtering controls.
+const ScreenerOptions = z.object({
+  enabled: z.boolean().optional(), // hide releases flagged dead/fake/mislabeled from my results
+  quorum: z.number().int().min(1).max(20).optional(), // agreements needed before a corroborate source filters
+});
+
 const OptionDefinition = z.looseObject({
   id: z.string().min(1),
   name: z.string(),
@@ -757,6 +765,7 @@ export const UserDataSchema = z.object({
     })
     .optional(),
   deduplicator: DeduplicatorOptions.optional(),
+  screener: ScreenerOptions.optional(),
   autoPlay: z
     .object({
       enabled: z.boolean().optional(),
@@ -945,9 +954,19 @@ export const NNTPServersSchema = z.array(NNTPServerSchema);
 
 export type NNTPServers = z.infer<typeof NNTPServersSchema>;
 
+// One contract for Screener's key at every stream boundary: only a valid
+// usenet `wd1:` key survives, anything else is dropped rather than rejecting the
+// whole stream.
+export const ScreenerKeySchema = z
+  .string()
+  .regex(/^wd1:[0-9a-f]{32}$/)
+  .optional()
+  .catch(undefined);
+
 export const StreamSchema = z.looseObject({
   url: z.string().or(z.null()).optional(),
   nzbUrl: z.string().or(z.null()).optional(),
+  screenerKey: ScreenerKeySchema,
   servers: z.array(z.string().min(1)).nullable().optional(),
   rarUrls: z.array(SourceSchema).nullable().optional(),
   zipUrls: z.array(SourceSchema).nullable().optional(),
@@ -1094,6 +1113,10 @@ export const ParsedStreamSchema = z.object({
   passthrough: PassthroughSchema.optional(),
   url: z.string().optional(),
   nzbUrl: z.string().optional(),
+  // Precomputed Screener release key (`wd1:...`) for usenet streams, set by the
+  // builtin that has the poster/date/size. Torrent/debrid keys are derived from
+  // `torrent.infoHash` at filter time and don't need this.
+  screenerKey: ScreenerKeySchema,
   // Same-release failover targets harvested from discarded duplicates by the
   // deduplicator merge step. Each is another playback URL for the *same*
   // release (a different indexer's NZB or another addon's debrid link).


### PR DESCRIPTION
Part 2 of the Screener feature, split from #1056.

Persistence for verdicts: the repository and migrations `0012`/`0013`, on the same SQLite+Postgres driver abstraction as the rest of the DB layer. Stores per-source verdicts keyed by the release identity from part 1. No filtering yet. SQL-equivalence tests run the repository against both backends.

Depends on part 1. Merge order 1 → 6; umbrella is #1056.
---
**Screener, split from #1056 into 6 parts to review in passes. Merge in order:**
1. #1063 — release keys + NDJSON interchange
2. #1064 — verdict store + migrations
3. #1065 — evaluator + config
4. #1066 — pipeline filter
5. #1067 — API + remote + GitHub sync
6. #1068 — dashboard
