### PR TITLE
fix(release-blocklist): only write an override when a remote source flags the release

### DIFF
--- a/packages/core/src/db/repositories/release-blocklist.ts
+++ b/packages/core/src/db/repositories/release-blocklist.ts
@@ -383,17 +383,36 @@ export class ReleaseBlocklistRepository {
   /**
    * The release was proven working: drop the local verdict and write an
    * override that suppresses remote verdicts for the key.
+   *
+   * `onlyIfBlocked` skips the override when no remote source flags the
+   * release, so automatic retractions do not pile up overrides for
+   * releases nothing has ever blocked.
    */
-  static async retract(key: string): Promise<void> {
+  static async retract(
+    key: string,
+    opts?: { onlyIfBlocked?: boolean }
+  ): Promise<void> {
     requireValidKey(key);
     const now = nowSeconds();
     await getDb().tx(async (tx) => {
+      let writeOverride = true;
+      if (opts?.onlyIfBlocked) {
+        const remote = await tx.query(
+          sql`SELECT 1 FROM release_blocklist_entries e
+              JOIN release_blocklist_keys kt ON kt.id = e.key_id
+              WHERE kt.k = ${key}
+                AND e.source_rid <> ${sourceRidSql(LOCAL_SOURCE_ID)}
+              LIMIT 1`
+        );
+        writeOverride = remote.length > 0;
+      }
       await tx.exec(
         sql`DELETE FROM release_blocklist_entries
             WHERE source_rid = ${sourceRidSql(LOCAL_SOURCE_ID)}
               AND key_id = ${keyIdSql(key)}`
       );
       await gcKeys(tx, key);
+      if (!writeOverride) return;
       await tx.exec(
         sql`INSERT INTO release_blocklist_overrides (k, created_at)
             VALUES (${key}, ${now})

--- a/packages/core/src/db/repositories/release-blocklist.ts
+++ b/packages/core/src/db/repositories/release-blocklist.ts
@@ -397,14 +397,12 @@ export class ReleaseBlocklistRepository {
     await getDb().tx(async (tx) => {
       let writeOverride = true;
       if (opts?.onlyIfBlocked) {
-        const remote = await tx.query(
-          sql`SELECT 1 FROM release_blocklist_entries e
-              JOIN release_blocklist_keys kt ON kt.id = e.key_id
-              WHERE kt.k = ${key}
-                AND e.source_rid <> ${sourceRidSql(LOCAL_SOURCE_ID)}
-              LIMIT 1`
+        const remote = await tx.maybeOne(
+          sql`SELECT 1 AS present FROM release_blocklist_entries
+              WHERE source_rid <> ${sourceRidSql(LOCAL_SOURCE_ID)}
+                AND key_id = ${keyIdSql(key)} LIMIT 1`
         );
-        writeOverride = remote.length > 0;
+        writeOverride = remote !== null;
       }
       await tx.exec(
         sql`DELETE FROM release_blocklist_entries

--- a/packages/core/src/release-blocklist/feedback.ts
+++ b/packages/core/src/release-blocklist/feedback.ts
@@ -32,16 +32,17 @@ export function markReleaseDead(
 
 /**
  * The release was proven working: drop any local verdicts and suppress
- * remote ones, under every key it is known by. Fire-and-forget; missing or
- * invalid keys are skipped.
+ * remote ones, under every key it is known by. Only keys a remote source
+ * actually flags get an override. Fire-and-forget; missing or invalid keys
+ * are skipped.
  */
 export function retractRelease(
   ...keys: Array<string | null | undefined>
 ): void {
   for (const key of keys) {
     if (!key || releaseKeyKind(key) === null) continue;
-    void ReleaseBlocklistRepository.retract(key).catch((err) =>
-      logger.warn(`failed to retract ${key}: ${err}`)
-    );
+    void ReleaseBlocklistRepository.retract(key, {
+      onlyIfBlocked: true,
+    }).catch((err) => logger.warn(`failed to retract ${key}: ${err}`));
   }
 }


### PR DESCRIPTION
`retract()` always writes an override row, without checking whether anything is actually blocking the release. That's right for the `/unmark` button, where a verdict exists by definition. But `retractRelease()` calls the same function on every successful usenet import (`library.ts`) and on a clean census (`census-shadow.ts`), where usually nothing has flagged the release at all.

So the overrides table fills with rows suppressing verdicts nobody has published. On my instance: 16 override rows across 8 releases, and 0 blocklist entries for any of those keys. The dashboard reads "16 overrides" on an instance that has never overridden anything.

Mostly cosmetic, but the rows are permanent. If one of those releases genuinely dies later and a subscribed list flags it, the override quietly suppresses that, and the only signal left is a failed playback.

Fix: `retract()` takes `onlyIfBlocked`. When set, it skips the override if no remote source has an entry for the key. The local verdict delete still runs unconditionally, since that's what un-sticks a release the instance previously marked dead. `retractRelease()` opts in, `/unmark` keeps its current behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release retractions now apply only when a release is actively blocked.
  * Prevents unnecessary override entries when no remote block exists.
  * Missing or invalid release keys are safely skipped during background retractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->