### PR TITLE
feat(dashboard): per-indexer stats

### DIFF
--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -40,6 +40,11 @@ export {
   type UsenetProviderRollup,
   type UsenetMetricBucket,
 } from './repositories/usenet-metrics.js';
+export {
+  IndexerMetricsRepository,
+  type IndexerMetricDelta,
+  type IndexerRollup,
+} from './repositories/indexer-metrics.js';
 export * from './schemas.js';
 
 export { sql, raw, join, SqlFragment } from './sql.js';

--- a/packages/core/src/db/migrations/0016_indexer_metrics.ts
+++ b/packages/core/src/db/migrations/0016_indexer_metrics.ts
@@ -1,0 +1,46 @@
+import type { Migration } from './types.js';
+
+/**
+ * Hourly per-indexer rollups. One row per (hour, indexer instance) accumulates
+ * search/result/error counts and a latency sum so the dashboard can show how
+ * each configured indexer performs. `instance_id` is the addon preset id
+ * (stable per configured indexer); `name` holds the latest display name.
+ */
+export const indexerMetrics: Migration = {
+  id: 16,
+  name: 'indexer_metrics',
+  up: {
+    sqlite: `
+      CREATE TABLE IF NOT EXISTS indexer_metrics (
+        hour_ms INTEGER NOT NULL,
+        instance_id TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        searches INTEGER NOT NULL DEFAULT 0,
+        results INTEGER NOT NULL DEFAULT 0,
+        errors INTEGER NOT NULL DEFAULT 0,
+        latency_ms_sum INTEGER NOT NULL DEFAULT 0,
+        latency_samples INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (hour_ms, instance_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_hour
+        ON indexer_metrics (hour_ms);
+    `,
+    postgres: `
+      CREATE TABLE IF NOT EXISTS indexer_metrics (
+        hour_ms BIGINT NOT NULL,
+        instance_id TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        searches BIGINT NOT NULL DEFAULT 0,
+        results BIGINT NOT NULL DEFAULT 0,
+        errors BIGINT NOT NULL DEFAULT 0,
+        latency_ms_sum BIGINT NOT NULL DEFAULT 0,
+        latency_samples BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (hour_ms, instance_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_hour
+        ON indexer_metrics (hour_ms);
+    `,
+  },
+};

--- a/packages/core/src/db/migrations/0016_indexer_metrics.ts
+++ b/packages/core/src/db/migrations/0016_indexer_metrics.ts
@@ -23,8 +23,8 @@ export const indexerMetrics: Migration = {
         PRIMARY KEY (hour_ms, instance_id)
       );
 
-      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_hour
-        ON indexer_metrics (hour_ms);
+      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_instance
+        ON indexer_metrics (instance_id, hour_ms);
     `,
     postgres: `
       CREATE TABLE IF NOT EXISTS indexer_metrics (
@@ -39,8 +39,8 @@ export const indexerMetrics: Migration = {
         PRIMARY KEY (hour_ms, instance_id)
       );
 
-      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_hour
-        ON indexer_metrics (hour_ms);
+      CREATE INDEX IF NOT EXISTS idx_indexer_metrics_instance
+        ON indexer_metrics (instance_id, hour_ms);
     `,
   },
 };

--- a/packages/core/src/db/migrations/index.ts
+++ b/packages/core/src/db/migrations/index.ts
@@ -13,6 +13,7 @@ import { usenetLibraryAliases } from './0012_usenet_library_aliases.js';
 import { releaseBlocklist } from './0013_release_blocklist.js';
 import { releaseBlocklistPublish } from './0014_release_blocklist_publish.js';
 import { usenetLatency } from './0015_usenet_latency.js';
+import { indexerMetrics } from './0016_indexer_metrics.js';
 import type { Migration } from './types.js';
 
 export const MIGRATIONS: readonly Migration[] = [
@@ -31,6 +32,7 @@ export const MIGRATIONS: readonly Migration[] = [
   releaseBlocklist,
   releaseBlocklistPublish,
   usenetLatency,
+  indexerMetrics,
 ];
 
 export type { Migration } from './types.js';

--- a/packages/core/src/db/repositories/indexer-metrics.ts
+++ b/packages/core/src/db/repositories/indexer-metrics.ts
@@ -1,0 +1,117 @@
+import { getDb } from '../db.js';
+import { sql } from '../sql.js';
+
+/** A drained per-indexer delta to fold into an hourly bucket. */
+export interface IndexerMetricDelta {
+  instanceId: string;
+  name: string;
+  searches: number;
+  results: number;
+  errors: number;
+  latencyMsSum: number;
+  latencySamples: number;
+}
+
+/** Aggregated per-indexer rollup over a window. */
+export interface IndexerRollup {
+  instanceId: string;
+  name: string;
+  searches: number;
+  results: number;
+  errors: number;
+  latencyMsSum: number;
+  latencySamples: number;
+}
+
+interface RollupRow {
+  instance_id: string;
+  name: string;
+  searches: number | string;
+  results: number | string;
+  errors: number | string;
+  latency_ms_sum: number | string;
+  latency_samples: number | string;
+  [k: string]: unknown;
+}
+
+const HOUR_MS = 3_600_000;
+
+function hourFloor(ts: number): number {
+  return ts - (ts % HOUR_MS);
+}
+
+/**
+ * Persistence for per-indexer performance rollups (`indexer_metrics`). The
+ * stream pipeline accumulates deltas in memory; a background task drains them
+ * here into the current hour bucket. The dashboard queries windowed aggregates.
+ */
+export class IndexerMetricsRepository {
+  /** Fold drained deltas into the hour bucket containing `atMs` (defaults now). */
+  static async addDeltas(
+    deltas: IndexerMetricDelta[],
+    atMs: number = Date.now()
+  ): Promise<void> {
+    if (deltas.length === 0) return;
+    const hourMs = hourFloor(atMs);
+    const db = getDb();
+    for (const d of deltas) {
+      await db.exec(
+        sql`INSERT INTO indexer_metrics
+              (hour_ms, instance_id, name, searches, results, errors, latency_ms_sum, latency_samples)
+            VALUES
+              (${hourMs}, ${d.instanceId}, ${d.name}, ${d.searches}, ${d.results}, ${d.errors}, ${d.latencyMsSum}, ${d.latencySamples})
+            ON CONFLICT(hour_ms, instance_id) DO UPDATE SET
+              name = EXCLUDED.name,
+              searches = indexer_metrics.searches + EXCLUDED.searches,
+              results = indexer_metrics.results + EXCLUDED.results,
+              errors = indexer_metrics.errors + EXCLUDED.errors,
+              latency_ms_sum = indexer_metrics.latency_ms_sum + EXCLUDED.latency_ms_sum,
+              latency_samples = indexer_metrics.latency_samples + EXCLUDED.latency_samples`
+      );
+    }
+  }
+
+  /** Per-indexer totals over [sinceMs, now]. Newest name per instance wins. */
+  static async summaryByIndexer(sinceMs: number): Promise<IndexerRollup[]> {
+    const rows = await getDb().query<RollupRow>(
+      sql`SELECT instance_id,
+                 (SELECT name FROM indexer_metrics n
+                   WHERE n.instance_id = m.instance_id
+                   ORDER BY hour_ms DESC LIMIT 1) AS name,
+                 SUM(searches) AS searches,
+                 SUM(results) AS results,
+                 SUM(errors) AS errors,
+                 SUM(latency_ms_sum) AS latency_ms_sum,
+                 SUM(latency_samples) AS latency_samples
+            FROM indexer_metrics m
+           WHERE hour_ms >= ${sinceMs}
+           GROUP BY instance_id`
+    );
+    return rows.map((r) => ({
+      instanceId: r.instance_id,
+      name: r.name ?? r.instance_id,
+      searches: Number(r.searches ?? 0),
+      results: Number(r.results ?? 0),
+      errors: Number(r.errors ?? 0),
+      latencyMsSum: Number(r.latency_ms_sum ?? 0),
+      latencySamples: Number(r.latency_samples ?? 0),
+    }));
+  }
+
+  /** Earliest recorded hour (for "all time" windows). */
+  static async firstHour(): Promise<number | undefined> {
+    const row = await getDb().maybeOne<{ hour_ms: number | string }>(
+      sql`SELECT MIN(hour_ms) AS hour_ms FROM indexer_metrics`
+    );
+    const v = row?.hour_ms;
+    return v == null ? undefined : Number(v);
+  }
+
+  /** Delete rollups older than the cutoff. Returns rows removed. */
+  static async pruneOlderThan(cutoffMs: number): Promise<number> {
+    const res = await getDb().exec(
+      sql`DELETE FROM indexer_metrics WHERE hour_ms < ${cutoffMs}`
+    );
+    return res.rowCount ?? 0;
+  }
+}

--- a/packages/core/src/db/repositories/indexer-metrics.ts
+++ b/packages/core/src/db/repositories/indexer-metrics.ts
@@ -53,10 +53,12 @@ export class IndexerMetricsRepository {
   ): Promise<void> {
     if (deltas.length === 0) return;
     const hourMs = hourFloor(atMs);
-    const db = getDb();
-    for (const d of deltas) {
-      await db.exec(
-        sql`INSERT INTO indexer_metrics
+    // One transaction so a mid-batch failure rolls back cleanly instead of
+    // leaving some deltas applied (a retry would then double-count them).
+    await getDb().tx(async (tx) => {
+      for (const d of deltas) {
+        await tx.exec(
+          sql`INSERT INTO indexer_metrics
               (hour_ms, instance_id, name, searches, results, errors, latency_ms_sum, latency_samples)
             VALUES
               (${hourMs}, ${d.instanceId}, ${d.name}, ${d.searches}, ${d.results}, ${d.errors}, ${d.latencyMsSum}, ${d.latencySamples})
@@ -67,8 +69,9 @@ export class IndexerMetricsRepository {
               errors = indexer_metrics.errors + EXCLUDED.errors,
               latency_ms_sum = indexer_metrics.latency_ms_sum + EXCLUDED.latency_ms_sum,
               latency_samples = indexer_metrics.latency_samples + EXCLUDED.latency_samples`
-      );
-    }
+        );
+      }
+    });
   }
 
   /** Per-indexer totals over [sinceMs, now]. Newest name per instance wins. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './debrid/index.js';
 export * from './usenet/integration/index.js';
 export * from './release-blocklist/index.js';
 export * from './proxy/index.js';
+export { indexerStats } from './streams/indexer-stats.js';
 export {
   TorBoxSearchAddon,
   GDriveAddon,

--- a/packages/core/src/streams/fetcher.ts
+++ b/packages/core/src/streams/fetcher.ts
@@ -6,6 +6,7 @@ import {
   getTimeTakenSincePoint,
 } from '../utils/index.js';
 import { Wrapper } from '../main/wrapper.js';
+import { indexerStats } from './indexer-stats.js';
 import {
   ExitConditionEvaluator,
   GroupConditionEvaluator,
@@ -639,6 +640,17 @@ class StreamFetcher {
     for (let i = 0; i < allStatisticStreams.length; i++) {
       allStatisticStreams[i] = statStreamsWithTime[i].stat;
     }
+    for (const info of dispositions.values()) {
+      if (info.disposition === 'not_started') continue;
+      indexerStats.recordSearch({
+        instanceId: info.addon.preset.id,
+        name: info.addon.name,
+        results: info.rawCount,
+        latencyMs: info.latencyMs,
+        error: info.disposition === 'error',
+      });
+    }
+
     return {
       streams: allStreams,
       errors: allErrors,

--- a/packages/core/src/streams/indexer-stats.ts
+++ b/packages/core/src/streams/indexer-stats.ts
@@ -1,0 +1,66 @@
+import type { IndexerMetricDelta } from '../db/repositories/indexer-metrics.js';
+
+interface IndexerCounters {
+  name: string;
+  searches: number;
+  results: number;
+  errors: number;
+  latencyMsSum: number;
+  latencySamples: number;
+}
+
+/**
+ * Process-global in-memory accumulator for per-indexer activity. The stream
+ * pipeline records searches (with result counts + latency); a background task
+ * drains the deltas to the DB and clears them.
+ */
+class IndexerStatsAccumulator {
+  private byInstance = new Map<string, IndexerCounters>();
+
+  private get(instanceId: string, name: string): IndexerCounters {
+    let c = this.byInstance.get(instanceId);
+    if (!c) {
+      c = {
+        name,
+        searches: 0,
+        results: 0,
+        errors: 0,
+        latencyMsSum: 0,
+        latencySamples: 0,
+      };
+      this.byInstance.set(instanceId, c);
+    }
+    if (name) c.name = name;
+    return c;
+  }
+
+  /** One completed search against an indexer instance. */
+  recordSearch(event: {
+    instanceId: string;
+    name: string;
+    results: number;
+    latencyMs: number;
+    error: boolean;
+  }): void {
+    const c = this.get(event.instanceId, event.name);
+    c.searches++;
+    c.results += event.results;
+    if (event.error) c.errors++;
+    if (event.latencyMs > 0) {
+      c.latencyMsSum += event.latencyMs;
+      c.latencySamples++;
+    }
+  }
+
+  /** Return per-indexer counters since the last drain and clear them. */
+  drain(): IndexerMetricDelta[] {
+    const out: IndexerMetricDelta[] = [];
+    for (const [instanceId, c] of this.byInstance) {
+      out.push({ instanceId, ...c });
+    }
+    this.byInstance.clear();
+    return out;
+  }
+}
+
+export const indexerStats = new IndexerStatsAccumulator();

--- a/packages/frontend/src/app/dashboard/usenet/queries.ts
+++ b/packages/frontend/src/app/dashboard/usenet/queries.ts
@@ -272,6 +272,32 @@ export function useUsenetStats(window: UsenetWindow) {
   });
 }
 
+export interface IndexerStatRow {
+  instanceId: string;
+  name: string;
+  searches: number;
+  results: number;
+  errors: number;
+  avgResults: number;
+  avgLatencyMs: number;
+  errorRate: number;
+}
+
+export interface IndexerStats {
+  window: UsenetWindow;
+  indexers: IndexerStatRow[];
+}
+
+export function useIndexerStats(window: UsenetWindow) {
+  return useQuery({
+    queryKey: [...ROOT, 'indexers', window],
+    queryFn: () =>
+      api<IndexerStats>(`/dashboard/usenet/indexers?window=${window}`),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+}
+
 const LIVE_QUERY_KEY = [...ROOT, 'live'] as const;
 
 /**

--- a/packages/frontend/src/app/dashboard/usenet/stats-page.tsx
+++ b/packages/frontend/src/app/dashboard/usenet/stats-page.tsx
@@ -11,6 +11,7 @@ import { AnimatedNumber } from '@/components/shared/animated-number';
 import {
   useUsenetStats,
   useUsenetLive,
+  useIndexerStats,
   liveFrameMs,
   type PoolInfo,
   type ProviderPoolInfo,
@@ -18,6 +19,7 @@ import {
   type ProviderState,
   type UsenetProviderStatRow,
   type UsenetStatsOverview,
+  type IndexerStatRow,
 } from './queries';
 import {
   formatBytes,
@@ -541,6 +543,65 @@ function ProviderTable({ providers }: { providers: UsenetProviderStatRow[] }) {
   );
 }
 
+function IndexerTable({ indexers }: { indexers: IndexerStatRow[] }) {
+  if (indexers.length === 0) {
+    return (
+      <p className="text-sm text-[--muted]">
+        No indexer activity recorded in this window yet.
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto -mx-4 px-4 lg:mx-0 lg:px-0">
+      <table className="w-full text-sm min-w-[640px]">
+        <thead className="text-[--muted] text-xs uppercase">
+          <tr className="text-left border-b border-[--border]">
+            <th className="py-2 pr-3">Indexer</th>
+            <th className="py-2 px-3 text-right">Searches</th>
+            <th className="py-2 px-3 text-right">Avg results</th>
+            <th className="py-2 px-3 text-right">Avg latency</th>
+            <th className="py-2 pl-3 text-right">Errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          {indexers.map((i) => (
+            <tr key={i.instanceId} className="border-b border-[--border]/50">
+              <td className="py-2 pr-3 font-medium">{i.name}</td>
+              <td className="py-2 px-3 text-right tabular-nums">
+                {formatCompact(i.searches)}
+              </td>
+              <td className="py-2 px-3 text-right tabular-nums">
+                {i.avgResults.toFixed(1)}
+              </td>
+              <td className="py-2 px-3 text-right tabular-nums">
+                {i.avgLatencyMs > 0 ? `${i.avgLatencyMs}ms` : '—'}
+              </td>
+              <td
+                className={cn(
+                  'py-2 pl-3 text-right tabular-nums',
+                  i.errorRate > 0.1 && 'text-red-500'
+                )}
+              >
+                {formatPercent(i.errorRate)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function IndexerCard({ window }: { window: UsenetWindow }) {
+  const { data } = useIndexerStats(window);
+  return (
+    <Card className="p-4">
+      <h3 className="text-sm font-semibold mb-3">Indexers</h3>
+      <IndexerTable indexers={data?.indexers ?? []} />
+    </Card>
+  );
+}
+
 function StatsSection({ data }: { data: UsenetStatsOverview }) {
   const chartData = data.throughput.map((b) => ({
     t: fmtBucketLabel(b.bucketMs, data.window),
@@ -624,6 +685,8 @@ function StatsSection({ data }: { data: UsenetStatsOverview }) {
           <ProviderTable providers={data.providers} />
         )}
       </Card>
+
+      <IndexerCard window={data.window} />
     </div>
   );
 }

--- a/packages/frontend/src/app/dashboard/usenet/stats-page.tsx
+++ b/packages/frontend/src/app/dashboard/usenet/stats-page.tsx
@@ -593,11 +593,15 @@ function IndexerTable({ indexers }: { indexers: IndexerStatRow[] }) {
 }
 
 function IndexerCard({ window }: { window: UsenetWindow }) {
-  const { data } = useIndexerStats(window);
+  const { data, isPending } = useIndexerStats(window);
   return (
     <Card className="p-4">
       <h3 className="text-sm font-semibold mb-3">Indexers</h3>
-      <IndexerTable indexers={data?.indexers ?? []} />
+      {isPending ? (
+        <p className="text-sm text-[--muted]">Loading…</p>
+      ) : (
+        <IndexerTable indexers={data?.indexers ?? []} />
+      )}
     </Card>
   );
 }

--- a/packages/server/src/routes/api/dashboard-usenet.ts
+++ b/packages/server/src/routes/api/dashboard-usenet.ts
@@ -22,6 +22,7 @@ import {
   ReleaseBlocklistRepository,
   blocklistEvalOptions,
   nzbContentKey,
+  IndexerMetricsRepository,
   type UsenetStatsWindow,
   type UsenetLibraryStatusGroup,
   type UsenetLibraryStatus,
@@ -68,6 +69,44 @@ router.get('/stats', async (req, res, next) => {
     const window = WINDOWS.includes(w) ? w : '24h';
     const overview = await getUsenetStatsOverview(window);
     res.status(200).json(createResponse({ success: true, data: overview }));
+  } catch (err) {
+    next(err);
+  }
+});
+
+const WINDOW_MS: Record<UsenetStatsWindow, number | null> = {
+  '24h': 24 * 60 * 60_000,
+  '7d': 7 * 24 * 60 * 60_000,
+  '30d': 30 * 24 * 60 * 60_000,
+  all: null,
+};
+
+// GET /dashboard/usenet/indexers?window=24h — per-indexer stats over the window.
+router.get('/indexers', async (req, res, next) => {
+  try {
+    const w = String(req.query.window ?? '24h') as UsenetStatsWindow;
+    const window = WINDOWS.includes(w) ? w : '24h';
+    const span = WINDOW_MS[window];
+    const sinceMs = span == null ? 0 : Date.now() - span;
+    const rows = await IndexerMetricsRepository.summaryByIndexer(sinceMs);
+    const indexers = rows
+      .map((r) => ({
+        instanceId: r.instanceId,
+        name: r.name,
+        searches: r.searches,
+        results: r.results,
+        errors: r.errors,
+        avgResults: r.searches > 0 ? r.results / r.searches : 0,
+        avgLatencyMs:
+          r.latencySamples > 0
+            ? Math.round(r.latencyMsSum / r.latencySamples)
+            : 0,
+        errorRate: r.searches > 0 ? r.errors / r.searches : 0,
+      }))
+      .sort((a, b) => b.searches - a.searches);
+    res
+      .status(200)
+      .json(createResponse({ success: true, data: { window, indexers } }));
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,6 +28,8 @@ import {
   flushAllDiskCaches,
   ReleaseBlocklistRemoteService,
   ReleaseBlocklistPublishService,
+  indexerStats,
+  IndexerMetricsRepository,
 } from '@aiostreams/core';
 
 const logger = createLogger('server');
@@ -170,6 +172,47 @@ function registerReleaseBlocklistTasks() {
   });
 }
 
+// Match the provider-metrics retention window (~13 months).
+const INDEXER_METRICS_RETENTION_DAYS = 400;
+
+function registerIndexerTasks() {
+  TaskManager.register({
+    id: 'indexer-metrics-drain',
+    label: 'Flush indexer metrics',
+    description:
+      'Drains the in-memory per-indexer counters (searches, results, ' +
+      'latency, errors, proxied grabs) into the hourly rollup table.',
+    category: 'data-sync',
+    kind: 'scheduled',
+    intervalMs: 60_000,
+    enabled: true,
+    destructive: false,
+    multiReplica: 'all',
+    run: async () => {
+      const deltas = indexerStats.drain();
+      await IndexerMetricsRepository.addDeltas(deltas);
+      return { ok: true, message: `flushed ${deltas.length} indexer deltas` };
+    },
+  });
+  TaskManager.register({
+    id: 'indexer-metrics-prune',
+    label: 'Prune old indexer metrics',
+    description: 'Deletes per-indexer rollups older than the retention window.',
+    category: 'data-sync',
+    kind: 'scheduled',
+    intervalMs: 24 * 60 * 60_000,
+    enabled: true,
+    destructive: true,
+    multiReplica: 'single',
+    run: async () => {
+      const cutoff =
+        Date.now() - INDEXER_METRICS_RETENTION_DAYS * 24 * 60 * 60_000;
+      const n = await IndexerMetricsRepository.pruneOlderThan(cutoff);
+      return { ok: true, message: `pruned ${n} indexer metric rows` };
+    },
+  });
+}
+
 async function initialiseRedis() {
   if (appConfig.bootstrap.redisUri) {
     await Cache.testRedisConnection();
@@ -226,6 +269,7 @@ async function start() {
     registerCacheTasks();
     registerUsenetTasks();
     registerReleaseBlocklistTasks();
+    registerIndexerTasks();
     void requeueInterruptedInspects();
     await initialiseAuth();
     startAnalytics();


### PR DESCRIPTION
Adds per-indexer visibility to the usenet stats page. Each configured indexer shows searches, average results, average latency, and error rate over the selected window, rather than collapsing into its preset name ("newznab").

Captured where the pipeline already times each addon (`fetcher.ts`), accumulated in memory and drained hourly into a rollup table, mirroring the existing provider-metrics pipeline. A `/dashboard/usenet/indexers` endpoint serves the windowed aggregates; the stats page renders an Indexers table beside Provider performance.

First slice of #1091. Grabs per indexer and library provenance are the remaining scope there (grabs are only observable via the built-in proxy; provenance needs import-path plumbing), left as follow-ups to keep this diff self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indexer performance tracking (searches, results, latency, errors) with hourly rollups, plus a new dashboard API endpoint for windowed indexer stats.
  * Updated the Usenet dashboard to include an indexer statistics section with per-indexer metrics by time window.
* **Improvements**
  * Show per-indexer averages (results and latency) and error rate, sorted by highest search volume, including loading and “no activity recorded” empty states.
* **Chores**
  * Implemented scheduled background draining and retention-based pruning of stored indexer metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->