### PR TITLE
fix(presets/newznab): move Season Pack Strategy option next to Search Mode

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -187,15 +187,6 @@ export class NewznabPreset extends BuiltinAddonPreset {
         ],
       },
       {
-        id: 'paginate',
-        name: 'Paginate Results',
-        description:
-          'Newznab endpoints can limit the number of results returned per request. Enabling this option will make the addon paginate through all available results to provide a more comprehensive set of results. Enabling this can increase the time taken to return results, some endpoints may not support pagination, and this will also increase the number of requests.',
-        type: 'boolean',
-        default: false,
-        showInSimpleMode: false,
-      },
-      {
         id: 'seasonPackStrategy',
         name: 'Season Pack Strategy',
         description:
@@ -210,6 +201,15 @@ export class NewznabPreset extends BuiltinAddonPreset {
           { label: 'Episode First, Season Pack Fallback', value: 'episodeFirstSeasonPackFallback' },
           { label: 'Season Pack First, Episode Fallback', value: 'seasonPackFirstEpisodeFallback' },
         ],
+      },
+      {
+        id: 'paginate',
+        name: 'Paginate Results',
+        description:
+          'Newznab endpoints can limit the number of results returned per request. Enabling this option will make the addon paginate through all available results to provide a more comprehensive set of results. Enabling this can increase the time taken to return results, some endpoints may not support pagination, and this will also increase the number of requests.',
+        type: 'boolean',
+        default: false,
+        showInSimpleMode: false,
       },
       {
         id: 'useMultipleInstances',


### PR DESCRIPTION
Match torznab's option ordering (searchMode -> seasonPackStrategy -> paginate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reorganised the Newznab preset’s advanced options for a clearer configuration layout.
  * No settings or behaviour were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->