### PR TITLE
feat(screener): filter flagged releases in the stream pipeline (4/6)

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -36,6 +36,7 @@ import {
   metadataStore,
   fileInfoStore,
   FileInfo,
+  ScreenerOptionsSchema,
 } from '../../debrid/index.js';
 import { processTorrents, processNZBs } from '../utils/debrid.js';
 import { calculateAbsoluteEpisode } from '../utils/general.js';
@@ -69,6 +70,9 @@ export const BaseDebridConfigSchema = z.object({
   cacheAndPlay: CacheAndPlaySchema.optional(),
   autoRemoveDownloads: z.boolean().optional(),
   checkOwned: z.boolean().optional().default(true),
+  // The viewer's Screener knobs, forwarded so a usenet playback token can carry
+  // them to the stateless resolve step (see _createStream).
+  screener: ScreenerOptionsSchema.optional(),
 });
 export type BaseDebridConfig = z.infer<typeof BaseDebridConfigSchema>;
 
@@ -740,6 +744,12 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
             nzb: torrentOrNzb.nzb,
             title: torrentOrNzb.title,
             hash: torrentOrNzb.hash,
+            screenerKey: torrentOrNzb.screenerKey,
+            // Only useful alongside a key (the resolve-skip gates on the key),
+            // so it rides only on keyed releases to keep keyless tokens unchanged.
+            screenerOptions: torrentOrNzb.screenerKey
+              ? this.userData.screener ?? {}
+              : undefined,
             index: torrentOrNzb.file.index,
             easynewsUrl:
               torrentOrNzb.service?.id === 'easynews'
@@ -785,6 +795,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
             )
           : undefined,
       nzbUrl: torrentOrNzb.type === 'usenet' ? torrentOrNzb.nzb : undefined,
+      screenerKey:
+        torrentOrNzb.type === 'usenet' ? torrentOrNzb.screenerKey : undefined,
       servers:
         torrentOrNzb.service?.id === 'stremio_nntp'
           ? (encryptedStoreAuth as string[])

--- a/packages/core/src/builtins/newznab/addon.ts
+++ b/packages/core/src/builtins/newznab/addon.ts
@@ -9,6 +9,8 @@ import {
 } from '../../debrid/index.js';
 import { SearchMetadata } from '../base/debrid.js';
 import { hashNzbUrl } from '../../debrid/utils.js';
+import { usenetKey } from '../../screener/key.js';
+import { toUnixSeconds } from '../../screener/fingerprint.js';
 import { BaseNabApi, SearchResultItem } from '../base/nab/api.js';
 import {
   BaseNabAddon,
@@ -208,6 +210,23 @@ export class NewznabAddon extends BaseNabAddon<NewznabAddonConfig, NewznabApi> {
       if (zyclopsHealth) {
         nzb.zyclopsHealth = zyclopsHealth;
       }
+
+      // Davex-compatible Screener key from the indexer's size/poster/date, so
+      // this release can be matched against shared dead-release lists.
+      const poster =
+        result.newznab?.poster == null
+          ? undefined
+          : String(result.newznab.poster).trim() || undefined;
+      // Hash the exact indexer-reported size, not the enclosure-length/0
+      // fallback nzb.size can hold, so the wd1 matches across indexers + davex.
+      const rawReleaseSize = result.size ?? result.newznab?.size;
+      const releaseSize =
+        rawReleaseSize == null ? undefined : Number(rawReleaseSize);
+      const screenerKey =
+        typeof releaseSize === 'number' && Number.isFinite(releaseSize)
+          ? usenetKey(releaseSize, poster, toUnixSeconds(date))
+          : null;
+      if (screenerKey) nzb.screenerKey = screenerKey;
 
       nzbs.push(nzb);
     }

--- a/packages/core/src/debrid/aiostreams.ts
+++ b/packages/core/src/debrid/aiostreams.ts
@@ -115,7 +115,9 @@ export class NativeUsenetService implements UsenetDebridService {
 
     return nzbs.map(({ name, hash }) => {
       const entry = hash ? library.get(hash) : undefined;
-      if (entry?.status === 'failed') {
+      // A viewer-specific Screener skip is not a shared availability failure;
+      // don't report it as failed for other viewers.
+      if (entry?.status === 'failed' && entry.errorCode !== 'screener_skip') {
         return {
           id: hash ?? name ?? 'unknown',
           hash,
@@ -212,8 +214,11 @@ export class NativeUsenetService implements UsenetDebridService {
       });
     }
 
-    if (existing?.status === 'failed') {
-      // Short-circuit on a cached failure WITHOUT re-checking providers. Logged
+    if (existing?.status === 'failed' && existing.errorCode !== 'screener_skip') {
+      // Short-circuit on a cached failure WITHOUT re-checking providers. A
+      // Screener skip is viewer-specific (it depends on the viewer's filter
+      // settings), so it's excluded here and re-evaluated per request instead of
+      // blocking every viewer. Logged
       // so a fast "previously failed" rejection is distinguishable from a fresh
       // inspect failure (delete the library entry to force a re-inspect).
       logger.debug(
@@ -289,6 +294,7 @@ export class NativeUsenetService implements UsenetDebridService {
       fileIndex: selected.index,
       innerPath: selected.path,
       filename: chosenFilename,
+      screenerKey: playbackInfo.screenerKey,
     });
 
     const url = `${appConfig.bootstrap.baseUrl}/api/v1/usenet/stream/${token}/${encodeURIComponent(

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -217,10 +217,35 @@ const TorrentInfoSchema = BaseFileInfoSchema.extend({
 const TorrentPlaybackInfoSchema =
   BasePlaybackInfoSchema.merge(TorrentInfoSchema);
 
+/**
+ * The user's Screener filtering knobs. Carried alongside a release key into the
+ * stateless playback token so the resolve step can apply the same filter
+ * decision (quorum/backbone/enabled) the stream list already used, without a
+ * resolved UserData at the `/playback` route.
+ */
+export const ScreenerOptionsSchema = z.object({
+  enabled: z.boolean().optional(),
+  quorum: z.number().int().min(1).max(20).optional(),
+});
+export type ScreenerOptions = z.infer<typeof ScreenerOptionsSchema>;
+
 const UsenetInfoSchema = BaseFileInfoSchema.extend({
   hash: z.string(),
   easynewsUrl: z.string().optional(),
   nzb: z.string(),
+  // Davex-compatible Screener key (`wd1:...`) carried to playback so a release
+  // discovered dead (articles missing) can auto-mark itself on Screener.
+  // Only valid usenet keys are accepted; anything else is dropped here.
+  screenerKey: z
+    .string()
+    .regex(/^wd1:[0-9a-f]{32}$/)
+    .optional()
+    .catch(undefined),
+  // The viewer's Screener knobs at stream-list time, so a sibling NZB of a
+  // flagged release can be skipped at resolve under the same rules. A malformed
+  // blob is dropped (falls back to the local-only skip) rather than failing the
+  // whole token.
+  screenerOptions: ScreenerOptionsSchema.optional().catch(undefined),
   type: z.literal('usenet'),
 });
 

--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -202,6 +202,8 @@ export interface NZB extends BaseFile {
   easynewsUrl?: string;
   zyclopsHealth?: string;
   serviceItemId?: string;
+  /** Screener release key (`wd1:...`) from the indexer's size/poster/date. */
+  screenerKey?: string;
 }
 
 export interface TorrentWithSelectedFile extends Torrent {

--- a/packages/core/src/main/failover.ts
+++ b/packages/core/src/main/failover.ts
@@ -93,6 +93,8 @@ function buildPlaybackInfo(
         title: fileInfo.title,
         hash: fileInfo.hash,
         nzb: fileInfo.nzb,
+        screenerKey: fileInfo.screenerKey,
+        screenerOptions: fileInfo.screenerOptions,
         easynewsUrl: fileInfo.easynewsUrl,
         index: fileInfo.index,
         filename,

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -289,6 +289,11 @@ export async function processStreams(
     filterMs = Date.now() - filterStart;
   }
 
+  // Drop releases Screener has flagged (dead/fake/mislabeled) before dedup,
+  // so a flagged candidate never becomes a failover attempt. Recorded as a
+  // 'screener' filter reason so it shows in the per-request stats / dashboard.
+  processedStreams = await ctx.filterer.screenFlagged(processedStreams);
+
   const dedupStart = Date.now();
   processedStreams = await ctx.deduplicator.deduplicate(processedStreams);
   deduplicationMs = Date.now() - dedupStart;

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import FileParser from './file.js';
+import { keyKind } from '../screener/key.js';
 import {
   parseAgeString,
   parseDuration,
@@ -88,6 +89,12 @@ class StreamParser {
       proxied: this.isProxied(stream),
       url: this.applyUrlModifications(stream.url ?? undefined),
       nzbUrl: stream.nzbUrl || undefined,
+      // Only carry a usenet (wd1) Screener key; ignore anything an addon injects
+      // that isn't a valid usenet key.
+      screenerKey:
+        keyKind(stream.screenerKey) === 'usenet'
+          ? (stream.screenerKey ?? undefined)
+          : undefined,
       tarUrls: stream.tarUrls ?? undefined,
       tgzUrls: stream.tgzUrls ?? undefined,
       '7zipUrls': stream['7zipUrls'] ?? undefined,

--- a/packages/core/src/presets/builtin.ts
+++ b/packages/core/src/presets/builtin.ts
@@ -288,6 +288,7 @@ export class BuiltinAddonPreset extends Preset {
       cacheAndPlay: userData.cacheAndPlay,
       autoRemoveDownloads: userData.autoRemoveDownloads,
       checkOwned: userData.checkOwned ?? true,
+      screener: userData.screener,
     };
   }
 }

--- a/packages/core/src/screener/feedback.ts
+++ b/packages/core/src/screener/feedback.ts
@@ -1,0 +1,27 @@
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { createLogger } from '../logging/logger.js';
+import { keyKind } from './key.js';
+import { myBackbones } from './backbones.js';
+
+const logger = createLogger('screener');
+
+/**
+ * Mark a release key dead. Use when the caller already knows the release is
+ * gone (e.g. the native usenet engine catching an `ArticleNotFoundError`).
+ * Fire-and-forget; no-op for a missing/invalid key.
+ */
+export function markReleaseDead(key: string | null | undefined): void {
+  // Usenet-only path: never let a torrent (btih) key in here.
+  if (!key || keyKind(key) !== 'usenet') return;
+  // Scope the verdict to the instance's usenet backbones when they derive;
+  // when none do (provider maps to no known backbone) record it unscoped so a
+  // confirmed death still lands, rather than dropping it.
+  const backbones = myBackbones();
+  logger.info(
+    `Screener: auto-marking ${key} dead` +
+      (backbones.length ? ` on ${backbones.join(', ')}` : ' (unscoped)')
+  );
+  void ScreenerStore.markVerdict(key, 'dead', backbones).catch((e) =>
+    logger.warn(`Screener auto-mark failed for ${key}: ${e}`)
+  );
+}

--- a/packages/core/src/screener/filter.ts
+++ b/packages/core/src/screener/filter.ts
@@ -1,0 +1,127 @@
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { config } from '../config/index.js';
+import { createLogger } from '../logging/logger.js';
+import { myBackbones } from './backbones.js';
+import { streamReleaseKey, type KeyableStream } from './stream-key.js';
+import type { ScreenerEvalOptions, ScreenerVerdict } from './types.js';
+import type { ScreenerOptions } from '../debrid/base.js';
+
+const logger = createLogger('screener');
+
+const DEFAULT_QUORUM = 2;
+
+/** Per-user Screener knobs (from UserData); the shared debrid-layer contract. */
+export type ScreenerUserOptions = ScreenerOptions;
+
+type FilterableStream = KeyableStream & { id: string };
+
+/**
+ * Drop streams whose release was flagged (dead/fake/mislabeled) by Screener,
+ * evaluated against the user's quorum/backbone settings. Runs before dedup so a
+ * flagged candidate never becomes a failover attempt.
+ *
+ * Default-on: filters unless the user explicitly disabled it. Never leaves the
+ * user with nothing, if every stream is flagged, all are shown as a last resort
+ * (mirroring nzbdavex). Returns the input array unchanged when nothing is
+ * dropped, so callers can cheaply detect a no-op.
+ */
+export async function applyScreener<T extends FilterableStream>(
+  streams: T[],
+  opts: ScreenerUserOptions | undefined,
+  ownBackbones: string[],
+  onRemoved?: (stream: T, verdict: ScreenerVerdict) => void
+): Promise<T[]> {
+  if (opts?.enabled === false || streams.length === 0) return streams;
+  try {
+    if (!(await ScreenerStore.hasEntries())) return streams;
+  } catch (err) {
+    // Fail open: a store hiccup must never reject the request.
+    logger.debug(`screener presence check failed, passing through: ${err}`);
+    return streams;
+  }
+
+  // Key by the stream object itself, not stream.id: ids can repeat across
+  // streams and an id-keyed map would judge one against another's verdict.
+  const keyByStream = new Map<T, string>();
+  for (const s of streams) {
+    const key = streamReleaseKey(s);
+    if (key) keyByStream.set(s, key);
+  }
+  if (keyByStream.size === 0) return streams;
+
+  const evalOpts: ScreenerEvalOptions = {
+    quorum: opts?.quorum ?? DEFAULT_QUORUM,
+    backboneScope: config.screener.backboneScope,
+    myBackbones: ownBackbones,
+    trustedBackbones: config.screener.trustedBackbones,
+  };
+
+  let verdicts: Map<string, ScreenerVerdict>;
+  try {
+    verdicts = await ScreenerStore.evaluateKeys(
+      [...new Set(keyByStream.values())],
+      evalOpts
+    );
+  } catch (err) {
+    logger.debug(`screener evaluate failed, passing streams through: ${err}`);
+    return streams;
+  }
+
+  const kept: T[] = [];
+  const removed: Array<{ stream: T; verdict: ScreenerVerdict }> = [];
+  for (const s of streams) {
+    const key = keyByStream.get(s);
+    const verdict = key ? verdicts.get(key) : undefined;
+    if (verdict?.filtered) {
+      removed.push({ stream: s, verdict });
+      continue;
+    }
+    kept.push(s);
+  }
+
+  if (removed.length === 0) return streams;
+  if (kept.length === 0) {
+    // Never leave the user with nothing, show all as a last resort, and don't
+    // record the skips since nothing was actually removed.
+    logger.warn(
+      `Screener flagged all ${streams.length} stream(s); showing anyway (last resort)`
+    );
+    return streams;
+  }
+  for (const r of removed) onRemoved?.(r.stream, r.verdict);
+  logger.info(
+    `Screener removed ${removed.length} flagged release(s); ${kept.length} remain`
+  );
+  return kept;
+}
+
+/**
+ * Would Screener filter this single release for a viewer with these
+ * options? The resolve-time counterpart of {@link applyScreener}: same enabled
+ * gate and the same {@link ScreenerStore.evaluateKeys} verdict under the
+ * viewer's quorum/backbone, so a sibling NZB of an already-flagged release is
+ * skipped under the exact rules the stream list used.
+ *
+ * Fails safe: any error (or no entries / disabled) returns false, so a store
+ * blip never blocks a playable release.
+ */
+export async function isReleaseScreened(
+  key: string,
+  opts: ScreenerUserOptions | undefined
+): Promise<boolean> {
+  if (opts?.enabled === false) return false;
+  try {
+    if (!(await ScreenerStore.hasEntries())) return false;
+    const evalOpts: ScreenerEvalOptions = {
+      quorum: opts?.quorum ?? DEFAULT_QUORUM,
+      backboneScope: config.screener.backboneScope,
+      myBackbones: myBackbones(),
+      trustedBackbones: config.screener.trustedBackbones,
+    };
+    const verdicts = await ScreenerStore.evaluateKeys([key], evalOpts);
+    return verdicts.get(key)?.filtered ?? false;
+  } catch (err) {
+    logger.debug(`screener resolve-check failed, not skipping: ${err}`);
+    return false;
+  }
+}

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -24,6 +24,8 @@ import { formatBitrate, formatBytes } from '../formatters/utils.js';
 import { iso6391ToLanguage } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
 import { StreamContext, ExtendedMetadata } from './context.js';
+import { applyScreener } from '../screener/filter.js';
+import { myBackbones } from '../screener/backbones.js';
 
 const logger = createLogger('filterer');
 
@@ -73,6 +75,7 @@ export interface FilterStatistics {
     requiredFilterCondition: Reason;
     size: Reason;
     bitrate: Reason;
+    screener: Reason;
   };
   included: {
     passthrough: Reason;
@@ -178,6 +181,7 @@ class StreamFilterer {
         requiredFilterCondition: { total: 0, details: {} },
         size: { total: 0, details: {} },
         bitrate: { total: 0, details: {} },
+        screener: { total: 0, details: {} },
       },
       included: {
         passthrough: { total: 0, details: {} },
@@ -239,6 +243,27 @@ class StreamFilterer {
 
   public getFilterStatistics() {
     return this.filterStatistics;
+  }
+
+  /**
+   * Remove releases Screener has flagged (dead/fake/mislabeled), recording
+   * each as a `screener` removal so it surfaces in the filter stats / dashboard
+   * ("skipped due to Screener"). Run once over the full candidate set before
+   * dedup, so a flagged release never becomes a failover attempt.
+   */
+  public async screenFlagged(
+    streams: ParsedStream[]
+  ): Promise<ParsedStream[]> {
+    return applyScreener(
+      streams,
+      this.userData.screener,
+      myBackbones(),
+      (_stream, verdict) =>
+        this.incrementRemovalReason(
+          'screener',
+          verdict.verdict ?? verdict.reason ?? 'flagged'
+        )
+    );
   }
 
   public getFilterTimings(): FilterTimings {

--- a/packages/core/src/usenet/integration/library.ts
+++ b/packages/core/src/usenet/integration/library.ts
@@ -4,6 +4,8 @@ import { ParsedResult, parseTorrentTitle } from '@viren070/parse-torrent-title';
 import { downloadManager, NzbTooLargeError } from '../../utils/index.js';
 import { getDataFolder } from '../../utils/general.js';
 import { createLogger } from '../../logging/logger.js';
+import { markReleaseDead } from '../../screener/feedback.js';
+import { isReleaseScreened } from '../../screener/filter.js';
 import {
   DebridError,
   DebridDownload,
@@ -18,11 +20,13 @@ import {
   parseNzb,
   isEligibleVideoTarget,
   contentTotalSize,
+  ArticleNotFoundError,
   type Nzb,
   type NzbContent,
 } from '../index.js';
 import {
   UsenetLibraryRepository,
+  ScreenerStore,
   type UsenetLibraryEntry,
   type UsenetLibraryFile,
 } from '../../db/index.js';
@@ -247,7 +251,53 @@ export async function resolveFileList(
   cached?: DebridFile[],
   signal?: AbortSignal
 ): Promise<DebridFile[]> {
+  // Already flagged dead? Check before serving cached files too, so a release the
+  // Screener has since flagged isn't handed back from a stale cache entry, and a
+  // sibling NZB of a release already proved dead isn't re-probed from scratch
+  // (the library failure-cache is per-hash; Screener is per-release-key).
+  // When the viewer's filter options rode along on the token, apply their full
+  // decision (quorum/backbone, respecting the enabled toggle); otherwise fall
+  // back to a local-only check (own full-trust marks always pass the filter).
+  if (playbackInfo.screenerKey) {
+    const flaggedDead = playbackInfo.screenerOptions
+      ? await isReleaseScreened(
+          playbackInfo.screenerKey,
+          playbackInfo.screenerOptions
+        )
+      : await ScreenerStore.isLocallyDead(playbackInfo.screenerKey);
+    if (flaggedDead) {
+      const reason = 'Skipped: already flagged dead by Screener';
+      await UsenetLibraryRepository.markFailed(
+        nzbHash,
+        reason,
+        playbackInfo.filename,
+        'screener_skip'
+      ).catch(() => {});
+      throw new DebridError(reason, {
+        statusCode: 404,
+        statusText: 'Not Found',
+        code: 'NO_MATCHING_FILE',
+        headers: {},
+        body: { reasonCode: 'screener_skip' },
+        type: 'api_error',
+      });
+    }
+  }
+
   if (cached?.length) return cached;
+
+  // A release confirmed gone on every provider is dead on usenet: self-fill the
+  // Screener. No-op without a key or for a torrent; the no-key case is logged so
+  // an empty list stays explainable.
+  const markScreenerDead = () => {
+    if (playbackInfo.screenerKey) {
+      markReleaseDead(playbackInfo.screenerKey);
+    } else {
+      logger.info(
+        `Screener: ${nzbHash} is dead on all providers but carries no release key, so it can't be listed (its indexer reported no size + poster/date).`
+      );
+    }
+  };
 
   // Split the import into grab (NZB fetch), parse, and inspect (the
   // segment-probing phase that dominates) so a slow cold load can be pinned to
@@ -286,6 +336,9 @@ export async function resolveFileList(
       playbackInfo.filename,
       friendly.code
     ).catch(() => {});
+    if (err instanceof ArticleNotFoundError && err.allProviders) {
+      markScreenerDead();
+    }
     throw toDebridError(err);
   }
   const inspectedAt = Date.now();
@@ -318,6 +371,7 @@ export async function resolveFileList(
       playbackInfo.filename,
       availFail.code
     ).catch(() => {});
+    markScreenerDead();
     throw new DebridError(availFail.reason, {
       statusCode: 404,
       statusText: 'Not Found',
@@ -403,6 +457,7 @@ export async function resolveFileList(
       playbackInfo.filename,
       code
     ).catch(() => {});
+    if (code === 'missing_on_providers') markScreenerDead();
     throw new DebridError(reason, {
       statusCode: 404,
       statusText: 'Not Found',

--- a/packages/core/src/usenet/integration/stream-session.ts
+++ b/packages/core/src/usenet/integration/stream-session.ts
@@ -32,6 +32,7 @@ import {
 } from '../../db/index.js';
 import { type UsenetStreamToken, decodeUsenetStreamToken } from './tokens.js';
 import { friendlyUsenetError } from './errors.js';
+import { markReleaseDead } from '../../screener/feedback.js';
 import { usenetEngineRegistry, getUsenetEngineConfig } from './engine.js';
 import { fetchNzb, parseNzbCached } from './library.js';
 
@@ -433,6 +434,19 @@ async function getStreamSession(
           decoded.filename,
           friendly.code
         ).catch(() => {});
+        // Articles missing on every provider == gone from usenet: self-fill the
+        // Screener. Gate on allProviders so a single-provider 430 (still alive
+        // elsewhere) doesn't poison the shared list. NotStreamableError is
+        // encrypted/etc — the release exists, so it's excluded already.
+        if (err instanceof ArticleNotFoundError && err.allProviders) {
+          if (decoded.screenerKey) {
+            markReleaseDead(decoded.screenerKey);
+          } else {
+            logger.info(
+              `Screener: ${decoded.hash} is dead on all providers but carries no release key, so it can't be listed (its indexer reported no size + poster/date).`
+            );
+          }
+        }
       }
       throw err;
     }

--- a/packages/core/src/usenet/integration/tokens.ts
+++ b/packages/core/src/usenet/integration/tokens.ts
@@ -16,6 +16,8 @@ export interface UsenetStreamToken {
   innerPath?: string;
   /** Best-effort display filename. */
   filename: string;
+  /** Davex-compatible Screener key (`wd1:...`), so a dead post can self-mark. */
+  screenerKey?: string;
 }
 
 /**


### PR DESCRIPTION
Part 4 of the Screener feature, split from #1056.

Where Screener goes live in the stream pipeline:

- Drops flagged releases before dedup/failover, recorded as a `screener` filter reason so it shows in per-request stats, via a `screenFlagged` step in the filterer.
- Skips a sibling NZB of a release already proven dead at playback resolve, under the viewer's own quorum/backbone.
- Auto-marks a usenet release `dead` when the native engine confirms it's gone from every provider.
- Builtins precompute the `wd1` key from indexer size/poster/date so the filter never re-derives it.

Fails open throughout: any store error passes streams through, and it never leaves a viewer with nothing (if every stream is flagged, all are shown).

Depends on parts 1-3. Merge order 1 → 6; umbrella is #1056.
---
**Screener, split from #1056 into 6 parts to review in passes. Merge in order:**
1. #1063 — release keys + NDJSON interchange
2. #1064 — verdict store + migrations
3. #1065 — evaluator + config
4. #1066 — pipeline filter
5. #1067 — API + remote + GitHub sync
6. #1068 — dashboard
