### PR TITLE
refactor(builtins/nab): rename seasonPackStrategy, drop dead season-first fallback

### DIFF
--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -63,14 +63,9 @@ export const NabAddonConfigSchema = BaseDebridConfigSchema.extend({
   forceQuerySearch: z.boolean().default(false),
   paginate: z.boolean().default(false),
   forceInitialLimit: z.number().min(1).max(10000).optional(),
-  seasonPackStrategy: z
-    .enum([
-      'episodeOnly',
-      'dynamic',
-      'episodeFirstSeasonPackFallback',
-      'seasonPackFirstEpisodeFallback',
-    ])
-    .default('episodeOnly'),
+  seasonEpisodeStrategy: z
+    .enum(['episode', 'season', 'episodeFirst', 'dynamic'])
+    .default('episode'),
 });
 export type NabAddonConfig = z.infer<typeof NabAddonConfigSchema>;
 
@@ -223,17 +218,13 @@ export abstract class BaseNabAddon<
       let fallbackParams: Record<string, string> | undefined;
       if (canApplySeasonPackStrategy) {
         const { ep, ...seasonOnlyParams } = queryParams;
-        let strategy = this.userData.seasonPackStrategy;
+        let strategy = this.userData.seasonEpisodeStrategy;
         if (strategy === 'dynamic') {
-          strategy =
-            metadata.ongoingSeason === true
-              ? 'episodeOnly'
-              : 'seasonPackFirstEpisodeFallback';
+          strategy = metadata.ongoingSeason ? 'episode' : 'season';
         }
-        if (strategy === 'seasonPackFirstEpisodeFallback') {
+        if (strategy === 'season') {
           primaryParams = seasonOnlyParams;
-          fallbackParams = queryParams;
-        } else if (strategy === 'episodeFirstSeasonPackFallback') {
+        } else if (strategy === 'episodeFirst') {
           fallbackParams = seasonOnlyParams;
         }
       }

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -187,24 +187,21 @@ export class NewznabPreset extends BuiltinAddonPreset {
         ],
       },
       {
-        id: 'seasonPackStrategy',
-        name: 'Season Pack Strategy',
+        id: 'seasonEpisodeStrategy',
+        name: 'Season/Episode Search Strategy',
         description:
-          'Controls episode vs. season-pack search order for series in `Auto` mode - useful for private trackers where season packs replace individual episodes. `Dynamic` decides based on whether the season is still airing. May include individual episodes too - pair with `Season/Episode Matching` in Filters to filter them out.',
+          "Controls whether series searches in `Auto` mode query at the episode level, the season level, or both - useful for private trackers where season packs replace individual episodes. A season-level search may return season packs, individual episodes, or both, depending on the indexer. `Dynamic` decides based on whether the season is still airing. Pair with `Season/Episode Matching` in Filters to filter out results that don't match.",
         type: 'select',
         required: false,
         showInSimpleMode: false,
-        default: 'episodeOnly',
+        default: 'episode',
         options: [
-          { label: 'Episode Only', value: 'episodeOnly' },
-          { label: 'Dynamic (Season Pack Preferred)', value: 'dynamic' },
+          { label: 'Episode', value: 'episode' },
+          { label: 'Season', value: 'season' },
+          { label: 'Dynamic (Season Preferred)', value: 'dynamic' },
           {
-            label: 'Episode First, Season Pack Fallback',
-            value: 'episodeFirstSeasonPackFallback',
-          },
-          {
-            label: 'Season Pack First, Episode Fallback',
-            value: 'seasonPackFirstEpisodeFallback',
+            label: 'Episode First, Season Fallback',
+            value: 'episodeFirst',
           },
         ],
       },
@@ -443,7 +440,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
       proxyAuth: options.proxyAuth,
       forceQuerySearch: options.forceQuerySearch ?? false,
       paginate: options.paginate ?? false,
-      seasonPackStrategy: options.seasonPackStrategy ?? 'episodeOnly',
+      seasonEpisodeStrategy: options.seasonEpisodeStrategy ?? 'episode',
       zyclopsHealthProxy: zyclopsHealthProxyConfig,
     };
 

--- a/packages/core/src/presets/torznab.ts
+++ b/packages/core/src/presets/torznab.ts
@@ -115,24 +115,21 @@ export class TorznabPreset extends BuiltinAddonPreset {
         ],
       },
       {
-        id: 'seasonPackStrategy',
-        name: 'Season Pack Strategy',
+        id: 'seasonEpisodeStrategy',
+        name: 'Season/Episode Search Strategy',
         description:
-          'Controls episode vs. season-pack search order for series in `Auto` mode - useful for private trackers where season packs replace individual episodes. `Dynamic` decides based on whether the season is still airing. May include individual episodes too - pair with `Season/Episode Matching` in Filters to filter them out.',
+          "Controls whether series searches in `Auto` mode query at the episode level, the season level, or both - useful for private trackers where season packs replace individual episodes. A season-level search may return season packs, individual episodes, or both, depending on the indexer. `Dynamic` decides based on whether the season is still airing. Pair with `Season/Episode Matching` in Filters to filter out results that don't match.",
         type: 'select',
         required: false,
         showInSimpleMode: false,
-        default: 'episodeOnly',
+        default: 'episode',
         options: [
-          { label: 'Episode Only', value: 'episodeOnly' },
-          { label: 'Dynamic (Season Pack Preferred)', value: 'dynamic' },
+          { label: 'Episode', value: 'episode' },
+          { label: 'Season', value: 'season' },
+          { label: 'Dynamic (Season Preferred)', value: 'dynamic' },
           {
-            label: 'Episode First, Season Pack Fallback',
-            value: 'episodeFirstSeasonPackFallback',
-          },
-          {
-            label: 'Season Pack First, Episode Fallback',
-            value: 'seasonPackFirstEpisodeFallback',
+            label: 'Episode First, Season Fallback',
+            value: 'episodeFirst',
           },
         ],
       },
@@ -270,7 +267,7 @@ export class TorznabPreset extends BuiltinAddonPreset {
       forceQuerySearch: options.forceQuerySearch ?? false,
       forceInitialLimit: options.initialLimit,
       paginate: options.paginate ?? false,
-      seasonPackStrategy: options.seasonPackStrategy ?? 'episodeOnly',
+      seasonEpisodeStrategy: options.seasonEpisodeStrategy ?? 'episode',
     };
 
     const configString = this.base64EncodeJSON(config, 'urlSafe');

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -754,6 +754,33 @@ export function applyMigrations(config: any): UserData {
     });
   }
 
+  // migrate seasonPackStrategy (torznab/newznab) to seasonEpisodeStrategy
+  if (config.presets && Array.isArray(config.presets)) {
+    const seasonPackStrategyMap: Record<string, string> = {
+      episodeOnly: 'episode',
+      dynamic: 'dynamic',
+      episodeFirstSeasonPackFallback: 'episodeFirst',
+      seasonPackFirstEpisodeFallback: 'season',
+    };
+    config.presets = config.presets.map((preset: any) => {
+      if (
+        typeof preset.options?.seasonPackStrategy === 'string' &&
+        preset.options.seasonEpisodeStrategy === undefined
+      ) {
+        const { seasonPackStrategy, ...restOptions } = preset.options;
+        return {
+          ...preset,
+          options: {
+            ...restOptions,
+            seasonEpisodeStrategy:
+              seasonPackStrategyMap[seasonPackStrategy] ?? 'episode',
+          },
+        };
+      }
+      return preset;
+    });
+  }
+
   if (config.formatter && config.formatter.definition) {
     config.formatter.definitions = {
       ...(config.formatter.definitions ?? {}),


### PR DESCRIPTION
Season-level searches can return season packs, loose episodes, or both depending on the indexer, so the old naming was misleading. Renamed the field/enum values and simplified dynamic mode (finished seasons search season-only with no episode fallback). Also removed the seasonFirst strategy entirely: its episode fallback only ever helped on non-standard indexers that behave inconsistently without an ep param, which real-world testing showed isn't worth designing around. Added a migration for existing configs.

---

This is based on research which I should have done better before tbh, sorry. it shows that episodes are included when searching for season, which is why I removed the episode fallback in dynamic for finished seasons. it also shows that e.g. stremthru and zilean behave different and should indeed not use a season-only strategy.

| Indexer | Show tested | Show status | Season-only (no `ep`) | Season+episode (`ep` included) |
|---|---|---|---|---|
| seedpool-api (jackett) | Silo S3 | Ongoing | All released episodes (E01+E02) | E01 only |
| privatehd (jackett) | Silo S3 | Ongoing | All released episodes (E01+E02) | E01 only |
| rockethd (jackett) | Silo S3 | Ongoing | All released episodes (E01+E02) | E01 only |
| filelist (jackett) | Silo S3 | Ongoing | All released episodes (E01+E02) | E01 only |
| torrentleech (jackett) | — | — | skipped — no id params supported at all (`q,season,ep` only) | skipped |
| digitalcore-api (jackett) | — | — | skipped — same reason | skipped |
| stremthru (torznab) | Silo S3 | Ongoing | ~0 results (1 hit, wrong season) — still broken without `ep` | 190+ results — packs + dozens of S03E01 releases |
| Zilean | Silo S3 | Ongoing | 4 results — 3× S03E01 + 1 full-series pack | Identical 4 results — `ep` changes nothing |

<img width="544" height="381" alt="image" src="https://github.com/user-attachments/assets/169b01fc-3cd3-4161-8a51-c0975cc463e0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Season/Episode Search Strategy” setting for Newznab and Torznab.
  * Supports episode, season, episode-first, dynamic, and mixed fallback modes to control series search behavior.

* **Bug Fixes**
  * Improved how season/episode searches retry with alternate parameter sets, especially for episode-first and dynamic flows.

* **Chores**
  * Automatically migrates existing configurations from the previous season pack strategy to the new season/episode strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->