### PR TITLE
feat(screener): admin API, remote subscriptions, GitHub sync (5/6)

### DIFF
--- a/packages/core/src/db/repositories/settings.ts
+++ b/packages/core/src/db/repositories/settings.ts
@@ -16,6 +16,13 @@ export class SettingsRepository {
     );
   }
 
+  static async get(key: string): Promise<unknown> {
+    const row = await getDb().maybeOne<{ value: string }>(
+      sql`SELECT value FROM settings WHERE key = ${key}`
+    );
+    return row ? JSON.parse(row.value) : undefined;
+  }
+
   static async getVersion(): Promise<number> {
     const row = await getDb().maybeOne<{ version: number | string }>(
       sql`SELECT version FROM settings_version WHERE id = ${1}`

--- a/packages/core/src/screener/github-sync.ts
+++ b/packages/core/src/screener/github-sync.ts
@@ -1,0 +1,329 @@
+import { SettingsRepository } from '../db/repositories/settings.js';
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { encryptString, decryptString } from '../utils/crypto.js';
+import { makeRequest } from '../utils/http.js';
+import { createLogger } from '../logging/logger.js';
+import { toNdjson, toDavexNdjson } from './io.js';
+
+const logger = createLogger('screener');
+
+const SETTINGS_KEY = 'screener.github-sync';
+const GITHUB_API = 'https://api.github.com';
+const SYNC_TIMEOUT_MS = 30_000;
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+export interface GitHubSyncConfig {
+  enabled: boolean;
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+  format: 'native' | 'davex';
+  scope: 'local' | 'all';
+  // Auto-sync cadence in seconds; 0 means manual-only (Sync now).
+  intervalSeconds: number;
+}
+
+interface StoredSyncConfig extends GitHubSyncConfig {
+  // AES-encrypted personal access token, or null when none is set.
+  tokenEnc: string | null;
+  lastSyncAt: number | null;
+  lastStatus: string | null;
+}
+
+// What the API/UI sees: the config plus whether a token is on file and the
+// raw URL subscribers point at. The token itself never leaves the server.
+export interface GitHubSyncView extends GitHubSyncConfig {
+  hasToken: boolean;
+  rawUrl: string | null;
+  lastSyncAt: number | null;
+  lastStatus: string | null;
+}
+
+export interface GitHubSyncInput extends Partial<GitHubSyncConfig> {
+  // undefined keeps the stored token; '' or null clears it; a string sets it.
+  token?: string | null;
+}
+
+const DEFAULTS: StoredSyncConfig = {
+  enabled: false,
+  owner: '',
+  repo: '',
+  branch: 'main',
+  path: 'screener.ndjson',
+  format: 'native',
+  scope: 'local',
+  intervalSeconds: 0,
+  tokenEnc: null,
+  lastSyncAt: null,
+  lastStatus: null,
+};
+
+// GitHub's Contents path keeps its slashes but each segment is escaped.
+function encodePath(path: string): string {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join('/');
+}
+
+function rawUrlFor(c: GitHubSyncConfig): string | null {
+  const path = c.path.split('/').filter(Boolean).join('/');
+  if (!c.owner || !c.repo || !path) return null;
+  return `https://raw.githubusercontent.com/${c.owner}/${c.repo}/${c.branch}/${path}`;
+}
+
+class ScreenerGitHubSyncServiceImpl {
+  private async load(): Promise<StoredSyncConfig> {
+    const raw = (await SettingsRepository.get(SETTINGS_KEY)) as
+      | Partial<StoredSyncConfig>
+      | undefined;
+    return { ...DEFAULTS, ...(raw ?? {}) };
+  }
+
+  private toView(c: StoredSyncConfig): GitHubSyncView {
+    const { tokenEnc, ...rest } = c;
+    return { ...rest, hasToken: !!tokenEnc, rawUrl: rawUrlFor(c) };
+  }
+
+  async getConfig(): Promise<GitHubSyncView> {
+    return this.toView(await this.load());
+  }
+
+  async setConfig(input: GitHubSyncInput): Promise<GitHubSyncView> {
+    const next = await this.load();
+    if (input.enabled !== undefined) next.enabled = input.enabled;
+    if (input.owner !== undefined) next.owner = input.owner.trim();
+    if (input.repo !== undefined) next.repo = input.repo.trim();
+    if (input.branch !== undefined) next.branch = input.branch.trim() || 'main';
+    if (input.path !== undefined)
+      next.path = input.path.split('/').filter(Boolean).join('/') || 'screener.ndjson';
+    if (input.format !== undefined) next.format = input.format;
+    if (input.scope !== undefined) next.scope = input.scope;
+    if (input.intervalSeconds !== undefined)
+      next.intervalSeconds = Math.max(0, Math.floor(input.intervalSeconds));
+
+    if (input.token === null || input.token?.trim() === '') {
+      next.tokenEnc = null;
+    } else if (typeof input.token === 'string') {
+      const enc = encryptString(input.token.trim());
+      if (!enc.success || !enc.data) {
+        throw new Error('Failed to encrypt the GitHub token.');
+      }
+      next.tokenEnc = enc.data;
+    }
+
+    await SettingsRepository.set(SETTINGS_KEY, next);
+    return this.toView(next);
+  }
+
+  private syncInFlight: Promise<string> | null = null;
+
+  // Build the export and push it to the configured repo. Returns a short status
+  // and persists it (success or failure) so the UI can show the last result.
+  // Serialised so a manual "Sync now" and the scheduler can't push concurrently
+  // and race on the file's blob sha.
+  async sync(): Promise<string> {
+    if (this.syncInFlight) return this.syncInFlight;
+    this.syncInFlight = this.runSync();
+    try {
+      return await this.syncInFlight;
+    } finally {
+      this.syncInFlight = null;
+    }
+  }
+
+  private async runSync(): Promise<string> {
+    const c = await this.load();
+    let status: string;
+    try {
+      status = await this.push(c);
+    } catch (err) {
+      status = `error: ${err instanceof Error ? err.message : String(err)}`;
+      await this.saveStatus(status);
+      throw err;
+    }
+    await this.saveStatus(status);
+    return status;
+  }
+
+  // Scheduler entry: push only when enabled and the configured interval has
+  // elapsed. Errors are swallowed (sync() already records them) so the task
+  // loop keeps running.
+  async syncIfDue(): Promise<string> {
+    const c = await this.load();
+    if (!c.enabled) return 'disabled';
+    if (!c.intervalSeconds || c.intervalSeconds <= 0) return 'manual only';
+    const dueAt = (c.lastSyncAt ?? 0) + c.intervalSeconds;
+    if (nowSec() < dueAt) return 'not due';
+    try {
+      return await this.sync();
+    } catch (err) {
+      return `error: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  private async saveStatus(status: string): Promise<void> {
+    // Re-read so a settings change during the (network-bound) push isn't
+    // clobbered by a stale copy captured before it started.
+    const latest = await this.load();
+    await SettingsRepository.set(SETTINGS_KEY, {
+      ...latest,
+      lastSyncAt: nowSec(),
+      lastStatus: status,
+    });
+  }
+
+  private async push(c: StoredSyncConfig): Promise<string> {
+    if (!c.owner || !c.repo || !c.path) {
+      throw new Error('owner, repo and path are required.');
+    }
+    if (!c.tokenEnc) throw new Error('A GitHub token is required.');
+    const dec = decryptString(c.tokenEnc);
+    if (!dec.success || !dec.data) {
+      throw new Error('The stored token could not be decrypted.');
+    }
+    const token = dec.data;
+
+    const ids =
+      c.scope === 'all'
+        ? (await ScreenerStore.getSources()).map((s) => s.id)
+        : ['local'];
+    const records = await ScreenerStore.getEntries(ids, true);
+    const body =
+      c.format === 'davex'
+        ? toDavexNdjson(records, nowSec())
+        : toNdjson(records, nowSec());
+    const contentB64 = Buffer.from(body, 'utf8').toString('base64');
+
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'aiostreams-screener',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    const jsonHeaders = { ...headers, 'Content-Type': 'application/json' };
+    const repoBase = `${GITHUB_API}/repos/${encodeURIComponent(
+      c.owner
+    )}/${encodeURIComponent(c.repo)}`;
+    const treePath = c.path.split('/').filter(Boolean).join('/');
+    const branchRef = `heads/${encodeURIComponent(c.branch)}`;
+    const message = `screener: update ${records.length} entries`;
+
+    // A shared list reaches tens of MB, which the Contents API rejects (its
+    // request-body cap is well below that, so the PUT fails with HTTP 400). Push
+    // via the Git Data API instead — blobs accept up to 100 MB — creating a blob,
+    // a tree, a commit, then moving the branch ref. The file stays plain ndjson.
+    const ref = await makeRequest(`${repoBase}/git/ref/${branchRef}`, {
+      method: 'GET',
+      timeout: SYNC_TIMEOUT_MS,
+      headers,
+    });
+    if (ref.status === 404) {
+      // No branch yet (empty repo): create the initial file via the Contents API,
+      // which also creates the branch. First push only, so it's the small case.
+      const put = await makeRequest(
+        `${repoBase}/contents/${encodePath(treePath)}`,
+        {
+          method: 'PUT',
+          timeout: SYNC_TIMEOUT_MS,
+          headers: jsonHeaders,
+          body: JSON.stringify({ message, content: contentB64, branch: c.branch }),
+        }
+      );
+      if (put.status !== 200 && put.status !== 201) {
+        throw new Error(await githubError('write', put));
+      }
+      logger.info(`Screener: created list with ${records.length} entries`);
+      return `synced ${records.length} entries`;
+    }
+    if (ref.status !== 200) throw new Error(await githubError('read ref', ref));
+    const baseCommitSha = ((await ref.json()) as { object?: { sha?: string } })
+      ?.object?.sha;
+    if (!baseCommitSha) throw new Error('GitHub read ref returned no commit sha');
+
+    const baseCommit = await makeRequest(
+      `${repoBase}/git/commits/${baseCommitSha}`,
+      { method: 'GET', timeout: SYNC_TIMEOUT_MS, headers }
+    );
+    if (baseCommit.status !== 200) {
+      throw new Error(await githubError('read commit', baseCommit));
+    }
+    const baseTreeSha = (
+      (await baseCommit.json()) as { tree?: { sha?: string } }
+    )?.tree?.sha;
+    if (!baseTreeSha) throw new Error('GitHub read commit returned no tree sha');
+
+    const blob = await makeRequest(`${repoBase}/git/blobs`, {
+      method: 'POST',
+      timeout: SYNC_TIMEOUT_MS,
+      headers: jsonHeaders,
+      body: JSON.stringify({ content: contentB64, encoding: 'base64' }),
+    });
+    if (blob.status !== 201) throw new Error(await githubError('write blob', blob));
+    const blobSha = ((await blob.json()) as { sha?: string })?.sha;
+    if (!blobSha) throw new Error('GitHub write blob returned no sha');
+
+    const tree = await makeRequest(`${repoBase}/git/trees`, {
+      method: 'POST',
+      timeout: SYNC_TIMEOUT_MS,
+      headers: jsonHeaders,
+      body: JSON.stringify({
+        base_tree: baseTreeSha,
+        tree: [{ path: treePath, mode: '100644', type: 'blob', sha: blobSha }],
+      }),
+    });
+    if (tree.status !== 201) throw new Error(await githubError('write tree', tree));
+    const newTreeSha = ((await tree.json()) as { sha?: string })?.sha;
+    if (!newTreeSha) throw new Error('GitHub write tree returned no sha');
+
+    const commit = await makeRequest(`${repoBase}/git/commits`, {
+      method: 'POST',
+      timeout: SYNC_TIMEOUT_MS,
+      headers: jsonHeaders,
+      body: JSON.stringify({
+        message,
+        tree: newTreeSha,
+        parents: [baseCommitSha],
+      }),
+    });
+    if (commit.status !== 201) {
+      throw new Error(await githubError('write commit', commit));
+    }
+    const newCommitSha = ((await commit.json()) as { sha?: string })?.sha;
+    if (!newCommitSha) throw new Error('GitHub write commit returned no sha');
+
+    const update = await makeRequest(`${repoBase}/git/refs/${branchRef}`, {
+      method: 'PATCH',
+      timeout: SYNC_TIMEOUT_MS,
+      headers: jsonHeaders,
+      body: JSON.stringify({ sha: newCommitSha }),
+    });
+    if (update.status !== 200) {
+      throw new Error(await githubError('update ref', update));
+    }
+
+    logger.info(
+      `Screener: synced ${records.length} entries to ${c.owner}/${c.repo}/${treePath}`
+    );
+    return `synced ${records.length} entries`;
+  }
+}
+
+async function githubError(
+  op: string,
+  res: { status: number; json: () => Promise<unknown> }
+): Promise<string> {
+  let detail = `HTTP ${res.status}`;
+  try {
+    const j = (await res.json()) as { message?: string };
+    if (j?.message) detail += `: ${j.message}`;
+  } catch {
+    // body wasn't JSON; the status code is enough
+  }
+  return `GitHub ${op} failed (${detail})`;
+}
+
+export const ScreenerGitHubSyncService = new ScreenerGitHubSyncServiceImpl();

--- a/packages/core/src/screener/remote.ts
+++ b/packages/core/src/screener/remote.ts
@@ -1,0 +1,165 @@
+import { gunzip } from 'node:zlib';
+import { promisify } from 'node:util';
+import { ScreenerStore } from '../db/repositories/screener.js';
+import { parseNdjson } from './io.js';
+import { createLogger, makeRequest } from '../utils/index.js';
+import { redactUrlParams } from '../logging/redact.js';
+import { isUnsafeRemoteUrl } from './url-safety.js';
+import type { ScreenerSource } from './types.js';
+
+const logger = createLogger('screener-remote');
+const gunzipAsync = promisify(gunzip);
+
+const MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 90_000;
+const MAX_REDIRECTS = 5;
+
+/**
+ * Read a response body into a buffer, aborting as soon as it exceeds `max`. A
+ * server that omits Content-Length can't flood memory because we stop on the
+ * first chunk that crosses the limit rather than buffering the whole body.
+ */
+async function readBodyCapped(
+  body: ReadableStream<Uint8Array> | null,
+  max: number
+): Promise<Buffer> {
+  if (!body) return Buffer.alloc(0);
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    total += chunk.length;
+    if (total > max) throw new Error('Download exceeds the size limit.');
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Refreshes remote Screener list subscriptions: fetch the URL, gunzip if the
+ * body is a `.gz`, parse it (native or davex NDJSON), and replace that source's
+ * entries. Conditional on ETag so unchanged lists are cheap. Operator-configured
+ * URLs only; nothing here trusts user input.
+ */
+export class ScreenerRemoteSourceService {
+  /** Refresh every remote source whose refresh interval has elapsed. */
+  static async refreshDue(): Promise<{ ok: boolean; message: string }> {
+    const now = nowSec();
+    // A listing failure propagates so the scheduled task reports it. Per-source
+    // failures stay contained in refreshOne (one bad source can't abort the
+    // sweep) but are aggregated into the returned status so they aren't hidden.
+    const sources = await ScreenerStore.getSources();
+    let checked = 0;
+    const failed: string[] = [];
+    for (const source of sources) {
+      if (!source.enabled || source.kind !== 'remote' || !source.url) continue;
+      if (now - source.lastChecked < source.refreshSeconds) continue;
+      checked++;
+      const status = await this.refreshOne(source);
+      if (status.startsWith('error')) failed.push(source.name);
+    }
+    if (checked === 0) return { ok: true, message: 'no sources due' };
+    if (failed.length > 0) {
+      return {
+        ok: false,
+        message: `${failed.length}/${checked} source(s) failed: ${failed.join(', ')}`,
+      };
+    }
+    return { ok: true, message: `refreshed ${checked} source(s)` };
+  }
+
+  /** Refresh a single remote source now. Returns a short status string. */
+  static async refreshOne(source: ScreenerSource): Promise<string> {
+    const now = nowSec();
+    if (!source.url) {
+      await ScreenerStore.touchChecked(source.id, now, 'error: no url');
+      return 'error: no url';
+    }
+    try {
+      const etag = await ScreenerStore.getSourceEtag(source.id);
+      let target = source.url;
+      // Re-check the stored URL before the first fetch, not just redirect hops.
+      if (isUnsafeRemoteUrl(target)) {
+        throw new Error('Source URL is not a public address.');
+      }
+      let res = await makeRequest(target, {
+        method: 'GET',
+        timeout: FETCH_TIMEOUT_MS,
+        headers: etag ? { 'If-None-Match': etag } : undefined,
+        rawOptions: { redirect: 'manual' },
+      });
+      // Follow redirects ourselves so every hop is re-checked: a public list URL
+      // (e.g. a GitHub "latest" link) must not be bounced to an internal target.
+      // 304 Not Modified is in the 3xx range but isn't a redirect.
+      for (
+        let hop = 0;
+        res.status >= 300 && res.status < 400 && res.status !== 304;
+        hop++
+      ) {
+        if (hop >= MAX_REDIRECTS) throw new Error('Too many redirects.');
+        const loc = res.headers.get('location');
+        if (!loc) throw new Error(`HTTP ${res.status} (no redirect target)`);
+        target = new URL(loc, target).toString();
+        if (isUnsafeRemoteUrl(target)) {
+          throw new Error('Redirect to a non-public address.');
+        }
+        res = await makeRequest(target, {
+          method: 'GET',
+          timeout: FETCH_TIMEOUT_MS,
+          headers: etag ? { 'If-None-Match': etag } : undefined,
+          rawOptions: { redirect: 'manual' },
+        });
+      }
+
+      if (res.status === 304) {
+        await ScreenerStore.touchChecked(source.id, now, `ok (${source.count})`);
+        return 'not-modified';
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // Reject early on a declared oversize body, and cap the decompressed
+      // payload so a small `.gz` can't expand past the limit and exhaust memory.
+      const declared = Number(res.headers.get('content-length'));
+      if (Number.isFinite(declared) && declared > MAX_DOWNLOAD_BYTES) {
+        throw new Error('Download exceeds the size limit.');
+      }
+      const buf = await readBodyCapped(res.body, MAX_DOWNLOAD_BYTES);
+      const text = looksGzip(buf)
+        ? (
+            await gunzipAsync(buf, { maxOutputLength: MAX_DOWNLOAD_BYTES })
+          ).toString('utf8')
+        : buf.toString('utf8');
+
+      const { records, invalid } = parseNdjson(text);
+      // Fail closed: don't let an empty or mostly-unparseable response (e.g. an
+      // HTML error page served with 200) replace a good source. A few unknown
+      // lines (a newer format the reader doesn't recognise yet) are tolerated.
+      if (records.length === 0 || invalid > records.length) {
+        throw new Error('Remote list is empty or malformed.');
+      }
+      const count = await ScreenerStore.bulkUpsert(source.id, records, {
+        replace: true,
+      });
+      const newEtag = res.headers.get('etag');
+      await ScreenerStore.setSourceStatus(source.id, newEtag, now, now, `ok (${count})`);
+      logger.info(
+        `refreshed remote list "${source.name}" (${count} entries${invalid ? `, ${invalid} skipped` : ''})`
+      );
+      return `ok (${count})`;
+    } catch (err) {
+      const msg =
+        'error: ' +
+        redactUrlParams(err instanceof Error ? err.message : String(err));
+      await ScreenerStore.touchChecked(source.id, now, msg);
+      logger.debug(`refresh failed for "${source.name}": ${msg}`);
+      return msg;
+    }
+  }
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function looksGzip(buf: Buffer): boolean {
+  return buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+}

--- a/packages/core/src/screener/url-safety.ts
+++ b/packages/core/src/screener/url-safety.ts
@@ -1,0 +1,46 @@
+import net from 'node:net';
+
+/**
+ * True if a remote list URL points at a loopback/private/link-local target, so a
+ * subscription (or a redirect it follows) can't make the server fetch internal
+ * resources. Covers literal IPs and localhost; hostnames that resolve to private
+ * space are out of scope (operator-configured, admin-gated route).
+ */
+export function isUnsafeRemoteUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return true;
+  }
+  // Fail closed on anything that isn't plain http(s): file:, data:, gopher:, etc.
+  // carry no host to range-check and must never be fetched server-side (a redirect
+  // could otherwise bounce a fetch onto one).
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true;
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  const kind = net.isIP(host);
+  if (kind === 4) {
+    const [a, b] = host.split('.').map(Number);
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 100 && b >= 64 && b <= 127)
+    );
+  }
+  if (kind === 6) {
+    return (
+      host === '::1' ||
+      host === '::' ||
+      /^fe[89ab]/i.test(host) || // fe80::/10 link-local
+      host.startsWith('fc') ||
+      host.startsWith('fd') ||
+      host.startsWith('::ffff:')
+    );
+  }
+  return false;
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -16,6 +16,7 @@ import {
   authApi,
   dashboardApi,
   usenetApi,
+  screenerApi,
 } from './routes/api/index.js';
 import {
   configure,
@@ -96,7 +97,14 @@ export const staticRoot = path.join(__dirname, './static');
 
 app.use(ipMiddleware);
 app.use(loggerMiddleware);
-app.use(express.json());
+// Screener's import accepts a large NDJSON body and sets its own limit on the
+// route; every other route keeps this small default. Parser built once.
+const jsonParser = express.json();
+app.use((req, res, next) =>
+  req.path.replace(/\/+$/, '').endsWith('/screener/import')
+    ? next()
+    : jsonParser(req, res, next)
+);
 app.use(express.urlencoded({ extended: true }));
 
 // Allow all origins in development for easier testing
@@ -133,6 +141,7 @@ apiRouter.use('/sync', syncApi);
 apiRouter.use('/auth', authApi);
 apiRouter.use('/dashboard', dashboardApi);
 apiRouter.use('/usenet', usenetApi);
+apiRouter.use('/screener', screenerApi);
 apiRouter.use('/sabnzbd', sabnzbdRouter);
 apiRouter.use('/newznab', createNabRouter('newznab'));
 apiRouter.use('/torznab', createNabRouter('torznab'));

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -14,3 +14,4 @@ export { default as syncApi } from './sync.js';
 export { default as authApi } from './auth.js';
 export { default as dashboardApi } from './dashboard.js';
 export { default as usenetApi } from './usenet.js';
+export { default as screenerApi } from './screener.js';

--- a/packages/server/src/routes/api/screener.ts
+++ b/packages/server/src/routes/api/screener.ts
@@ -1,0 +1,364 @@
+import { Router, json } from 'express';
+import {
+  APIError,
+  constants,
+  createLogger,
+  config,
+  settingsStore,
+  ScreenerStore,
+  ScreenerRemoteSourceService,
+  ScreenerGitHubSyncService,
+  parseNdjson,
+  toNdjson,
+  toDavexNdjson,
+  isValidKey,
+  isUnsafeRemoteUrl,
+  type ScreenerSource,
+} from '@aiostreams/core';
+import { z } from 'zod';
+import { requireAdmin } from '../../middlewares/auth.js';
+import { createResponse } from '../../utils/responses.js';
+
+const router: Router = Router();
+const logger = createLogger('screener');
+
+// Screener's store and its sources are instance-global and operator-managed.
+router.use(requireAdmin);
+
+const Trust = z.enum(['full', 'corroborate', 'observe']);
+const Verdict = z.enum(['dead', 'fake', 'mislabeled']);
+
+const badRequest = (message: string) =>
+  new APIError(constants.ErrorCode.MISSING_REQUIRED_FIELDS, undefined, message);
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+async function snapshot() {
+  const [counts, sources] = await Promise.all([
+    ScreenerStore.getCounts(),
+    ScreenerStore.getSources(),
+  ]);
+  return {
+    counts,
+    sources,
+    settings: {
+      backboneScope: config.screener.backboneScope,
+      trustedBackbones: config.screener.trustedBackbones,
+    },
+  };
+}
+
+// Current state: entry counts + every configured source.
+router.get('/', async (_req, res, next) => {
+  try {
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Distinct backbone root domains seen across entries — options for the
+// trusted-backbones picker on the dashboard.
+router.get('/backbones', async (_req, res, next) => {
+  try {
+    res.json(
+      createResponse({
+        success: true,
+        data: await ScreenerStore.getDistinctBackbones(),
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Instance-level backbone-scope settings (operator-managed, on Screener's page).
+const SettingsSchema = z
+  .object({
+    backboneScope: z.boolean().optional(),
+    trustedBackbones: z.array(z.string().trim()).optional(),
+  })
+  .strict();
+router.put('/settings', async (req, res, next) => {
+  const parsed = SettingsSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Invalid screener settings.'));
+  try {
+    if (parsed.data.backboneScope !== undefined) {
+      await settingsStore.set(
+        'screener.backboneScope',
+        parsed.data.backboneScope
+      );
+    }
+    if (parsed.data.trustedBackbones !== undefined) {
+      const domains = [
+        ...new Set(
+          parsed.data.trustedBackbones
+            .map((d) => d.trim().toLowerCase())
+            .filter(Boolean)
+        ),
+      ];
+      await settingsStore.set('screener.trustedBackbones', domains);
+    }
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Subscribe to a remote list (and fetch it immediately).
+const AddRemoteSchema = z.object({
+  name: z.string().trim().optional(),
+  url: z
+    .url()
+    .refine((u) => /^https?:\/\//i.test(u), 'URL must be http or https')
+    .refine((u) => {
+      try {
+        const parsed = new URL(u);
+        return !parsed.username && !parsed.password;
+      } catch {
+        return false;
+      }
+    }, 'URL must not embed credentials')
+    .refine((u) => !isUnsafeRemoteUrl(u), 'URL must be a public address'),
+  trust: Trust.optional(),
+  refreshSeconds: z.number().int().min(1).max(2592000).optional(),
+});
+router.post('/sources/remote', async (req, res, next) => {
+  const parsed = AddRemoteSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('A valid url is required.'));
+  const { name, url, trust, refreshSeconds } = parsed.data;
+  try {
+    const id = await ScreenerStore.addSource(
+      'remote',
+      name || new URL(url).host,
+      url,
+      trust ?? 'corroborate',
+      refreshSeconds ?? 86400
+    );
+    const source = (await ScreenerStore.getSources()).find((s) => s.id === id);
+    const status = source
+      ? await ScreenerRemoteSourceService.refreshOne(source)
+      : 'error: not found';
+    res.json(
+      createResponse({ success: true, data: { id, status, ...(await snapshot()) } })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+const UpdateSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    trust: Trust.optional(),
+    refreshSeconds: z.number().int().min(1).max(2592000).optional(),
+    name: z.string().trim().min(1).optional(),
+  })
+  .strict()
+  .refine((v) => Object.keys(v).length > 0);
+router.patch('/sources/:id', async (req, res, next) => {
+  const parsed = UpdateSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Nothing valid to update.'));
+  try {
+    await ScreenerStore.updateSource(req.params.id, parsed.data);
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Remove a source, or empty it with ?action=clear.
+router.delete('/sources/:id', async (req, res, next) => {
+  try {
+    if (req.query.action === 'clear') {
+      const removed = await ScreenerStore.clearSource(req.params.id);
+      res.json(
+        createResponse({ success: true, data: { removed, ...(await snapshot()) } })
+      );
+      return;
+    }
+    const ok = await ScreenerStore.removeSource(req.params.id);
+    if (!ok) return next(badRequest('The local source cannot be removed.'));
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Re-fetch a remote source now.
+router.post('/sources/:id/refresh', async (req, res, next) => {
+  try {
+    const source = (await ScreenerStore.getSources()).find(
+      (s: ScreenerSource) => s.id === req.params.id
+    );
+    if (!source || source.kind !== 'remote') {
+      return next(badRequest('Not a remote source.'));
+    }
+    const status = await ScreenerRemoteSourceService.refreshOne(source);
+    res.json(
+      createResponse({ success: true, data: { status, ...(await snapshot()) } })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Import an NDJSON list (native or davex format), merged into local or kept
+// as its own removable source.
+const ImportSchema = z.object({
+  content: z.string().min(1).max(16 * 1024 * 1024),
+  target: z.enum(['merge', 'separate']).default('separate'),
+  name: z.string().trim().optional(),
+  trust: Trust.optional(),
+});
+router.post('/import', json({ limit: '20mb' }), async (req, res, next) => {
+  const parsed = ImportSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Import content is required.'));
+  const { content, target, name, trust } = parsed.data;
+  try {
+    const { records, invalid } = parseNdjson(content);
+    if (records.length === 0) {
+      return next(badRequest('No valid entries found in the import.'));
+    }
+    let added: number;
+    if (target === 'merge') {
+      added = await ScreenerStore.bulkUpsert('local', records);
+    } else {
+      const id = await ScreenerStore.addSource(
+        'imported',
+        name || 'Imported list',
+        null,
+        trust ?? 'corroborate',
+        86400
+      );
+      try {
+        added = await ScreenerStore.bulkUpsert(id, records, { replace: true });
+        await ScreenerStore.setSourceStatus(
+          id,
+          null,
+          nowSec(),
+          nowSec(),
+          `imported ${added}`
+        );
+      } catch (err) {
+        // Don't leave an empty orphaned source behind if the import write fails.
+        await ScreenerStore.removeSource(id).catch(() => {});
+        throw err;
+      }
+    }
+    res.json(
+      createResponse({
+        success: true,
+        data: { added, invalid, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Export as NDJSON. scope=local|all, format=native|davex, dedup=1.
+router.get('/export', async (req, res, next) => {
+  try {
+    const scope = req.query.scope === 'all' ? 'all' : 'local';
+    const format = req.query.format === 'davex' ? 'davex' : 'native';
+    const dedup = req.query.dedup !== '0';
+    const ids =
+      scope === 'all'
+        ? (await ScreenerStore.getSources()).map((s) => s.id)
+        : ['local'];
+    const records = await ScreenerStore.getEntries(ids, dedup);
+    const body =
+      format === 'davex'
+        ? toDavexNdjson(records, nowSec())
+        : toNdjson(records, nowSec());
+    res.type('application/x-ndjson');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="screener.${format === 'davex' ? 'warden.' : ''}ndjson"`
+    );
+    res.send(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Manually contribute a verdict for a release key.
+const MarkSchema = z.object({
+  key: z.string(),
+  verdict: Verdict,
+  backbones: z.array(z.string()).optional(),
+});
+router.post('/mark', async (req, res, next) => {
+  const parsed = MarkSchema.safeParse(req.body);
+  if (!parsed.success || !isValidKey(parsed.data.key)) {
+    return next(badRequest('A valid release key and verdict are required.'));
+  }
+  try {
+    await ScreenerStore.markVerdict(
+      parsed.data.key,
+      parsed.data.verdict,
+      parsed.data.backbones ?? []
+    );
+    res.json(createResponse({ success: true, data: await snapshot() }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GitHub sync: publish the list to a repo so others can subscribe to its raw
+// URL. The token is held server-side and never returned.
+router.get('/sync/github', async (_req, res, next) => {
+  try {
+    res.json(
+      createResponse({
+        success: true,
+        data: await ScreenerGitHubSyncService.getConfig(),
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+const GitHubSyncSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    owner: z.string().trim().optional(),
+    repo: z.string().trim().optional(),
+    branch: z.string().trim().optional(),
+    path: z.string().trim().optional(),
+    format: z.enum(['native', 'davex']).optional(),
+    scope: z.enum(['local', 'all']).optional(),
+    // 0 = manual-only; otherwise auto-sync every N seconds.
+    intervalSeconds: z.number().int().min(0).max(2592000).optional(),
+    // undefined keeps the stored token; '' or null clears it; a string sets it.
+    token: z.string().nullable().optional(),
+  })
+  .strict();
+router.put('/sync/github', async (req, res, next) => {
+  const parsed = GitHubSyncSchema.safeParse(req.body);
+  if (!parsed.success) return next(badRequest('Invalid GitHub sync settings.'));
+  try {
+    const data = await ScreenerGitHubSyncService.setConfig(parsed.data);
+    res.json(createResponse({ success: true, data }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/sync/github/run', async (_req, res, next) => {
+  try {
+    const status = await ScreenerGitHubSyncService.sync();
+    res.json(
+      createResponse({
+        success: true,
+        data: { status, ...(await ScreenerGitHubSyncService.getConfig()) },
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -25,6 +25,8 @@ import {
   drainUsenetMetrics,
   pruneUsenetMetrics,
   flushAllDiskCaches,
+  ScreenerRemoteSourceService,
+  ScreenerGitHubSyncService,
 } from '@aiostreams/core';
 
 const logger = createLogger('server');
@@ -135,6 +137,41 @@ function registerUsenetTasks() {
   });
 }
 
+function registerScreenerTask() {
+  TaskManager.register({
+    id: 'screener-remote-refresh',
+    label: 'Refresh Screener remote lists',
+    description:
+      'Re-fetches subscribed remote Screener lists whose refresh interval has ' +
+      'elapsed and replaces their stored entries.',
+    category: 'data-sync',
+    kind: 'scheduled',
+    intervalMs: 15 * 60_000,
+    enabled: true,
+    destructive: false,
+    multiReplica: 'single',
+    run: async () => ScreenerRemoteSourceService.refreshDue(),
+  });
+  TaskManager.register({
+    id: 'screener-github-sync',
+    label: 'Publish Screener list to GitHub',
+    description:
+      'Pushes Screener list to the configured GitHub repo when auto-sync ' +
+      'is enabled and its interval has elapsed.',
+    category: 'data-sync',
+    kind: 'scheduled',
+    intervalMs: 15 * 60_000,
+    enabled: true,
+    destructive: false,
+    multiReplica: 'single',
+    run: async () => {
+      // syncIfDue never throws; it signals a failed push with an `error:` prefix.
+      const message = await ScreenerGitHubSyncService.syncIfDue();
+      return { ok: !message.startsWith('error:'), message };
+    },
+  });
+}
+
 async function initialiseRedis() {
   if (appConfig.bootstrap.redisUri) {
     await Cache.testRedisConnection();
@@ -190,6 +227,7 @@ async function start() {
     registerPruneTask();
     registerCacheTasks();
     registerUsenetTasks();
+    registerScreenerTask();
     await initialiseAuth();
     startAnalytics();
     const server = app.listen(appConfig.bootstrap.port, (error) => {


### PR DESCRIPTION
Part 5 of the Screener feature, split from #1056.

The operator control plane:

- Admin API for sources, manual marks, and import/export.
- Remote list subscriptions: scheduled fetch, gunzip, parse, replace, ETag-conditional and size-capped, SSRF-guarded (loopback/private/link-local and non-http(s) targets refused, including across redirects).
- GitHub sync to publish or follow a list.
- Refresh and auto-sync jobs wired onto the existing TaskManager.

Depends on parts 1-4. Merge order 1 → 6; umbrella is #1056.
---
**Screener, split from #1056 into 6 parts to review in passes. Merge in order:**
1. #1063 — release keys + NDJSON interchange
2. #1064 — verdict store + migrations
3. #1065 — evaluator + config
4. #1066 — pipeline filter
5. #1067 — API + remote + GitHub sync
6. #1068 — dashboard
