### PR TITLE
feat(parser/regex): add `DVD REMUX` quality

### DIFF
--- a/packages/core/src/parser/regex.ts
+++ b/packages/core/src/parser/regex.ts
@@ -61,7 +61,8 @@ export const PARSE_REGEX: PARSE_REGEX = {
     '144p': createRegex('(bd|hd|m)?(144(p|i)?)'),
   },
   qualities: {
-    'BluRay REMUX': createRegex('(bd|br|b|uhd)?remux'),
+    'BluRay REMUX': createRegex('(?<!dvd.*)(bd|br|b|uhd)?remux(?!.*dvd)'),
+    'DVD REMUX': createRegex('(hd[ .\\-_]?)?dvd.*remux|remux.*(hd[ .\\-_]?)?dvd'),
     BluRay: createRegex(
       '(?<!remux.*)(bd|blu[ .\\-_]?ray|((bd|br)[ .\\-_]?rip))(?!.*remux)'
     ),

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -1025,6 +1025,7 @@ const RESOLUTIONS = [
 
 const QUALITIES = [
   'BluRay REMUX',
+  'DVD REMUX',
   'BluRay',
   'WEB-DL',
   'WEBRip',


### PR DESCRIPTION
- Added `DVD REMUX` quality - https://regex101.com/r/b2SvSx
- Fixed DVD remux detected as BluRay remux.

Closes #1004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognising DVD REMUX releases.
  * Improved detection of BluRay REMUX releases, including common format prefixes.

* **Bug Fixes**
  * Reduced incorrect overlap between DVD and BluRay REMUX classifications.
  * Expanded recognition of release names where DVD, HD, and REMUX terms appear in different orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->