### PR TITLE
feat(release-blocklists): support batch source operations

### DIFF
--- a/packages/core/src/release-blocklist/remote.ts
+++ b/packages/core/src/release-blocklist/remote.ts
@@ -177,13 +177,31 @@ export class ReleaseBlocklistRemoteService {
     };
   }
 
-  /** Refresh specific sources now, regardless of their interval. */
-  static async refreshByIds(ids: string[]): Promise<void> {
-    for (const id of ids) {
-      const source = await ReleaseBlocklistRepository.getSource(id);
-      if (source?.kind === 'remote' && source.url) {
-        await this.refreshOne(source);
+  /**
+   * Refresh specific sources now, regardless of their interval. Remote sources
+   * are fetched with bounded concurrency; non-remote ids are skipped. Returns
+   * how many were refreshed vs errored (refreshOne records status rather than
+   * throwing, so failures are read from its returned status string).
+   */
+  static async refreshByIds(
+    ids: string[]
+  ): Promise<{ refreshed: number; failed: number }> {
+    const CONCURRENCY = 5;
+    let refreshed = 0;
+    let failed = 0;
+    let next = 0;
+    const worker = async () => {
+      while (next < ids.length) {
+        const source = await ReleaseBlocklistRepository.getSource(ids[next++]);
+        if (source?.kind !== 'remote' || !source.url) continue;
+        const status = await this.refreshOne(source);
+        if (status.startsWith('error')) failed++;
+        else refreshed++;
       }
-    }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker())
+    );
+    return { refreshed, failed };
   }
 }

--- a/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
+++ b/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/bi';
 import { Card } from '@/components/ui/card';
 import { Button, IconButton } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { TextInput } from '@/components/ui/text-input';
 import { Textarea } from '@/components/ui/textarea';
 import { NumberInput } from '@/components/ui/number-input';
@@ -19,6 +20,7 @@ import { Select } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Modal } from '@/components/ui/modal';
 import { SimpleDropzone } from '@/components/ui/simple-dropzone';
+import { cn } from '@/components/ui/core/styling';
 import {
   ConfirmationDialog,
   useConfirmationDialog,
@@ -67,6 +69,13 @@ function SourcesView({
   const [editing, setEditing] = React.useState<BlocklistSource>();
   const [pendingDelete, setPendingDelete] = React.useState<BlocklistSource>();
   const [pendingClear, setPendingClear] = React.useState<BlocklistSource>();
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
+  const [batchEditOpen, setBatchEditOpen] = React.useState(false);
+
+  const sources = snapshot.sources;
+  const allOnPageSelected =
+    sources.length > 0 && sources.every((s) => selectedIds.has(s.id));
+  const nonLocalSources = sources.filter((s) => s.id !== 'local');
 
   const patchSource = useMutation({
     mutationFn: (args: { id: string; body: Record<string, unknown> }) =>
@@ -105,6 +114,54 @@ function SourcesView({
     onError: (e: any) => toast.error(e?.message ?? 'Clear failed'),
   });
 
+  // Batch mutations
+  const batchRemove = useMutation({
+    mutationFn: (ids: string[]) =>
+      api('POST /dashboard/blocklist/batch/sources/remove', { body: { ids } }),
+    onSuccess: (result: any) => {
+      toast.success(`Removed ${result.removed} source${result.removed === 1 ? '' : 's'}`);
+      setSelectedIds(new Set());
+      invalidate();
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+  });
+
+  const batchClear = useMutation({
+    mutationFn: (ids: string[]) =>
+      api('POST /dashboard/blocklist/batch/sources/clear', { body: { ids } }),
+    onSuccess: (result: any) => {
+      toast.success(`Cleared ${result.cleared} source${result.cleared === 1 ? '' : 's'}`);
+      setSelectedIds(new Set());
+      invalidate();
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+  });
+
+  const batchRefresh = useMutation({
+    mutationFn: (ids: string[]) =>
+      api('POST /dashboard/blocklist/batch/sources/refresh', { body: { ids } }),
+    onSuccess: (result: any) => {
+      toast.success(`Refreshed ${result.refreshed} source${result.refreshed === 1 ? '' : 's'}`);
+      setSelectedIds(new Set());
+      invalidate();
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+  });
+
+  const batchPatch = useMutation({
+    mutationFn: (args: { ids: string[]; body: Record<string, unknown> }) =>
+      api('POST /dashboard/blocklist/batch/sources/patch', {
+        body: { ids: args.ids, ...args.body },
+      }),
+    onSuccess: (result: any) => {
+      toast.success(`Updated ${result.patched} source${result.patched === 1 ? '' : 's'}`);
+      setSelectedIds(new Set());
+      setBatchEditOpen(false);
+      invalidate();
+    },
+    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+  });
+
   const confirmDelete = useConfirmationDialog({
     title: 'Remove source',
     description:
@@ -122,6 +179,52 @@ function SourcesView({
     actionIntent: 'alert-subtle',
     onConfirm: () => pendingClear && clearSource.mutate(pendingClear.id),
   });
+
+  const confirmBatchRemove = useConfirmationDialog({
+    title: 'Remove selected sources',
+    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: the source and every entry it contributed will be removed. This cannot be undone. The local source is skipped.`,
+    actionText: 'Remove all',
+    actionIntent: 'alert-subtle',
+    onConfirm: () => batchRemove.mutate([...selectedIds]),
+  });
+
+  const confirmBatchClear = useConfirmationDialog({
+    title: 'Clear entries from selected sources',
+    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: entries are removed but the sources themselves are kept.`,
+    actionText: 'Clear all',
+    actionIntent: 'alert-subtle',
+    onConfirm: () => batchClear.mutate([...selectedIds]),
+  });
+
+  const confirmBatchRefresh = useConfirmationDialog({
+    title: 'Refresh selected sources',
+    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: refetch their lists from their remote URLs now.`,
+    actionText: 'Refresh all',
+    actionIntent: 'primary-subtle',
+    onConfirm: () => batchRefresh.mutate([...selectedIds]),
+  });
+
+  const confirmRemoveAllNonLocal = useConfirmationDialog({
+    title: 'Remove all non-local sources',
+    description: `Remove every source except this instance's own list (${nonLocalSources.length} source${nonLocalSources.length === 1 ? '' : 's'}). This cannot be undone.`,
+    actionText: 'Remove all',
+    actionIntent: 'alert-subtle',
+    onConfirm: () =>
+      batchRemove.mutate(nonLocalSources.map((s) => s.id)),
+  });
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const hasRemoteSelected = [...selectedIds].some(
+    (id) => sources.find((s) => s.id === id)?.kind === 'remote'
+  );
 
   return (
     <div className="space-y-4">
@@ -150,13 +253,83 @@ function SourcesView({
         >
           Export
         </Button>
+        <div className="flex-1" />
+        {nonLocalSources.length > 0 && (
+          <Button
+            size="sm"
+            intent="alert-subtle"
+            onClick={confirmRemoveAllNonLocal.open}
+            title="Remove all sources except the local one"
+          >
+            Remove all (except local)
+          </Button>
+        )}
       </div>
+
+      {/* Batch actions toolbar */}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[--accent]/10 border border-[--accent]/20">
+          <span className="text-sm font-medium tabular-nums">
+            {selectedIds.size} selected
+          </span>
+          <div className="flex-1" />
+          <Button
+            size="sm"
+            intent="gray-subtle"
+            leftIcon={<BiRefresh />}
+            loading={batchRefresh.isPending}
+            onClick={confirmBatchRefresh.open}
+            disabled={!hasRemoteSelected}
+          >
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            intent="gray-subtle"
+            leftIcon={<BiPencil />}
+            onClick={() => setBatchEditOpen(true)}
+          >
+            Edit...
+          </Button>
+          <Button
+            size="sm"
+            intent="gray-subtle"
+            leftIcon={<BiBlock />}
+            loading={batchClear.isPending}
+            onClick={confirmBatchClear.open}
+          >
+            Clear entries
+          </Button>
+          <Button
+            size="sm"
+            intent="alert-subtle"
+            leftIcon={<BiTrash />}
+            loading={batchRemove.isPending}
+            onClick={confirmBatchRemove.open}
+          >
+            Remove
+          </Button>
+        </div>
+      )}
 
       <Card className="p-0 overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="text-[--muted] text-xs uppercase bg-[--subtle]/40">
               <tr className="text-left">
+                <th className="p-3 w-10">
+                  <Checkbox
+                    value={allOnPageSelected}
+                    onValueChange={(checked) => {
+                      if (checked) {
+                        setSelectedIds(new Set(sources.map((s) => s.id)));
+                      } else {
+                        setSelectedIds(new Set());
+                      }
+                    }}
+                    aria-label="Select all"
+                  />
+                </th>
                 <th className="p-3">Name</th>
                 <th className="p-3">Kind</th>
                 <th className="p-3">Trust</th>
@@ -171,8 +344,20 @@ function SourcesView({
               {snapshot.sources.map((source) => (
                 <tr
                   key={source.id}
-                  className="border-t border-[--border]/50 hover:bg-[--subtle]/30"
+                  className={cn(
+                    'border-t border-[--border]/50',
+                    selectedIds.has(source.id)
+                      ? 'bg-[--accent]/5'
+                      : 'hover:bg-[--subtle]/30'
+                  )}
                 >
+                  <td className="p-3">
+                    <Checkbox
+                      value={selectedIds.has(source.id)}
+                      onValueChange={() => toggleSelect(source.id)}
+                      aria-label={`Select ${source.name}`}
+                    />
+                  </td>
                   <td className="p-3 font-medium">{source.name}</td>
                   <td className="p-3">
                     <Badge className={KIND_BADGE[source.kind]}>
@@ -187,13 +372,13 @@ function SourcesView({
                   <td className="p-3 tabular-nums">
                     {source.kind === 'remote'
                       ? formatInterval(source.refreshSeconds)
-                      : '—'}
+                      : '\u2014'}
                   </td>
                   <td
                     className="p-3 text-xs text-[--muted] max-w-[220px] truncate"
                     title={source.status ?? undefined}
                   >
-                    {source.status ?? '—'}
+                    {source.status ?? '\u2014'}
                   </td>
                   <td className="p-3 text-right tabular-nums">
                     <div>{source.count}</div>
@@ -208,7 +393,7 @@ function SourcesView({
                   </td>
                   <td className="p-3">
                     {source.kind === 'local' ? (
-                      '—'
+                      '\u2014'
                     ) : (
                       <Switch
                         value={source.enabled}
@@ -294,8 +479,21 @@ function SourcesView({
           invalidate={invalidate}
         />
       )}
+      {batchEditOpen && (
+        <BatchEditSourceModal
+          selectedIds={[...selectedIds]}
+          sources={sources}
+          onSave={(patch) => batchPatch.mutate({ ids: [...selectedIds], body: patch })}
+          loading={batchPatch.isPending}
+          onClose={() => setBatchEditOpen(false)}
+        />
+      )}
       <ConfirmationDialog {...confirmDelete} />
       <ConfirmationDialog {...confirmClear} />
+      <ConfirmationDialog {...confirmBatchRemove} />
+      <ConfirmationDialog {...confirmBatchClear} />
+      <ConfirmationDialog {...confirmBatchRefresh} />
+      <ConfirmationDialog {...confirmRemoveAllNonLocal} />
     </div>
   );
 }
@@ -610,7 +808,7 @@ function ExportModal({
         <Select
           label="Scope"
           options={[
-            { label: 'This instance’s own verdicts', value: 'local' },
+            { label: "This instance's own verdicts", value: 'local' },
             { label: 'Everything (all sources, deduplicated)', value: 'all' },
           ]}
           value={scope}
@@ -628,6 +826,94 @@ function ExportModal({
           </Button>
           <Button intent="primary" leftIcon={<BiDownload />} onClick={download}>
             Download
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function BatchEditSourceModal({
+  selectedIds,
+  sources,
+  onSave,
+  loading,
+  onClose,
+}: {
+  selectedIds: string[];
+  sources: BlocklistSource[];
+  onSave: (body: Record<string, unknown>) => void;
+  loading: boolean;
+  onClose: () => void;
+}) {
+  const selected = sources.filter((s) => selectedIds.includes(s.id));
+  const hasRemote = selected.some((s) => s.kind === 'remote');
+  const [trust, setTrust] = React.useState<Trust | ''>('');
+  const [refreshHours, setRefreshHours] = React.useState(24);
+  const [enabled, setEnabled] = React.useState<boolean | ''>('');
+
+  const buildPatch = (): Record<string, unknown> => {
+    const body: Record<string, unknown> = {};
+    if (trust) body.trust = trust;
+    if (hasRemote && refreshHours > 0) {
+      body.refreshSeconds = Math.round(refreshHours * 3600);
+    }
+    if (enabled !== '') body.enabled = enabled;
+    return body;
+  };
+
+  return (
+    <Modal
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title={`Edit ${selectedIds.length} source${selectedIds.length === 1 ? '' : 's'}`}
+      description="Set common fields for all selected sources. Blank fields are left unchanged."
+    >
+      <div className="space-y-3">
+        <Select
+          label="Trust"
+          options={[
+            { label: 'Leave unchanged', value: '' },
+            ...TRUSTS.map((t) => ({ label: t, value: t })),
+          ]}
+          value={trust}
+          onValueChange={(v) => setTrust(v as Trust | '')}
+          help="full filters on its own; corroborate needs the quorum; observe never filters"
+        />
+        {hasRemote && (
+          <NumberInput
+            label="Refresh (hours)"
+            value={refreshHours}
+            min={1}
+            max={720}
+            onValueChange={(v) => setRefreshHours(v || 24)}
+            help="Only applies to remote sources"
+          />
+        )}
+        <Select
+          label="Enabled"
+          options={[
+            { label: 'Leave unchanged', value: '' },
+            { label: 'Enable', value: 'true' },
+            { label: 'Disable', value: 'false' },
+          ]}
+          value={enabled === '' ? '' : String(enabled)}
+          onValueChange={(v) =>
+            setEnabled(v === '' ? '' : v === 'true')
+          }
+          help="Enable or disable the source. The local source cannot be disabled."
+        />
+        <div className="flex justify-end gap-2">
+          <Button intent="gray-outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            intent="primary"
+            loading={loading}
+            disabled={Object.keys(buildPatch()).length === 0}
+            onClick={() => onSave(buildPatch())}
+          >
+            Save
           </Button>
         </div>
       </div>

--- a/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
+++ b/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
@@ -11,7 +11,7 @@ import {
   BiUpload,
 } from 'react-icons/bi';
 import { Card } from '@/components/ui/card';
-import { Button, IconButton } from '@/components/ui/button';
+import { Button, IconButton, type ButtonProps } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TextInput } from '@/components/ui/text-input';
 import { Textarea } from '@/components/ui/textarea';
@@ -40,6 +40,17 @@ import {
   type Trust,
 } from './shared';
 
+type SourceMutationResult = Snapshot & { affected: number; failed: number };
+
+// A single confirmation dialog is driven by whichever action set this spec.
+type ConfirmSpec = {
+  title: string;
+  description: React.ReactNode;
+  actionText: string;
+  actionIntent: ButtonProps['intent'];
+  onConfirm: () => void;
+};
+
 export function BlocklistSourcesPage() {
   const snapshotQuery = useBlocklistSnapshot();
   const invalidate = useInvalidateBlocklist();
@@ -67,157 +78,155 @@ function SourcesView({
   const [importOpen, setImportOpen] = React.useState(false);
   const [exportOpen, setExportOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<BlocklistSource>();
-  const [pendingDelete, setPendingDelete] = React.useState<BlocklistSource>();
-  const [pendingClear, setPendingClear] = React.useState<BlocklistSource>();
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
   const [batchEditOpen, setBatchEditOpen] = React.useState(false);
+  const [confirmSpec, setConfirmSpec] = React.useState<ConfirmSpec | null>(
+    null
+  );
 
   const sources = snapshot.sources;
   const nonLocalSources = sources.filter((s) => s.id !== 'local');
-  const allOnPageSelected =
+  // Local is selectable; actions that don't apply to it (remove, refresh,
+  // enable/disable) skip it on the server, so the returned counts stay honest.
+  const allSelected =
     sources.length > 0 && sources.every((s) => selectedIds.has(s.id));
 
   // Clear selection when the source list changes (subscribe, import, delete)
-  const sourcesKey = sources.map((s) => s.id).sort().join(',');
+  const sourcesKey = sources
+    .map((s) => s.id)
+    .sort()
+    .join(',');
   React.useEffect(() => {
     setSelectedIds(new Set());
   }, [sourcesKey]);
 
-  const patchSource = useMutation({
-    mutationFn: (args: { id: string; body: Record<string, unknown> }) =>
-      api(`PATCH /dashboard/blocklist/sources/${args.id}`, { body: args.body }),
-    onSuccess: invalidate,
-    onError: (e: any) => toast.error(e?.message ?? 'Update failed'),
-  });
-
-  const refreshSource = useMutation({
-    mutationFn: (id: string) =>
-      api(`POST /dashboard/blocklist/sources/${id}/refresh`, { body: {} }),
-    onSuccess: () => {
-      toast.success('Source refreshed');
+  const removeSources = useMutation({
+    mutationFn: (ids: string[]) =>
+      api<SourceMutationResult>('POST /dashboard/blocklist/sources/remove', {
+        body: { ids },
+      }),
+    onSuccess: (result) => {
+      toast.success(
+        `Removed ${result.affected} source${result.affected === 1 ? '' : 's'}`
+      );
       invalidate();
     },
-    onError: (e: any) => toast.error(e?.message ?? 'Refresh failed'),
+    onError: (e: any) => toast.error(e?.message ?? 'Remove failed'),
   });
 
-  const deleteSource = useMutation({
-    mutationFn: (id: string) =>
-      api(`DELETE /dashboard/blocklist/sources/${id}`),
-    onSuccess: () => {
-      toast.success('Source removed');
-      invalidate();
-    },
-    onError: (e: any) => toast.error(e?.message ?? 'Delete failed'),
-  });
-
-  const clearSource = useMutation({
-    mutationFn: (id: string) =>
-      api(`POST /dashboard/blocklist/sources/${id}/clear`, { body: {} }),
-    onSuccess: () => {
-      toast.success('Source cleared');
+  const clearSources = useMutation({
+    mutationFn: (ids: string[]) =>
+      api<SourceMutationResult>('POST /dashboard/blocklist/sources/clear', {
+        body: { ids },
+      }),
+    onSuccess: (result) => {
+      toast.success(
+        `Cleared ${result.affected} source${result.affected === 1 ? '' : 's'}`
+      );
       invalidate();
     },
     onError: (e: any) => toast.error(e?.message ?? 'Clear failed'),
   });
 
-  // Batch mutations
-  const batchRemove = useMutation({
+  const refreshSources = useMutation({
     mutationFn: (ids: string[]) =>
-      api('POST /dashboard/blocklist/batch/sources/remove', { body: { ids } }),
-    onSuccess: (result: any) => {
-      toast.success(`Removed ${result.removed} source${result.removed === 1 ? '' : 's'}`);
-      setSelectedIds(new Set());
+      api<SourceMutationResult>('POST /dashboard/blocklist/sources/refresh', {
+        body: { ids },
+      }),
+    onSuccess: (result) => {
+      toast.success(
+        `Refreshed ${result.affected} source${result.affected === 1 ? '' : 's'}`
+      );
       invalidate();
     },
-    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+    onError: (e: any) => toast.error(e?.message ?? 'Refresh failed'),
   });
 
-  const batchClear = useMutation({
-    mutationFn: (ids: string[]) =>
-      api('POST /dashboard/blocklist/batch/sources/clear', { body: { ids } }),
-    onSuccess: (result: any) => {
-      toast.success(`Cleared ${result.cleared} source${result.cleared === 1 ? '' : 's'}`);
-      setSelectedIds(new Set());
-      invalidate();
-    },
-    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
-  });
-
-  const batchRefresh = useMutation({
-    mutationFn: (ids: string[]) =>
-      api('POST /dashboard/blocklist/batch/sources/refresh', { body: { ids } }),
-    onSuccess: (result: any) => {
-      toast.success(`Refreshed ${result.refreshed} source${result.refreshed === 1 ? '' : 's'}`);
-      setSelectedIds(new Set());
-      invalidate();
-    },
-    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
-  });
-
-  const batchPatch = useMutation({
+  const patchSources = useMutation({
     mutationFn: (args: { ids: string[]; body: Record<string, unknown> }) =>
-      api('POST /dashboard/blocklist/batch/sources/patch', {
+      api<SourceMutationResult>('PATCH /dashboard/blocklist/sources', {
         body: { ids: args.ids, ...args.body },
       }),
-    onSuccess: (result: any) => {
-      toast.success(`Updated ${result.patched} source${result.patched === 1 ? '' : 's'}`);
-      setSelectedIds(new Set());
-      setBatchEditOpen(false);
-      invalidate();
-    },
-    onError: (e: any) => toast.error(e?.message ?? 'Failed'),
+    onSuccess: () => invalidate(),
+    onError: (e: any) => toast.error(e?.message ?? 'Update failed'),
   });
 
-  const confirmDelete = useConfirmationDialog({
-    title: 'Remove source',
-    description:
-      'This removes the source and every entry it contributed. This cannot be undone.',
-    actionText: 'Remove',
-    actionIntent: 'alert-subtle',
-    onConfirm: () => pendingDelete && deleteSource.mutate(pendingDelete.id),
-  });
+  // Batch actions clear the selection on success; row actions do not.
+  const clearAfter = { onSuccess: () => setSelectedIds(new Set()) };
 
-  const confirmClear = useConfirmationDialog({
-    title: 'Clear source entries',
-    description:
-      'This removes every entry this source contributed but keeps the source itself.',
-    actionText: 'Clear',
-    actionIntent: 'alert-subtle',
-    onConfirm: () => pendingClear && clearSource.mutate(pendingClear.id),
+  const confirm = useConfirmationDialog({
+    title: confirmSpec?.title ?? '',
+    description: confirmSpec?.description,
+    actionText: confirmSpec?.actionText,
+    actionIntent: confirmSpec?.actionIntent,
+    onConfirm: () => confirmSpec?.onConfirm(),
   });
+  const askConfirm = (spec: ConfirmSpec) => {
+    setConfirmSpec(spec);
+    confirm.open();
+  };
 
-  const confirmBatchRemove = useConfirmationDialog({
-    title: 'Remove selected sources',
-    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: the source and every entry it contributed will be removed. This cannot be undone. The local source is skipped.`,
-    actionText: 'Remove all',
-    actionIntent: 'alert-subtle',
-    onConfirm: () => batchRemove.mutate([...selectedIds]),
-  });
+  const count = (n: number) => `${n} source${n === 1 ? '' : 's'}`;
 
-  const confirmBatchClear = useConfirmationDialog({
-    title: 'Clear entries from selected sources',
-    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: entries are removed but the sources themselves are kept.`,
-    actionText: 'Clear all',
-    actionIntent: 'alert-subtle',
-    onConfirm: () => batchClear.mutate([...selectedIds]),
-  });
+  const askRemoveSource = (source: BlocklistSource) =>
+    askConfirm({
+      title: 'Remove source',
+      description:
+        'This removes the source and every entry it contributed. This cannot be undone.',
+      actionText: 'Remove',
+      actionIntent: 'alert-subtle',
+      onConfirm: () => removeSources.mutate([source.id]),
+    });
 
-  const confirmBatchRefresh = useConfirmationDialog({
-    title: 'Refresh selected sources',
-    description: `${selectedIds.size} selected source${selectedIds.size === 1 ? '' : 's'}: refetch their lists from their remote URLs now.`,
-    actionText: 'Refresh all',
-    actionIntent: 'primary-subtle',
-    onConfirm: () => batchRefresh.mutate([...selectedIds]),
-  });
+  const askClearSource = (source: BlocklistSource) =>
+    askConfirm({
+      title: 'Clear source entries',
+      description:
+        'This removes every entry this source contributed but keeps the source itself.',
+      actionText: 'Clear',
+      actionIntent: 'alert-subtle',
+      onConfirm: () => clearSources.mutate([source.id]),
+    });
 
-  const confirmRemoveAllNonLocal = useConfirmationDialog({
-    title: 'Remove all non-local sources',
-    description: `Remove every source except this instance's own list (${nonLocalSources.length} source${nonLocalSources.length === 1 ? '' : 's'}). This cannot be undone.`,
-    actionText: 'Remove all',
-    actionIntent: 'alert-subtle',
-    onConfirm: () =>
-      batchRemove.mutate(nonLocalSources.map((s) => s.id)),
-  });
+  const askBatchRemove = () =>
+    askConfirm({
+      title: 'Remove selected sources',
+      description: `${count(selectedIds.size)} selected: the source and every entry it contributed will be removed. This cannot be undone. The local source is skipped.`,
+      actionText: 'Remove all',
+      actionIntent: 'alert-subtle',
+      onConfirm: () => removeSources.mutate([...selectedIds], clearAfter),
+    });
+
+  const askBatchClear = () =>
+    askConfirm({
+      title: 'Clear entries from selected sources',
+      description: `${count(selectedIds.size)} selected: entries are removed but the sources themselves are kept.`,
+      actionText: 'Clear all',
+      actionIntent: 'alert-subtle',
+      onConfirm: () => clearSources.mutate([...selectedIds], clearAfter),
+    });
+
+  const askBatchRefresh = () =>
+    askConfirm({
+      title: 'Refresh selected sources',
+      description: `${count(selectedIds.size)} selected: refetch their lists from their remote URLs now.`,
+      actionText: 'Refresh all',
+      actionIntent: 'primary-subtle',
+      onConfirm: () => refreshSources.mutate([...selectedIds], clearAfter),
+    });
+
+  const askRemoveAllNonLocal = () =>
+    askConfirm({
+      title: 'Remove all non-local sources',
+      description: `Remove every source except this instance's own list (${count(nonLocalSources.length)}). This cannot be undone.`,
+      actionText: 'Remove all',
+      actionIntent: 'alert-subtle',
+      onConfirm: () =>
+        removeSources.mutate(
+          nonLocalSources.map((s) => s.id),
+          clearAfter
+        ),
+    });
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
@@ -228,14 +237,18 @@ function SourcesView({
     });
   };
 
+  const selectAll = (checked: boolean | 'indeterminate') =>
+    setSelectedIds(
+      checked === true ? new Set(sources.map((s) => s.id)) : new Set()
+    );
+
   const hasRemoteSelected = [...selectedIds].some(
     (id) => sources.find((s) => s.id === id)?.kind === 'remote'
   );
-  const hasLocalSelected = selectedIds.has('local');
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2 flex-wrap">
+      <div className="flex gap-2 flex-wrap items-center min-h-9">
         <Button
           size="sm"
           intent="primary-subtle"
@@ -260,66 +273,70 @@ function SourcesView({
         >
           Export
         </Button>
-        <div className="flex-1" />
-        {nonLocalSources.length > 0 && (
-          <Button
-            size="sm"
-            intent="alert-subtle"
-            onClick={confirmRemoveAllNonLocal.open}
-            title="Remove all sources except the local one"
+        <div className="relative flex flex-1 gap-2 items-center">
+          <div
+            className={cn(
+              'flex flex-1 gap-2 items-center',
+              selectedIds.size === 0 && 'invisible'
+            )}
           >
-            Remove all (except local)
-          </Button>
-        )}
-      </div>
-
-      {/* Batch actions toolbar */}
-      {selectedIds.size > 0 && (
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[--accent]/10 border border-[--accent]/20">
-          <span className="text-sm font-medium tabular-nums">
-            {selectedIds.size} selected
-          </span>
-          <div className="flex-1" />
-          <Button
-            size="sm"
-            intent="gray-subtle"
-            leftIcon={<BiRefresh />}
-            loading={batchRefresh.isPending}
-            onClick={confirmBatchRefresh.open}
-            disabled={hasLocalSelected}
-          >
-            Refresh
-          </Button>
-          <Button
-            size="sm"
-            intent="gray-subtle"
-            leftIcon={<BiPencil />}
-            onClick={() => setBatchEditOpen(true)}
-            disabled={hasLocalSelected}
-          >
-            Edit...
-          </Button>
-          <Button
-            size="sm"
-            intent="gray-subtle"
-            leftIcon={<BiBlock />}
-            loading={batchClear.isPending}
-            onClick={confirmBatchClear.open}
-          >
-            Clear entries
-          </Button>
-          <Button
-            size="sm"
-            intent="alert-subtle"
-            leftIcon={<BiTrash />}
-            loading={batchRemove.isPending}
-            onClick={confirmBatchRemove.open}
-            disabled={hasLocalSelected}
-          >
-            Remove
-          </Button>
+            <span className="text-sm font-medium tabular-nums text-[--muted]">
+              {selectedIds.size} selected
+            </span>
+            <div className="flex-1" />
+            <IconButton
+              size="sm"
+              intent="gray-subtle"
+              icon={<BiRefresh />}
+              aria-label="Refresh selected"
+              title="Refresh selected"
+              loading={refreshSources.isPending}
+              onClick={askBatchRefresh}
+              disabled={!hasRemoteSelected}
+            />
+            <IconButton
+              size="sm"
+              intent="gray-subtle"
+              icon={<BiPencil />}
+              aria-label="Edit selected"
+              title="Edit selected"
+              onClick={() => setBatchEditOpen(true)}
+            />
+            <IconButton
+              size="sm"
+              intent="gray-subtle"
+              icon={<BiBlock />}
+              aria-label="Clear entries of selected"
+              title="Clear entries of selected"
+              loading={clearSources.isPending}
+              onClick={askBatchClear}
+            />
+            <IconButton
+              size="sm"
+              intent="alert-subtle"
+              icon={<BiTrash />}
+              aria-label="Remove selected"
+              title="Remove selected"
+              loading={removeSources.isPending}
+              onClick={askBatchRemove}
+            />
+          </div>
+          {selectedIds.size === 0 && nonLocalSources.length > 0 && (
+            <Button
+              // hideTextOnSmallScreen
+              size="sm"
+              intent="alert-subtle"
+              leftIcon={<BiTrash />}
+              title="Remove all sources except the local one"
+              loading={removeSources.isPending}
+              onClick={askRemoveAllNonLocal}
+              className="absolute right-0"
+            >
+              Remove all
+            </Button>
+          )}
         </div>
-      )}
+      </div>
 
       <Card className="p-0 overflow-hidden">
         <div className="overflow-x-auto">
@@ -327,16 +344,10 @@ function SourcesView({
             <thead className="text-[--muted] text-xs uppercase bg-[--subtle]/40">
               <tr className="text-left">
                 <th className="p-3 w-10">
-                  {nonLocalSources.length > 0 && (
+                  {sources.length > 0 && (
                     <Checkbox
-                      value={allOnPageSelected}
-                      onValueChange={(checked) => {
-                        if (checked) {
-                          setSelectedIds(new Set(sources.map((s) => s.id)));
-                        } else {
-                          setSelectedIds(new Set());
-                        }
-                      }}
+                      value={allSelected}
+                      onValueChange={selectAll}
                       aria-label="Select all"
                     />
                   )}
@@ -409,8 +420,8 @@ function SourcesView({
                       <Switch
                         value={source.enabled}
                         onValueChange={(enabled) =>
-                          patchSource.mutate({
-                            id: source.id,
+                          patchSources.mutate({
+                            ids: [source.id],
                             body: { enabled },
                           })
                         }
@@ -426,10 +437,11 @@ function SourcesView({
                           icon={<BiRefresh />}
                           aria-label="Refresh now"
                           loading={
-                            refreshSource.isPending &&
-                            refreshSource.variables === source.id
+                            refreshSources.isPending &&
+                            refreshSources.variables?.length === 1 &&
+                            refreshSources.variables[0] === source.id
                           }
-                          onClick={() => refreshSource.mutate(source.id)}
+                          onClick={() => refreshSources.mutate([source.id])}
                         />
                       )}
                       {source.kind !== 'local' && (
@@ -446,10 +458,12 @@ function SourcesView({
                         intent="gray-subtle"
                         icon={<BiBlock />}
                         aria-label="Clear entries"
-                        onClick={() => {
-                          setPendingClear(source);
-                          confirmClear.open();
-                        }}
+                        loading={
+                          clearSources.isPending &&
+                          clearSources.variables?.length === 1 &&
+                          clearSources.variables[0] === source.id
+                        }
+                        onClick={() => askClearSource(source)}
                       />
                       {source.kind !== 'local' && (
                         <IconButton
@@ -457,10 +471,12 @@ function SourcesView({
                           intent="alert-subtle"
                           icon={<BiTrash />}
                           aria-label="Remove source"
-                          onClick={() => {
-                            setPendingDelete(source);
-                            confirmDelete.open();
-                          }}
+                          loading={
+                            removeSources.isPending &&
+                            removeSources.variables?.length === 1 &&
+                            removeSources.variables[0] === source.id
+                          }
+                          onClick={() => askRemoveSource(source)}
                         />
                       )}
                     </div>
@@ -494,17 +510,25 @@ function SourcesView({
         <BatchEditSourceModal
           selectedIds={[...selectedIds]}
           sources={sources}
-          onSave={(patch) => batchPatch.mutate({ ids: [...selectedIds], body: patch })}
-          loading={batchPatch.isPending}
+          onSave={(patch) =>
+            patchSources.mutate(
+              { ids: [...selectedIds], body: patch },
+              {
+                onSuccess: (result) => {
+                  toast.success(
+                    `Updated ${result.affected} source${result.affected === 1 ? '' : 's'}`
+                  );
+                  setSelectedIds(new Set());
+                  setBatchEditOpen(false);
+                },
+              }
+            )
+          }
+          loading={patchSources.isPending}
           onClose={() => setBatchEditOpen(false)}
         />
       )}
-      <ConfirmationDialog {...confirmDelete} />
-      <ConfirmationDialog {...confirmClear} />
-      <ConfirmationDialog {...confirmBatchRemove} />
-      <ConfirmationDialog {...confirmBatchClear} />
-      <ConfirmationDialog {...confirmBatchRefresh} />
-      <ConfirmationDialog {...confirmRemoveAllNonLocal} />
+      <ConfirmationDialog {...confirm} />
     </div>
   );
 }
@@ -535,7 +559,9 @@ function EditSourceModal({
         body.refreshSeconds = Math.round(refreshHours * 3600);
         if (url.trim()) body.url = url.trim();
       }
-      return api(`PATCH /dashboard/blocklist/sources/${source.id}`, { body });
+      return api('PATCH /dashboard/blocklist/sources', {
+        body: { ids: [source.id], ...body },
+      });
     },
     onSuccess: () => {
       toast.success('Source updated');
@@ -913,9 +939,7 @@ function BatchEditSourceModal({
             { label: 'Disable', value: 'false' },
           ]}
           value={enabled === '' ? '' : String(enabled)}
-          onValueChange={(v) =>
-            setEnabled(v === '' ? '' : v === 'true')
-          }
+          onValueChange={(v) => setEnabled(v === '' ? '' : v === 'true')}
           help="Enable or disable the source. The local source cannot be disabled."
         />
         <div className="flex justify-end gap-2">

--- a/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
+++ b/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
@@ -286,7 +286,7 @@ function SourcesView({
             leftIcon={<BiRefresh />}
             loading={batchRefresh.isPending}
             onClick={confirmBatchRefresh.open}
-            disabled={!hasRemoteSelected}
+            disabled={hasLocalSelected}
           >
             Refresh
           </Button>
@@ -861,12 +861,13 @@ function BatchEditSourceModal({
   const hasRemote = selected.some((s) => s.kind === 'remote');
   const [trust, setTrust] = React.useState<Trust | ''>('');
   const [refreshHours, setRefreshHours] = React.useState(24);
+  const [refreshChanged, setRefreshChanged] = React.useState(false);
   const [enabled, setEnabled] = React.useState<boolean | ''>('');
 
   const buildPatch = (): Record<string, unknown> => {
     const body: Record<string, unknown> = {};
     if (trust) body.trust = trust;
-    if (hasRemote && refreshHours > 0) {
+    if (hasRemote && refreshChanged && refreshHours > 0) {
       body.refreshSeconds = Math.round(refreshHours * 3600);
     }
     if (enabled !== '') body.enabled = enabled;
@@ -897,7 +898,10 @@ function BatchEditSourceModal({
             value={refreshHours}
             min={1}
             max={720}
-            onValueChange={(v) => setRefreshHours(v || 24)}
+            onValueChange={(v) => {
+              setRefreshHours(v || 24);
+              setRefreshChanged(true);
+            }}
             help="Only applies to remote sources"
           />
         )}

--- a/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
+++ b/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
@@ -73,9 +73,15 @@ function SourcesView({
   const [batchEditOpen, setBatchEditOpen] = React.useState(false);
 
   const sources = snapshot.sources;
+  const nonLocalSources = sources.filter((s) => s.id !== 'local');
   const allOnPageSelected =
     sources.length > 0 && sources.every((s) => selectedIds.has(s.id));
-  const nonLocalSources = sources.filter((s) => s.id !== 'local');
+
+  // Clear selection when the source list changes (subscribe, import, delete)
+  const sourcesKey = sources.map((s) => s.id).sort().join(',');
+  React.useEffect(() => {
+    setSelectedIds(new Set());
+  }, [sourcesKey]);
 
   const patchSource = useMutation({
     mutationFn: (args: { id: string; body: Record<string, unknown> }) =>
@@ -225,6 +231,7 @@ function SourcesView({
   const hasRemoteSelected = [...selectedIds].some(
     (id) => sources.find((s) => s.id === id)?.kind === 'remote'
   );
+  const hasLocalSelected = selectedIds.has('local');
 
   return (
     <div className="space-y-4">
@@ -288,6 +295,7 @@ function SourcesView({
             intent="gray-subtle"
             leftIcon={<BiPencil />}
             onClick={() => setBatchEditOpen(true)}
+            disabled={hasLocalSelected}
           >
             Edit...
           </Button>
@@ -306,6 +314,7 @@ function SourcesView({
             leftIcon={<BiTrash />}
             loading={batchRemove.isPending}
             onClick={confirmBatchRemove.open}
+            disabled={hasLocalSelected}
           >
             Remove
           </Button>
@@ -318,17 +327,19 @@ function SourcesView({
             <thead className="text-[--muted] text-xs uppercase bg-[--subtle]/40">
               <tr className="text-left">
                 <th className="p-3 w-10">
-                  <Checkbox
-                    value={allOnPageSelected}
-                    onValueChange={(checked) => {
-                      if (checked) {
-                        setSelectedIds(new Set(sources.map((s) => s.id)));
-                      } else {
-                        setSelectedIds(new Set());
-                      }
-                    }}
-                    aria-label="Select all"
-                  />
+                  {nonLocalSources.length > 0 && (
+                    <Checkbox
+                      value={allOnPageSelected}
+                      onValueChange={(checked) => {
+                        if (checked) {
+                          setSelectedIds(new Set(sources.map((s) => s.id)));
+                        } else {
+                          setSelectedIds(new Set());
+                        }
+                      }}
+                      aria-label="Select all"
+                    />
+                  )}
                 </th>
                 <th className="p-3">Name</th>
                 <th className="p-3">Kind</th>

--- a/packages/server/src/routes/api/dashboard-blocklist.ts
+++ b/packages/server/src/routes/api/dashboard-blocklist.ts
@@ -65,13 +65,46 @@ const RemoteSourcesSchema = z.object({
   refreshSeconds: RefreshSecondsSchema.optional(),
 });
 
-const PatchSourceSchema = z.object({
-  name: z.string().trim().min(1).max(120).optional(),
-  url: z.string().trim().min(1).max(2000).optional(),
-  enabled: z.boolean().optional(),
-  trust: TrustSchema.optional(),
-  refreshSeconds: RefreshSecondsSchema.optional(),
-});
+const SourceIdsSchema = z
+  .object({
+    ids: z.array(z.string().trim().min(1)).min(1).max(200),
+  })
+  .refine((data) => new Set(data.ids).size === data.ids.length, {
+    message: 'duplicate IDs are not allowed',
+    path: ['ids'],
+  });
+
+const PatchSourcesSchema = z
+  .object({
+    ids: z.array(z.string().trim().min(1)).min(1).max(200),
+    name: z.string().trim().min(1).max(120).optional(),
+    url: z.string().trim().min(1).max(2000).optional(),
+    enabled: z.boolean().optional(),
+    trust: TrustSchema.optional(),
+    refreshSeconds: RefreshSecondsSchema.optional(),
+  })
+  .refine((data) => new Set(data.ids).size === data.ids.length, {
+    message: 'duplicate IDs are not allowed',
+    path: ['ids'],
+  })
+  .refine(
+    (data) =>
+      data.name !== undefined ||
+      data.url !== undefined ||
+      data.enabled !== undefined ||
+      data.trust !== undefined ||
+      data.refreshSeconds !== undefined,
+    { message: 'at least one field to update must be provided', path: ['ids'] }
+  )
+  .refine(
+    (data) =>
+      (data.name === undefined && data.url === undefined) ||
+      data.ids.length === 1,
+    {
+      message: 'name and url can only be set on a single source',
+      path: ['ids'],
+    }
+  );
 
 const PublishIntervalSchema = z
   .number()
@@ -465,68 +498,124 @@ router.post('/sources/remote', async (req, res, next) => {
   }
 });
 
-// PATCH /dashboard/blocklist/sources/:id - edit a source.
-router.patch('/sources/:id', async (req, res, next) => {
+// PATCH /dashboard/blocklist/sources - edit one or more sources. name/url are
+// single-source only (see PatchSourcesSchema). The local source silently skips
+// trust/enabled changes it does not allow.
+router.patch('/sources', async (req, res, next) => {
   try {
-    const body = PatchSourceSchema.parse(req.body ?? {});
+    const body = PatchSourcesSchema.parse(req.body ?? {});
     if (body.url !== undefined) {
       const urlError = validateListUrl(body.url);
       if (urlError) return badRequest(res, urlError);
     }
-    await ReleaseBlocklistRepository.updateSource(req.params.id, {
-      name: body.name,
-      url: body.url,
-      enabled: body.enabled,
-      trust: body.trust as never,
-      refreshSeconds: body.refreshSeconds,
-    });
-    res
-      .status(200)
-      .json(createResponse({ success: true, data: await snapshot() }));
+    let affected = 0;
+    let failed = 0;
+    for (const id of body.ids) {
+      if (
+        id === LOCAL_SOURCE_ID &&
+        (body.enabled !== undefined || body.trust !== undefined)
+      ) {
+        continue;
+      }
+      try {
+        await ReleaseBlocklistRepository.updateSource(id, {
+          name: body.name,
+          url: body.url,
+          enabled: body.enabled,
+          trust: body.trust as never,
+          refreshSeconds: body.refreshSeconds,
+        });
+        affected++;
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'patch source failed');
+      }
+    }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { affected, failed, ...(await snapshot()) },
+      })
+    );
   } catch (err) {
     if (err instanceof ZodError) return badRequest(res, zodMessage(err));
-    if (err instanceof Error && /local source/.test(err.message)) {
-      return badRequest(res, err.message);
+    next(err);
+  }
+});
+
+// POST /dashboard/blocklist/sources/remove - remove one or more sources and
+// their entries. The local source is always skipped.
+router.post('/sources/remove', async (req, res, next) => {
+  try {
+    const { ids } = SourceIdsSchema.parse(req.body ?? {});
+    let affected = 0;
+    let failed = 0;
+    for (const id of ids) {
+      if (id === LOCAL_SOURCE_ID) continue;
+      try {
+        await ReleaseBlocklistRepository.removeSource(id);
+        affected++;
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'remove source failed');
+      }
     }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { affected, failed, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
     next(err);
   }
 });
 
-// DELETE /dashboard/blocklist/sources/:id - remove a source and its entries.
-router.delete('/sources/:id', async (req, res, next) => {
+// POST /dashboard/blocklist/sources/clear - drop the entries of one or more
+// sources while keeping the sources themselves.
+router.post('/sources/clear', async (req, res, next) => {
   try {
-    await ReleaseBlocklistRepository.removeSource(req.params.id);
-    res
-      .status(200)
-      .json(createResponse({ success: true, data: await snapshot() }));
-  } catch (err) {
-    if (err instanceof Error && /local source/.test(err.message)) {
-      return badRequest(res, err.message);
+    const { ids } = SourceIdsSchema.parse(req.body ?? {});
+    let affected = 0;
+    let failed = 0;
+    for (const id of ids) {
+      try {
+        await ReleaseBlocklistRepository.clearSource(id);
+        affected++;
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'clear source failed');
+      }
     }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { affected, failed, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
     next(err);
   }
 });
 
-// POST /dashboard/blocklist/sources/:id/clear - drop a source's entries.
-router.post('/sources/:id/clear', async (req, res, next) => {
+// POST /dashboard/blocklist/sources/refresh - refetch one or more remote
+// sources now. Non-remote ids are skipped; concurrency is bounded in the
+// service.
+router.post('/sources/refresh', async (req, res, next) => {
   try {
-    await ReleaseBlocklistRepository.clearSource(req.params.id);
-    res
-      .status(200)
-      .json(createResponse({ success: true, data: await snapshot() }));
+    const { ids } = SourceIdsSchema.parse(req.body ?? {});
+    const { refreshed, failed } =
+      await ReleaseBlocklistRemoteService.refreshByIds(ids);
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { affected: refreshed, failed, ...(await snapshot()) },
+      })
+    );
   } catch (err) {
-    next(err);
-  }
-});
-
-// POST /dashboard/blocklist/sources/:id/refresh - refetch now.
-router.post('/sources/:id/refresh', async (req, res, next) => {
-  try {
-    await ReleaseBlocklistRemoteService.refreshByIds([req.params.id]);
-    res
-      .status(200)
-      .json(createResponse({ success: true, data: await snapshot() }));
-  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
     next(err);
   }
 });
@@ -817,163 +906,6 @@ router.delete('/entries', async (req, res, next) => {
       .status(200)
       .json(createResponse({ success: true, data: await snapshot() }));
   } catch (err) {
-    next(err);
-  }
-});
-
-const BatchSourceIdsSchema = z.object({
-  ids: z.array(z.string().trim().min(1)).min(1).max(200),
-}).refine(
-  (data) => new Set(data.ids).size === data.ids.length,
-  { message: 'duplicate IDs are not allowed', path: ['ids'] }
-);
-
-const BatchPatchSourceSchema = z.object({
-  ids: z.array(z.string().trim().min(1)).min(1).max(200),
-  trust: TrustSchema.optional(),
-  refreshSeconds: RefreshSecondsSchema.optional(),
-  enabled: z.boolean().optional(),
-})
-  .refine(
-    (data) => new Set(data.ids).size === data.ids.length,
-    { message: 'duplicate IDs are not allowed', path: ['ids'] }
-  )
-  .refine(
-    (data) =>
-      data.trust !== undefined ||
-      data.refreshSeconds !== undefined ||
-      data.enabled !== undefined,
-    {
-      message:
-        'at least one of trust, refreshSeconds, or enabled must be provided',
-      path: ['trust'],
-    }
-  );
-
-// POST /dashboard/blocklist/batch/sources/remove - batch remove non-local sources.
-router.post('/batch/sources/remove', async (req, res, next) => {
-  try {
-    const body = BatchSourceIdsSchema.parse(req.body ?? {});
-    let removed = 0;
-    let failed = 0;
-    for (const id of body.ids) {
-      if (id === LOCAL_SOURCE_ID) continue;
-      try {
-        await ReleaseBlocklistRepository.removeSource(id);
-        removed++;
-      } catch (err) {
-        failed++;
-        logger.warn({ id, err }, 'batch remove source failed');
-      }
-    }
-    res.status(200).json(
-      createResponse({
-        success: true,
-        data: { removed, failed, ...(await snapshot()) },
-      })
-    );
-  } catch (err) {
-    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
-    next(err);
-  }
-});
-
-// POST /dashboard/blocklist/batch/sources/clear - batch clear source entries.
-router.post('/batch/sources/clear', async (req, res, next) => {
-  try {
-    const body = BatchSourceIdsSchema.parse(req.body ?? {});
-    let cleared = 0;
-    let failed = 0;
-    for (const id of body.ids) {
-      try {
-        await ReleaseBlocklistRepository.clearSource(id);
-        cleared++;
-      } catch (err) {
-        failed++;
-        logger.warn({ id, err }, 'batch clear source failed');
-      }
-    }
-    res.status(200).json(
-      createResponse({
-        success: true,
-        data: { cleared, failed, ...(await snapshot()) },
-      })
-    );
-  } catch (err) {
-    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
-    next(err);
-  }
-});
-
-// POST /dashboard/blocklist/batch/sources/refresh - batch refresh remote sources.
-// Processes up to CONCURRENT_REFRESHES at a time via a bounded worker pool.
-const CONCURRENT_REFRESHES = 5;
-router.post('/batch/sources/refresh', async (req, res, next) => {
-  try {
-    const body = BatchSourceIdsSchema.parse(req.body ?? {});
-    let refreshed = 0;
-    let failed = 0;
-    let nextIndex = 0;
-    const ids = body.ids;
-    const worker = async () => {
-      while (nextIndex < ids.length) {
-        const i = nextIndex++;
-        const id = ids[i];
-        try {
-          await ReleaseBlocklistRemoteService.refreshByIds([id]);
-          refreshed++;
-        } catch (err) {
-          failed++;
-          logger.warn({ id, err }, 'batch refresh source failed');
-        }
-      }
-    };
-    await Promise.all(
-      Array.from(
-        { length: Math.min(CONCURRENT_REFRESHES, ids.length) },
-        () => worker()
-      )
-    );
-    res.status(200).json(
-      createResponse({
-        success: true,
-        data: { refreshed, failed, ...(await snapshot()) },
-      })
-    );
-  } catch (err) {
-    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
-    next(err);
-  }
-});
-
-// POST /dashboard/blocklist/batch/sources/patch - batch edit source fields.
-router.post('/batch/sources/patch', async (req, res, next) => {
-  try {
-    const body = BatchPatchSourceSchema.parse(req.body ?? {});
-    let patched = 0;
-    let failed = 0;
-    for (const id of body.ids) {
-      if (id === LOCAL_SOURCE_ID && (body.enabled !== undefined || body.trust !== undefined)) continue;
-      try {
-        await ReleaseBlocklistRepository.updateSource(id, {
-          trust: body.trust as never,
-          refreshSeconds: body.refreshSeconds,
-          enabled: body.enabled,
-        });
-        patched++;
-      } catch (err) {
-        failed++;
-        logger.warn({ id, err }, 'batch patch source failed');
-      }
-    }
-    res.status(200).json(
-      createResponse({
-        success: true,
-        data: { patched, failed, ...(await snapshot()) },
-      })
-    );
-  } catch (err) {
-    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
     next(err);
   }
 });

--- a/packages/server/src/routes/api/dashboard-blocklist.ts
+++ b/packages/server/src/routes/api/dashboard-blocklist.ts
@@ -823,31 +823,53 @@ router.delete('/entries', async (req, res, next) => {
 
 const BatchSourceIdsSchema = z.object({
   ids: z.array(z.string().trim().min(1)).min(1).max(200),
-});
+}).refine(
+  (data) => new Set(data.ids).size === data.ids.length,
+  { message: 'duplicate IDs are not allowed', path: ['ids'] }
+);
 
 const BatchPatchSourceSchema = z.object({
   ids: z.array(z.string().trim().min(1)).min(1).max(200),
   trust: TrustSchema.optional(),
   refreshSeconds: RefreshSecondsSchema.optional(),
   enabled: z.boolean().optional(),
-});
+})
+  .refine(
+    (data) => new Set(data.ids).size === data.ids.length,
+    { message: 'duplicate IDs are not allowed', path: ['ids'] }
+  )
+  .refine(
+    (data) =>
+      data.trust !== undefined ||
+      data.refreshSeconds !== undefined ||
+      data.enabled !== undefined,
+    {
+      message:
+        'at least one of trust, refreshSeconds, or enabled must be provided',
+      path: ['trust'],
+    }
+  );
 
 // POST /dashboard/blocklist/batch/sources/remove - batch remove non-local sources.
 router.post('/batch/sources/remove', async (req, res, next) => {
   try {
     const body = BatchSourceIdsSchema.parse(req.body ?? {});
     let removed = 0;
+    let failed = 0;
     for (const id of body.ids) {
       if (id === LOCAL_SOURCE_ID) continue;
       try {
         await ReleaseBlocklistRepository.removeSource(id);
         removed++;
-      } catch {}
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'batch remove source failed');
+      }
     }
     res.status(200).json(
       createResponse({
         success: true,
-        data: { removed, ...(await snapshot()) },
+        data: { removed, failed, ...(await snapshot()) },
       })
     );
   } catch (err) {
@@ -861,16 +883,20 @@ router.post('/batch/sources/clear', async (req, res, next) => {
   try {
     const body = BatchSourceIdsSchema.parse(req.body ?? {});
     let cleared = 0;
+    let failed = 0;
     for (const id of body.ids) {
       try {
         await ReleaseBlocklistRepository.clearSource(id);
         cleared++;
-      } catch {}
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'batch clear source failed');
+      }
     }
     res.status(200).json(
       createResponse({
         success: true,
-        data: { cleared, ...(await snapshot()) },
+        data: { cleared, failed, ...(await snapshot()) },
       })
     );
   } catch (err) {
@@ -880,20 +906,38 @@ router.post('/batch/sources/clear', async (req, res, next) => {
 });
 
 // POST /dashboard/blocklist/batch/sources/refresh - batch refresh remote sources.
+// Processes up to CONCURRENT_REFRESHES at a time via a bounded worker pool.
+const CONCURRENT_REFRESHES = 5;
 router.post('/batch/sources/refresh', async (req, res, next) => {
   try {
     const body = BatchSourceIdsSchema.parse(req.body ?? {});
     let refreshed = 0;
-    for (const id of body.ids) {
-      try {
-        await ReleaseBlocklistRemoteService.refreshByIds([id]);
-        refreshed++;
-      } catch {}
-    }
+    let failed = 0;
+    let nextIndex = 0;
+    const ids = body.ids;
+    const worker = async () => {
+      while (nextIndex < ids.length) {
+        const i = nextIndex++;
+        const id = ids[i];
+        try {
+          await ReleaseBlocklistRemoteService.refreshByIds([id]);
+          refreshed++;
+        } catch (err) {
+          failed++;
+          logger.warn({ id, err }, 'batch refresh source failed');
+        }
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(CONCURRENT_REFRESHES, ids.length) },
+        () => worker()
+      )
+    );
     res.status(200).json(
       createResponse({
         success: true,
-        data: { refreshed, ...(await snapshot()) },
+        data: { refreshed, failed, ...(await snapshot()) },
       })
     );
   } catch (err) {
@@ -907,6 +951,7 @@ router.post('/batch/sources/patch', async (req, res, next) => {
   try {
     const body = BatchPatchSourceSchema.parse(req.body ?? {});
     let patched = 0;
+    let failed = 0;
     for (const id of body.ids) {
       if (id === LOCAL_SOURCE_ID && (body.enabled !== undefined || body.trust !== undefined)) continue;
       try {
@@ -916,12 +961,15 @@ router.post('/batch/sources/patch', async (req, res, next) => {
           enabled: body.enabled,
         });
         patched++;
-      } catch {}
+      } catch (err) {
+        failed++;
+        logger.warn({ id, err }, 'batch patch source failed');
+      }
     }
     res.status(200).json(
       createResponse({
         success: true,
-        data: { patched, ...(await snapshot()) },
+        data: { patched, failed, ...(await snapshot()) },
       })
     );
   } catch (err) {

--- a/packages/server/src/routes/api/dashboard-blocklist.ts
+++ b/packages/server/src/routes/api/dashboard-blocklist.ts
@@ -821,6 +821,115 @@ router.delete('/entries', async (req, res, next) => {
   }
 });
 
+const BatchSourceIdsSchema = z.object({
+  ids: z.array(z.string().trim().min(1)).min(1).max(200),
+});
+
+const BatchPatchSourceSchema = z.object({
+  ids: z.array(z.string().trim().min(1)).min(1).max(200),
+  trust: TrustSchema.optional(),
+  refreshSeconds: RefreshSecondsSchema.optional(),
+  enabled: z.boolean().optional(),
+});
+
+// POST /dashboard/blocklist/batch/sources/remove - batch remove non-local sources.
+router.post('/batch/sources/remove', async (req, res, next) => {
+  try {
+    const body = BatchSourceIdsSchema.parse(req.body ?? {});
+    let removed = 0;
+    for (const id of body.ids) {
+      if (id === LOCAL_SOURCE_ID) continue;
+      try {
+        await ReleaseBlocklistRepository.removeSource(id);
+        removed++;
+      } catch {}
+    }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { removed, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
+    next(err);
+  }
+});
+
+// POST /dashboard/blocklist/batch/sources/clear - batch clear source entries.
+router.post('/batch/sources/clear', async (req, res, next) => {
+  try {
+    const body = BatchSourceIdsSchema.parse(req.body ?? {});
+    let cleared = 0;
+    for (const id of body.ids) {
+      try {
+        await ReleaseBlocklistRepository.clearSource(id);
+        cleared++;
+      } catch {}
+    }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { cleared, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
+    next(err);
+  }
+});
+
+// POST /dashboard/blocklist/batch/sources/refresh - batch refresh remote sources.
+router.post('/batch/sources/refresh', async (req, res, next) => {
+  try {
+    const body = BatchSourceIdsSchema.parse(req.body ?? {});
+    let refreshed = 0;
+    for (const id of body.ids) {
+      try {
+        await ReleaseBlocklistRemoteService.refreshByIds([id]);
+        refreshed++;
+      } catch {}
+    }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { refreshed, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
+    next(err);
+  }
+});
+
+// POST /dashboard/blocklist/batch/sources/patch - batch edit source fields.
+router.post('/batch/sources/patch', async (req, res, next) => {
+  try {
+    const body = BatchPatchSourceSchema.parse(req.body ?? {});
+    let patched = 0;
+    for (const id of body.ids) {
+      if (id === LOCAL_SOURCE_ID && (body.enabled !== undefined || body.trust !== undefined)) continue;
+      try {
+        await ReleaseBlocklistRepository.updateSource(id, {
+          trust: body.trust as never,
+          refreshSeconds: body.refreshSeconds,
+          enabled: body.enabled,
+        });
+        patched++;
+      } catch {}
+    }
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { patched, ...(await snapshot()) },
+      })
+    );
+  } catch (err) {
+    if (err instanceof ZodError) return badRequest(res, zodMessage(err));
+    next(err);
+  }
+});
+
 // POST /dashboard/blocklist/unmark - allow a release on this instance:
 // deletes any local verdict and writes an override suppressing remote ones.
 router.post('/unmark', async (req, res, next) => {


### PR DESCRIPTION
### PR Description:
Adds checkbox selection and batch actions to the blocklist sources page, plus the required backend batch endpoints.

### Backend
-  POST /batch/sources/remove  — batch remove non-local sources
-  POST /batch/sources/clear  — batch clear entries from sources
-  POST /batch/sources/refresh  — batch refresh remote sources
-  POST /batch/sources/patch  — batch edit trust, refresh interval, and enabled state

### Frontend
-  packages/frontend/src/app/dashboard/blocklist/sources-page.tsx  — Added multiselect operations:
- Checkbox column (select-all header + per-row checkboxes)
- Batch toolbar: Refresh, Edit..., Clear entries, Remove
- "Remove all (except local)" button
-  BatchEditSourceModal  for editing trust / refresh interval / enabled across selected sources
- Confirmation dialogs for all batch actions
- Header checkbox properly clears all selections when unchecked
- Smart context menu switching depending on what row is selected

<img width="2405" height="307" alt="image" src="https://github.com/user-attachments/assets/d393607c-9c46-4de3-b2ae-10930ae363ff" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-select support for blocklist sources, including select-all and selected-row highlighting.
  * Added batch actions to remove, clear, refresh, and edit multiple sources.
  * Added a batch edit dialog for updating trust, refresh intervals, and enabled status, with confirmation prompts for batch operations.
* **Bug Fixes**
  * Standardised placeholders for unavailable status and the local-source enabled state.
  * Batch edits now only apply permitted changes to local sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->