### PR TITLE
fix(usenet): mint extension-less stream urls for cloudflare compatibility

### DIFF
--- a/packages/core/src/debrid/aiostreams.ts
+++ b/packages/core/src/debrid/aiostreams.ts
@@ -291,9 +291,7 @@ export class NativeUsenetService implements UsenetDebridService {
       filename: chosenFilename,
     });
 
-    const url = `${appConfig.bootstrap.baseUrl}/api/v1/usenet/stream/${token}/${encodeURIComponent(
-      chosenFilename
-    )}`;
+    const url = `${appConfig.bootstrap.baseUrl}/api/v1/usenet/stream/${token}`;
     logger.debug(
       {
         hash: nzbHash,

--- a/packages/server/src/routes/api/dashboard-usenet.ts
+++ b/packages/server/src/routes/api/dashboard-usenet.ts
@@ -380,9 +380,9 @@ async function mintAndRespond(
       );
       return;
     }
-    const url = `/api/v1/usenet/stream/${minted.token}/${encodeURIComponent(
-      minted.filename
-    )}${download ? '?download=1' : ''}`;
+    const url = `/api/v1/usenet/stream/${minted.token}${
+      download ? '?download=1' : ''
+    }`;
     res.status(200).json(
       createResponse({
         success: true,


### PR DESCRIPTION
Native usenet streams froze on seek behind a CDN (Cloudflare): playback started fine, scrubbing hung.

## Cause

A file extension in the stream URL (`…/api/v1/usenet/stream/<token>/<name>.mkv`) makes Cloudflare classify the response as a cacheable static asset by extension, at request time before any response header is read. It then engages its cache/range machinery and can drop the client's `Range` header, streaming the whole file from byte 0, so a seek never reaches the offset and playback stalls. Large files make it worse: they exceed CF's cacheable-object limit, so every request is a miss and every miss is a full-file origin pull.

## Fix

Mint the stream URL without the file extension. The real filename stays in the token, so `Content-Type` and the download filename (`Content-Disposition`) are unchanged, and the route still accepts the old filename-suffixed URLs. `Cache-Control` stays `no-store`, which is correct for per-user capability URLs.

## Testing

End-to-end through Cloudflare on a 68 GiB 4K remux (over CF's 512 MB cacheable limit), deep-range seek 2 GiB from the end:

| URL | Cache-Control | cf-cache-status | Range honored |
|-----|--------------|-----------------|---------------|
| extensionless | `no-store` | DYNAMIC | 30/30 |
| extensionless | `private` | DYNAMIC | 20/20 |
| `.mkv` | `no-store` | BYPASS | flips CF to cache-eligible (the state that intermittently strips Range) |

The extension is the only thing that moves Cloudflare between `DYNAMIC` (hands off, always forwards `Range`) and `BYPASS` (engages cache machinery, intermittently strips). `Cache-Control` has no effect on that classification, so the extensionless URL is the fix and `no-store` is kept.
