### PR TITLE
feat(screener): trust/quorum/backbone evaluator and config (3/6)

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -24,6 +24,7 @@ import {
   builtinsSchema,
   analyticsSchema,
   usenetSchema,
+  screenerSchema,
 } from './schema/index.js';
 
 export const runtimeSchemas = {
@@ -45,6 +46,7 @@ export const runtimeSchemas = {
   builtins: builtinsSchema,
   analytics: analyticsSchema,
   usenet: usenetSchema,
+  screener: screenerSchema,
 } as const;
 
 export const runtimeKeyAliases: Record<string, string> = {

--- a/packages/core/src/config/schema/index.ts
+++ b/packages/core/src/config/schema/index.ts
@@ -16,3 +16,4 @@ export { presetsSchema } from './presets.js';
 export { builtinsSchema } from './builtins.js';
 export { analyticsSchema } from './analytics.js';
 export { usenetSchema } from './usenet.js';
+export { screenerSchema } from './screener.js';

--- a/packages/core/src/config/schema/screener.ts
+++ b/packages/core/src/config/schema/screener.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { RuntimeConfigSection } from '../types.js';
+
+const stringList = z.array(z.string());
+
+export const screenerSchema = {
+  backboneScope: {
+    schema: z.boolean(),
+    default: true,
+    label: 'Screener backbone scope',
+    description:
+      "Only honour usenet verdicts recorded on a backbone that matches one of this instance's providers, so a release that's dead on another provider's backbone can't hide one that's still fine on yours. Turn off to apply every verdict regardless of backbone.",
+    env: 'SCREENER_BACKBONE_SCOPE',
+    requiresRestart: false,
+    secret: false,
+  },
+  trustedBackbones: {
+    schema: stringList,
+    default: [],
+    label: 'Screener trusted backbones',
+    description:
+      "Extra provider root domains (e.g. newshosting.com) whose verdicts are honoured under backbone scope even though they aren't this instance's own — for resellers that share a backbone. Ignored when backbone scope is off.",
+    env: 'SCREENER_TRUSTED_BACKBONES',
+    requiresRestart: false,
+    secret: false,
+  },
+} as const satisfies RuntimeConfigSection;

--- a/packages/core/src/screener/backbones.ts
+++ b/packages/core/src/screener/backbones.ts
@@ -1,0 +1,35 @@
+import { config as appConfig } from '../config/index.js';
+import { createLogger } from '../logging/logger.js';
+import { rootDomain } from './evaluate.js';
+
+const logger = createLogger('screener');
+
+/**
+ * The backbones (provider root domains) this instance streams from, derived
+ * from the enabled native Usenet providers. Used to scope shared dead-release
+ * verdicts to backbones we actually use, and recorded on our own verdicts so
+ * others can scope against them.
+ *
+ * Empty when no native providers are configured (e.g. debrid-only usenet),
+ * which leaves backbone scoping inert.
+ */
+export function myBackbones(): string[] {
+  try {
+    const providers = (appConfig.usenet.providers ?? []) as Array<{
+      host?: string;
+      enabled?: boolean;
+    }>;
+    const set = new Set<string>();
+    for (const p of providers) {
+      if (p.enabled === false) continue;
+      const root = rootDomain(p.host);
+      if (root !== 'unknown') set.add(root);
+    }
+    return [...set];
+  } catch (err) {
+    // Fail safe (no scoping) but surface it: silently empty backbones would
+    // quietly apply every remote verdict regardless of provider.
+    logger.warn(`could not derive backbones; scoping disabled: ${err}`);
+    return [];
+  }
+}

--- a/packages/core/src/screener/evaluate.test.ts
+++ b/packages/core/src/screener/evaluate.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateKey, rootDomain, type SourceVerdict } from './evaluate.js';
+import type { ScreenerEvalOptions } from './types.js';
+
+const OPTS = (over: Partial<ScreenerEvalOptions> = {}): ScreenerEvalOptions => ({
+  quorum: 2,
+  backboneScope: false,
+  myBackbones: [],
+  ...over,
+});
+
+const row = (over: Partial<SourceVerdict> = {}): SourceVerdict => ({
+  isLocal: false,
+  trust: 'corroborate',
+  verdict: 'dead',
+  backbones: [],
+  ...over,
+});
+
+describe('evaluateKey: trust + quorum', () => {
+  it('a full source filters on its own', () => {
+    const r = evaluateKey([row({ trust: 'full', isLocal: true })], OPTS());
+    assert.equal(r.filtered, true);
+    assert.equal(r.verdict, 'dead');
+    assert.equal(r.reason, 'dead');
+  });
+
+  it('one corroborate source does not meet quorum 2', () => {
+    assert.equal(evaluateKey([row()], OPTS()).filtered, false);
+  });
+
+  it('two corroborate sources meet quorum 2', () => {
+    const r = evaluateKey([row(), row()], OPTS());
+    assert.equal(r.filtered, true);
+    assert.equal(r.reason, 'dead (2 sources)');
+  });
+
+  it('observe sources never filter', () => {
+    assert.equal(
+      evaluateKey([row({ trust: 'observe' }), row({ trust: 'observe' })], OPTS())
+        .filtered,
+      false
+    );
+  });
+
+  it('surfaces the most severe verdict', () => {
+    const r = evaluateKey(
+      [row({ verdict: 'dead' }), row({ verdict: 'fake' })],
+      OPTS()
+    );
+    assert.equal(r.verdict, 'fake');
+  });
+});
+
+describe('evaluateKey: backbone scope', () => {
+  const scoped = OPTS({ backboneScope: true, myBackbones: ['news.myprovider.com'] });
+
+  it('excludes a remote verdict from a non-matching backbone', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['news.other.com'] })],
+        scoped
+      ).filtered,
+      false
+    );
+  });
+
+  it('honours a verdict from a trusted (non-matching) backbone', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['news.other.com'] })],
+        OPTS({
+          backboneScope: true,
+          myBackbones: ['news.myprovider.com'],
+          trustedBackbones: ['other.com'],
+        })
+      ).filtered,
+      true
+    );
+  });
+
+  it('honours a remote verdict whose backbone matches mine (root domain)', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['feed.myprovider.com'] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+
+  it('treats a verdict with no backbones as in-scope', () => {
+    assert.equal(
+      evaluateKey([row({ trust: 'full', backbones: [] })], scoped).filtered,
+      true
+    );
+  });
+
+  it('treats a verdict with only unparseable backbones as applying everywhere', () => {
+    // No known backbones (all collapse to "unknown") means it applies anywhere,
+    // the same as an empty list.
+    assert.equal(
+      evaluateKey(
+        [row({ trust: 'full', backbones: ['', '   '] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+
+  it('local verdicts always count regardless of scope', () => {
+    assert.equal(
+      evaluateKey(
+        [row({ isLocal: true, trust: 'full', backbones: ['news.other.com'] })],
+        scoped
+      ).filtered,
+      true
+    );
+  });
+});
+
+describe('rootDomain', () => {
+  it('reduces a host to its registrable root', () => {
+    assert.equal(rootDomain('news.example.com'), 'example.com');
+    assert.equal(rootDomain('example.com'), 'example.com');
+    assert.equal(rootDomain('a.b.co.uk'), 'b.co.uk');
+    assert.equal(rootDomain('news.example.com:563'), 'example.com');
+    assert.equal(rootDomain('1.2.3.4'), '1.2.3.4');
+    assert.equal(rootDomain(''), 'unknown');
+    assert.equal(rootDomain(null), 'unknown');
+  });
+
+  it('preserves IPv6 literals instead of truncating at the first colon', () => {
+    assert.equal(rootDomain('2001:db8::1'), '2001:db8::1');
+    assert.equal(rootDomain('[2001:db8::1]:563'), '2001:db8::1');
+    assert.equal(rootDomain('[::1]'), '::1');
+  });
+});

--- a/packages/core/src/screener/evaluate.ts
+++ b/packages/core/src/screener/evaluate.ts
@@ -1,0 +1,157 @@
+import type {
+  Trust,
+  Verdict,
+  ScreenerEvalOptions,
+  ScreenerVerdict,
+} from './types.js';
+import { moreSevere } from './types.js';
+
+/** One source's verdict on a single release, as fed to the evaluator. */
+export interface SourceVerdict {
+  /** True for the always-on local source (exempt from backbone scoping). */
+  isLocal: boolean;
+  trust: Trust;
+  verdict: Verdict;
+  /** Backbones / trackers that observed this verdict (for scoping). */
+  backbones: string[];
+}
+
+const IPV4 = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
+/**
+ * Collapse a host to its registrable root domain, e.g. `news.example.com` ->
+ * `example.com`, `a.b.co.uk` -> `b.co.uk`. Bare IPs pass through. Ported from
+ * nzbdavex's `WardenFingerprint.RootDomain` so backbone scoping agrees with it.
+ */
+export function rootDomain(host: string | null | undefined): string {
+  if (!host) return 'unknown';
+  let h = host.trim().toLowerCase();
+  // IPv6 literal: bracketed `[2001:db8::1]:563` or bare `2001:db8::1`. Keep the
+  // whole address; the first-colon port split below would otherwise truncate it.
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return end > 1 ? h.slice(1, end) : 'unknown';
+  }
+  if ((h.match(/:/g)?.length ?? 0) >= 2) return h;
+  const colon = h.indexOf(':');
+  if (colon > 0) h = h.slice(0, colon);
+  h = h.replace(/^\.+|\.+$/g, '');
+  if (h.length === 0) return 'unknown';
+  if (IPV4.test(h)) return h;
+
+  const labels = h.split('.').filter(Boolean);
+  if (labels.length <= 2) return h;
+  // A 2-char TLD with a short second level (e.g. co.uk, com.au) keeps 3 labels.
+  const tld = labels[labels.length - 1];
+  const sld = labels[labels.length - 2];
+  const take = tld.length === 2 && sld.length <= 3 ? 3 : 2;
+  return labels.slice(labels.length - take).join('.');
+}
+
+/**
+ * True if an entry applies to one of my backbones. Mirrors davex's
+ * BackboneInScope: an entry with no *known* backbones (empty, or all
+ * unparseable) applies everywhere; otherwise one of its backbones must overlap
+ * mine.
+ */
+function backboneInScope(
+  backbones: readonly string[],
+  myRoots: ReadonlySet<string>
+): boolean {
+  let known = false;
+  for (const b of backbones) {
+    const rb = rootDomain(b);
+    if (rb === 'unknown') continue;
+    known = true;
+    if (myRoots.has(rb)) return true;
+  }
+  return !known;
+}
+
+/**
+ * True if any of an entry's backbones is explicitly trusted, so a verdict from a
+ * backbone that isn't mine (e.g. a same-backbone reseller I opted into) still
+ * counts under scope. Empty trust set never matches.
+ */
+function backboneTrusted(
+  backbones: readonly string[],
+  trustedRoots: ReadonlySet<string>
+): boolean {
+  if (trustedRoots.size === 0) return false;
+  for (const b of backbones) {
+    const rb = rootDomain(b);
+    if (rb !== 'unknown' && trustedRoots.has(rb)) return true;
+  }
+  return false;
+}
+
+/**
+ * Reduce one release's per-source verdicts to a filter decision. Mirrors
+ * nzbdavex's trust + quorum + backbone-scope rules:
+ *  - `observe` sources never filter (kept for visibility only).
+ *  - a `full` source filters on its own.
+ *  - `corroborate` sources filter only once >= quorum of them agree.
+ *  - with backbone scope on (and at least one known local backbone), a
+ *    non-local source's verdict only counts when its backbones intersect mine,
+ *    or it records none.
+ *
+ * Callers should pass only rows from enabled sources; `observe` is tolerated
+ * here so the rule lives in one place.
+ */
+export function evaluateKey(
+  rows: readonly SourceVerdict[],
+  opts: ScreenerEvalOptions
+): ScreenerVerdict {
+  const quorum = Math.max(1, opts.quorum);
+  const myRoots = opts.backboneScope
+    ? new Set(
+        opts.myBackbones.map(rootDomain).filter((b) => b !== 'unknown')
+      )
+    : new Set<string>();
+  const scope = myRoots.size > 0;
+  const trustedRoots = new Set(
+    (opts.trustedBackbones ?? []).map(rootDomain).filter((b) => b !== 'unknown')
+  );
+
+  let agree = 0;
+  let fullSource = false;
+  let fullVerdict: Verdict | null = null;
+  let corroborateVerdict: Verdict | null = null;
+
+  for (const row of rows) {
+    if (row.trust === 'observe') continue;
+    if (
+      scope &&
+      !row.isLocal &&
+      !backboneInScope(row.backbones, myRoots) &&
+      !backboneTrusted(row.backbones, trustedRoots)
+    ) {
+      continue;
+    }
+    if (row.trust === 'full') {
+      fullSource = true;
+      fullVerdict = fullVerdict
+        ? moreSevere(fullVerdict, row.verdict)
+        : row.verdict;
+    } else {
+      agree++;
+      corroborateVerdict = corroborateVerdict
+        ? moreSevere(corroborateVerdict, row.verdict)
+        : row.verdict;
+    }
+  }
+
+  const quorumMet = agree >= quorum;
+  const filtered = fullSource || quorumMet;
+  // Full sources always set the verdict; corroborate sources only contribute
+  // once they meet quorum, so a lone corroborator can't upgrade a verdict.
+  let verdict: Verdict | null = fullVerdict;
+  if (quorumMet && corroborateVerdict) {
+    verdict = verdict ? moreSevere(verdict, corroborateVerdict) : corroborateVerdict;
+  }
+  if (!filtered || !verdict) {
+    return { filtered: false, verdict: null, reason: null };
+  }
+  const reason = fullSource ? verdict : `${verdict} (${agree} sources)`;
+  return { filtered: true, verdict, reason };
+}

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -46,6 +46,7 @@ export const FILTER_TAB_IDS = [
   'bitrate',
   'limit',
   'deduplicator',
+  'screener',
   'miscellaneous',
 ] as const;
 export type FilterTabId = (typeof FILTER_TAB_IDS)[number];
@@ -196,6 +197,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
 
   sortCriteria: { label: 'Sort Criteria', group: 'sorting', type: 'scalar', menu: 'sorting' },
   deduplicator: { label: 'Deduplicator', group: 'sorting', type: 'scalar', menu: 'filters', subTab: 'deduplicator' },
+  screener: { label: 'Screener', group: 'filters', type: 'scalar', menu: 'filters', subTab: 'screener' },
   resultLimits: { label: 'Result Limits', group: 'sorting', type: 'scalar', menu: 'filters', subTab: 'limit' },
 
   formatter: { label: 'Formatter', group: 'formatter', type: 'scalar', menu: 'formatter' },

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -1131,6 +1131,13 @@ neither the environment variable nor a stored value is present.
 | `ANALYTICS_EVENT_RETENTION_DAYS` | Event Retention Days | number | `7` | How many days of raw per-request analytics events to keep before the rollup task prunes them. The per-user Stats tab is limited to this window. |
 | `ANALYTICS_DAILY_RETENTION_DAYS` | Daily Retention Days | number | `90` | How many days of aggregated daily analytics to keep. |
 
+### Screener
+
+| Environment Variable | UI Setting | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `SCREENER_BACKBONE_SCOPE` | Backbone Scope | boolean | `true` | Only honour usenet verdicts recorded on a backbone that matches one of this instance's providers, so a release that's dead on another provider's backbone can't hide one that's still fine on yours. Turn off to apply every verdict regardless of backbone. |
+| `SCREENER_TRUSTED_BACKBONES` | Trusted Backbones | list | — | Extra provider root domains (e.g. newshosting.com) whose verdicts are honoured under backbone scope even though they aren't this instance's own — for resellers that share a backbone. Ignored when backbone scope is off. |
+
 ### Usenet
 
 | Environment Variable | UI Setting | Type | Default | Description |


### PR DESCRIPTION
Part 3 of the Screener feature, split from #1056.

The decision logic plus config. Turns stored verdicts into a filter decision:

- `full` / `corroborate` / `observe` trust levels and a corroboration quorum.
- Optional backbone scoping: a verdict from a provider backbone that isn't yours can't hide a release that's still fine on yours. Root-domain collapsing is ported from Warden's `RootDomain`.
- The per-user config schema, and the operator backbone env vars (documented).

Still headless, no wiring into the pipeline yet. Evaluator rules are unit-tested.

Depends on parts 1-2. Merge order 1 → 6; umbrella is #1056.
---
**Screener, split from #1056 into 6 parts to review in passes. Merge in order:**
1. #1063 — release keys + NDJSON interchange
2. #1064 — verdict store + migrations
3. #1065 — evaluator + config
4. #1066 — pipeline filter
5. #1067 — API + remote + GitHub sync
6. #1068 — dashboard
