### PR TITLE
fix: avoid stale empty catalogs and resolve generated addon IDs

### DIFF
--- a/packages/core/src/main/catalog.ts
+++ b/packages/core/src/main/catalog.ts
@@ -33,10 +33,6 @@ export function resolveCatalogAddon(
   );
   if (exactMatch) return exactMatch;
 
-  // Catalog modifications and merged catalogs may retain the stable preset
-  // instance ID, while generated addons append a hash to their runtime ID.
-  // Only fall back when the preset resolves unambiguously; presets that create
-  // multiple addons must continue to use their full generated instance IDs.
   const presetMatches = ctx.addons.filter(
     (addon) => addon.preset.id === addonInstanceId
   );

--- a/packages/core/src/main/catalog.ts
+++ b/packages/core/src/main/catalog.ts
@@ -24,6 +24,25 @@ import {
 
 const logger = createLogger('core');
 
+export function resolveCatalogAddon(
+  ctx: Pick<AIOStreamsContext, 'addons'>,
+  addonInstanceId: string
+): AIOStreamsContext['addons'][number] | undefined {
+  const exactMatch = ctx.addons.find(
+    (addon) => addon.instanceId === addonInstanceId
+  );
+  if (exactMatch) return exactMatch;
+
+  // Catalog modifications and merged catalogs may retain the stable preset
+  // instance ID, while generated addons append a hash to their runtime ID.
+  // Only fall back when the preset resolves unambiguously; presets that create
+  // multiple addons must continue to use their full generated instance IDs.
+  const presetMatches = ctx.addons.filter(
+    (addon) => addon.preset.id === addonInstanceId
+  );
+  return presetMatches.length === 1 ? presetMatches[0] : undefined;
+}
+
 export function convertDiscoverDeepLinks(
   ctx: Pick<AIOStreamsContext, 'addons' | 'manifestUrl'>,
   items: Meta['links']
@@ -63,7 +82,7 @@ export async function fetchRawCatalogItems(
   items: MetaPreview[];
   error?: { title: string; description: string };
 }> {
-  const addon = ctx.addons.find((a) => a.instanceId === addonInstanceId);
+  const addon = resolveCatalogAddon(ctx, addonInstanceId);
 
   if (!addon) {
     const initError = (
@@ -139,12 +158,13 @@ export async function fetchRawCatalogItems(
  * Used to determine what extras (search, genre, etc.) a catalog supports.
  */
 export function getCatalogExtras(
-  ctx: Pick<AIOStreamsContext, 'manifests'>,
+  ctx: Pick<AIOStreamsContext, 'addons' | 'manifests'>,
   addonInstanceId: string,
   catalogId: string,
   catalogType: string
 ): Manifest['catalogs'][number]['extra'] | undefined {
-  const manifest = ctx.manifests[addonInstanceId];
+  const addon = resolveCatalogAddon(ctx, addonInstanceId);
+  const manifest = ctx.manifests[addon?.instanceId ?? addonInstanceId];
   if (!manifest) return undefined;
 
   const catalog = manifest.catalogs?.find(

--- a/packages/core/src/main/wrapper.ts
+++ b/packages/core/src/main/wrapper.ts
@@ -631,8 +631,13 @@ export class Wrapper {
         cacher,
         cacheKey: effectiveCacheKey,
         cacheTtl,
+        // Do not retain transient empty catalog responses. An upstream
+        // timeout or provider hiccup can otherwise make a catalog disappear
+        // for the full TTL, even when the next request would succeed.
         shouldCache: (data: T) =>
-          resource !== 'stream' || (Array.isArray(data) && data.length > 0),
+          resource === 'catalog'
+            ? Array.isArray(data) && data.length > 0
+            : resource !== 'stream' || (Array.isArray(data) && data.length > 0),
       });
       const count = this.resultCountOf(data);
       track({

--- a/packages/core/src/main/wrapper.ts
+++ b/packages/core/src/main/wrapper.ts
@@ -631,9 +631,6 @@ export class Wrapper {
         cacher,
         cacheKey: effectiveCacheKey,
         cacheTtl,
-        // Do not retain transient empty catalog responses. An upstream
-        // timeout or provider hiccup can otherwise make a catalog disappear
-        // for the full TTL, even when the next request would succeed.
         shouldCache: (data: T) =>
           resource === 'catalog'
             ? Array.isArray(data) && data.length > 0


### PR DESCRIPTION
## Summary

- Resolve merged/catalog source references by exact generated addon ID, with an unambiguous stable preset-ID fallback.
- Do not cache empty catalog responses from upstream addons.

## Why

Generated custom addons currently append a short hash to their preset instance ID. A merged catalog configured with the stable preset ID can therefore fail with `Addon not found` even when the preset produced exactly one addon. The fallback now resolves that case without guessing when a preset produces multiple addons.

Separately, a transient upstream timeout or provider hiccup can return an empty catalog with HTTP 200. AIOStreams currently caches that empty result for the catalog TTL, making a catalog appear missing until expiry. Successful catalog responses continue to be cached; empty catalog responses are retried on the next request.

## Validation

- TypeScript compilation: `tsc -p packages/core/tsconfig.json --noEmit`
- Prettier check passed for changed TypeScript files.
- No test files are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon matching when retrieving catalogue data, including support for unique preset-based matches.
  * Corrected catalogue extras lookup when addon identifiers differ.
  * Prevented empty catalogue responses from being cached, ensuring cached results contain available items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->