### PR TITLE
feat(presets): add 101Catalogs marketplace preset

### DIFF
--- a/packages/core/src/config/schema/presets.ts
+++ b/packages/core/src/config/schema/presets.ts
@@ -433,6 +433,13 @@ export const presetsSchema = {
     timeoutEnv: 'DEFAULT_RPDB_CATALOGS_TIMEOUT',
     userAgentEnv: 'DEFAULT_RPDB_CATALOGS_USER_AGENT',
   }),
+  oneZeroOneCatalogs: basicPreset({
+    label: '101Catalogs',
+    default: ['https://api.101catalogs.xyz'],
+    envBase: 'ONE_ZERO_ONE_CATALOGS_URL',
+    timeoutEnv: 'DEFAULT_ONE_ZERO_ONE_CATALOGS_TIMEOUT',
+    userAgentEnv: 'DEFAULT_ONE_ZERO_ONE_CATALOGS_USER_AGENT',
+  }),
   streamingCatalogs: basicPreset({
     label: 'Streaming Catalogs',
     default: [

--- a/packages/core/src/presets/oneZeroOneCatalogs.ts
+++ b/packages/core/src/presets/oneZeroOneCatalogs.ts
@@ -1,0 +1,100 @@
+import { Addon, Option, UserData } from '../db/index.js';
+import { Preset, baseOptions } from './preset.js';
+import { constants } from '../utils/index.js';
+import { config as appConfig } from '../config/index.js';
+
+export class OneZeroOneCatalogsPreset extends Preset {
+  static override get METADATA() {
+    const supportedResources = [constants.CATALOG_RESOURCE];
+
+    const options: Option[] = [
+      ...baseOptions(
+        '101Catalogs',
+        supportedResources,
+        appConfig.presets.oneZeroOneCatalogs.defaultTimeout ??
+          appConfig.presets.defaultTimeout
+      ).filter((option) => option.id !== 'url'),
+      {
+        id: 'installationUrl',
+        name: 'Installation URL',
+        description:
+          'Configure your catalogs and retrieve your unique installation URL from [config.101catalogs.xyz](https://config.101catalogs.xyz), then paste it here.',
+        type: 'password',
+        required: true,
+      },
+      {
+        id: 'socials',
+        name: '',
+        description: '',
+        type: 'socials',
+        socials: [{ id: 'website', url: 'https://config.101catalogs.xyz' }],
+      },
+    ];
+
+    return {
+      ID: '101catalogs',
+      NAME: '101Catalogs',
+      LOGO: 'https://ik.imagekit.io/royalancap/101catalogs/logo101.png',
+      URL: appConfig.presets.oneZeroOneCatalogs.url,
+      TIMEOUT:
+        appConfig.presets.oneZeroOneCatalogs.defaultTimeout ??
+        appConfig.presets.defaultTimeout,
+      USER_AGENT:
+        appConfig.presets.oneZeroOneCatalogs.defaultUserAgent ??
+        appConfig.http.defaultUserAgent,
+      SUPPORTED_SERVICES: [],
+      DESCRIPTION:
+        'Customize your catalog with 550+ lists configured via [config.101catalogs.xyz](https://config.101catalogs.xyz).',
+      OPTIONS: options,
+      SUPPORTED_STREAM_TYPES: [],
+      SUPPORTED_RESOURCES: supportedResources,
+      CATEGORY: constants.PresetCategory.META_CATALOGS,
+    };
+  }
+
+  static async generateAddons(
+    userData: UserData,
+    options: Record<string, any>
+  ): Promise<Addon[]> {
+    const urlStr = options.installationUrl;
+    if (typeof urlStr !== 'string' || !urlStr.trim()) {
+      throw new Error('101Catalogs installation URL is required and must be a valid string.');
+    }
+
+    try {
+      const parsedUrl = new URL(urlStr.trim());
+      if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+        throw new Error('Installation URL must use HTTP or HTTPS protocol.');
+      }
+      if (!parsedUrl.pathname.endsWith('/manifest.json')) {
+        throw new Error('Installation URL pathname must end with /manifest.json');
+      }
+    } catch (err: any) {
+      throw new Error(`Invalid 101Catalogs installation URL: ${err.message || err}`);
+    }
+
+    return [this.generateAddon(userData, options)];
+  }
+
+  private static generateAddon(
+    userData: UserData,
+    options: Record<string, any>
+  ): Addon {
+    return {
+      name: options.name || this.METADATA.NAME,
+      manifestUrl: options.installationUrl,
+      enabled: true,
+      library: false,
+      resources: options.resources || this.METADATA.SUPPORTED_RESOURCES,
+      timeout: options.timeout || this.METADATA.TIMEOUT,
+      preset: {
+        id: '',
+        type: this.METADATA.ID,
+        options: options,
+      },
+      headers: {
+        'User-Agent': this.METADATA.USER_AGENT,
+      },
+    };
+  }
+}

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -79,6 +79,7 @@ import { StreamNZBPreset } from './streamnzb.js';
 import { DavexPreset } from './davex.js';
 import { HdHubPreset } from './hdhub.js';
 import { BaguettioPreset } from './baguettio.js';
+import { OneZeroOneCatalogsPreset } from './oneZeroOneCatalogs.js';
 import { Preset } from './index.js';
 
 let PRESET_LIST: string[] = [
@@ -140,6 +141,7 @@ let PRESET_LIST: string[] = [
   'debridio-tmdb',
   'debridio-tvdb',
   'debridio-ic4a',
+  '101catalogs',
   'streaming-catalogs',
   'anime-catalogs',
   'torrent-catalogs',
@@ -245,6 +247,8 @@ export class PresetManager {
         return WebStreamrPreset;
       case 'astream':
         return AStreamPreset;
+      case '101catalogs':
+        return OneZeroOneCatalogsPreset;
       case 'streaming-catalogs':
         return StreamingCatalogsPreset;
       case 'anime-catalogs':

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -588,6 +588,14 @@ neither the environment variable nor a stored value is present.
 | `DEFAULT_RPDB_CATALOGS_TIMEOUT`    | RPDB Catalogs › Default Timeout    | number | —                                                | Default timeout for the RPDB Catalogs addon (milliseconds). Falls back to the global default when unset. |
 | `DEFAULT_RPDB_CATALOGS_USER_AGENT` | RPDB Catalogs › Default User Agent | string | —                                                | Default User-Agent for the RPDB Catalogs addon. Supports `{version}`/`{random}` placeholders.            |
 
+#### One Zero One Catalogs
+
+| Environment Variable                       | UI Setting                                 | Type   | Default                           | Description                                                                                            |
+| ------------------------------------------ | ------------------------------------------ | ------ | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `ONE_ZERO_ONE_CATALOGS_URL`                | One Zero One Catalogs › URL                | list   | `["https://api.101catalogs.xyz"]` | Upstream URL(s) for the 101Catalogs addon.                                                             |
+| `DEFAULT_ONE_ZERO_ONE_CATALOGS_TIMEOUT`    | One Zero One Catalogs › Default Timeout    | number | —                                 | Default timeout for the 101Catalogs addon (milliseconds). Falls back to the global default when unset. |
+| `DEFAULT_ONE_ZERO_ONE_CATALOGS_USER_AGENT` | One Zero One Catalogs › Default User Agent | string | —                                 | Default User-Agent for the 101Catalogs addon. Supports `{version}`/`{random}` placeholders.            |
+
 #### Streaming Catalogs
 
 | Environment Variable                    | UI Setting                              | Type   | Default                                                                   | Description                                                                                                   |


### PR DESCRIPTION
## Description
This PR adds support for **101Catalogs** as a native marketplace preset.

## How it works
Following the **DMM Cast** pattern, this preset provides a secure, single-option configuration where users can paste their personalized installation URL obtained from [config.101catalogs.xyz](https://config.101catalogs.xyz). 

This allows users to seamlessly use their custom 101Catalogs configuration with AIOStreams, while bypassing any need for complex/dynamic OAuth or catalog checklists within the AIOStreams settings page itself.

## Changes
- Created `OneZeroOneCatalogsPreset` in `packages/core/src/presets/oneZeroOneCatalogs.ts`.
- Registered the preset ID `101catalogs` in `presetManager.ts`.
- Added configuration options to `presetsSchema` in `packages/core/src/config/schema/presets.ts`.
- Regenerated environment variable documentation (`packages/docs/content/docs/configuration/environment-variables.mdx`).

<img width="1264" height="870" alt="Screenshot 2026-07-14 at 11 08 46 AM" src="https://github.com/user-attachments/assets/57fbe4f5-4b54-4785-a9ce-f533ba0fe373" />
<img width="448" height="516" alt="Screenshot 2026-07-14 at 11 08 21 AM" src="https://github.com/user-attachments/assets/e8e52987-c3c1-44bc-bb9a-cd01ac48c28c" />
<img width="567" height="589" alt="Screenshot 2026-07-14 at 11 07 58 AM" src="https://github.com/user-attachments/assets/839f1627-b5df-4fd6-8aa8-7d633f8f11b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the 101Catalogs preset.
  * Added configuration for installation manifest URLs, upstream endpoints, request timeouts, and User-Agent settings.
  * The preset validates installation manifest URLs before enabling the catalogue addon.
* **Documentation**
  * Documented new runtime environment variables for configuring 101Catalogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->