### PR TITLE
chore(presets/newznab): rename SceneNZBs to Treasure Maps

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -71,7 +71,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
           { label: 'NzbNoob', value: 'https://nzbnoob.com' },
           { label: 'NzbPlanet', value: 'https://api.nzbplanet.net' },
           { label: 'NZBStars', value: 'https://nzbstars.com/' },
-          { label: 'SceneNZBs', value: 'https://scenenzbs.com' },
+          { label: 'Treasure Maps (formerly SceneNZBs)', value: 'https://treasure-maps.com' },
           {
             label: 'Tabula Rasa',
             value: 'https://www.tabula-rasa.pw/api/v1/',


### PR DESCRIPTION
Didn't check yet how this behaves for add-ons having scene selected. I guess it jumps to "Custom"? Created from my phone 🙈

<img width="1080" height="2400" alt="Screenshot_20260704-092720" src="https://github.com/user-attachments/assets/6bb14044-826f-41dd-9b7a-4550a0ba920b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Newznab URL selection options to show **Treasure Maps (formerly SceneNZBs)** instead of the previous entry.
  * Improved the available endpoint choice for this preset, helping users select the correct service more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->