### PR TITLE
fix(presets): show addon name in service error

### DIFF
--- a/packages/core/src/presets/baguettio.ts
+++ b/packages/core/src/presets/baguettio.ts
@@ -183,7 +183,7 @@ export class BaguettioPreset extends Preset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     const services = usableServices?.map((s) => s.id) || [];
 
     return [this.generateAddon(userData, options, services)];

--- a/packages/core/src/presets/comet.ts
+++ b/packages/core/src/presets/comet.ts
@@ -200,7 +200,7 @@ export class CometPreset extends StremThruPreset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     // if no services are usable, use p2p
     if (!usableServices || usableServices.length === 0) {
       return [this.generateAddon(userData, options, [])];

--- a/packages/core/src/presets/debridioScraper.ts
+++ b/packages/core/src/presets/debridioScraper.ts
@@ -97,7 +97,7 @@ export class DebridioPreset extends Preset {
       );
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     // if no services are usable, return a single addon with no services
     if (!usableServices || usableServices.length === 0) {

--- a/packages/core/src/presets/easynewsSearch.ts
+++ b/packages/core/src/presets/easynewsSearch.ts
@@ -178,7 +178,7 @@ export class EasynewsSearchPreset extends BuiltinAddonPreset {
       );
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service, but none were found. Please enable at least one of the following services: ${this.METADATA.SUPPORTED_SERVICES.join(

--- a/packages/core/src/presets/fkstream.ts
+++ b/packages/core/src/presets/fkstream.ts
@@ -108,7 +108,7 @@ export class FKStreamPreset extends StremThruPreset {
       return [this.generateAddon(userData, options, undefined)];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     // if no services are usable, use p2p
     if (!usableServices || usableServices.length === 0) {
       return [this.generateAddon(userData, options, undefined)];

--- a/packages/core/src/presets/hdhub.ts
+++ b/packages/core/src/presets/hdhub.ts
@@ -118,7 +118,7 @@ export class HdHubPreset extends Preset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const services = this.getUsableServices(userData);
+    const services = this.getUsableServices(userData, undefined, options.name);
     if (services?.find((service) => service.id === constants.TORBOX_SERVICE)) {
       return [
         this.generateAddon(

--- a/packages/core/src/presets/jackettio.ts
+++ b/packages/core/src/presets/jackettio.ts
@@ -97,7 +97,7 @@ export class JackettioPreset extends StremThruPreset {
       return [this.generateAddon(userData, options, undefined)];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service from the list of supported services: ${this.METADATA.SUPPORTED_SERVICES.map((service) => constants.SERVICE_DETAILS[service].name).join(', ')}`

--- a/packages/core/src/presets/library.ts
+++ b/packages/core/src/presets/library.ts
@@ -177,7 +177,7 @@ export class LibraryPreset extends BuiltinAddonPreset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service, but none were found. Please enable at least one of the following services: ${this.METADATA.SUPPORTED_SERVICES.join(

--- a/packages/core/src/presets/mediafusion.ts
+++ b/packages/core/src/presets/mediafusion.ts
@@ -344,7 +344,7 @@ export class MediaFusionPreset extends Preset {
     }
 
     const usableServiceIds: (ServiceId | 'p2p')[] | undefined =
-      this.getUsableServices(userData, options.services)?.map(
+      this.getUsableServices(userData, options.services, options.name)?.map(
         (service) => service.id
       );
 

--- a/packages/core/src/presets/meteor.ts
+++ b/packages/core/src/presets/meteor.ts
@@ -276,7 +276,7 @@ export class MeteorPreset extends Preset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       return [this.generateAddon(userData, options, [])];
     }

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -311,7 +311,7 @@ export class NewznabPreset extends BuiltinAddonPreset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service, but none were found. Please enable at least one of the following services: ${this.METADATA.SUPPORTED_SERVICES.join(

--- a/packages/core/src/presets/orion.ts
+++ b/packages/core/src/presets/orion.ts
@@ -137,7 +137,7 @@ export class OrionPreset extends Preset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     // if no services are usable, use p2p
     if (!usableServices || usableServices.length === 0) {
       return [this.generateAddon(userData, options, [])];

--- a/packages/core/src/presets/peerflix.ts
+++ b/packages/core/src/presets/peerflix.ts
@@ -113,7 +113,7 @@ export class PeerflixPreset extends Preset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     // if no services are usable, return a single addon with no services
     if (!usableServices || usableServices.length === 0) {

--- a/packages/core/src/presets/preset.ts
+++ b/packages/core/src/presets/preset.ts
@@ -188,7 +188,8 @@ export abstract class Preset {
 
   protected static getUsableServices(
     userData: UserData,
-    specifiedServices?: ServiceId[]
+    specifiedServices?: ServiceId[],
+    addonName?: string
   ) {
     let usableServices = userData.services?.filter(
       (service) =>
@@ -203,8 +204,15 @@ export abstract class Preset {
           (s) => s.id === service
         );
         if (!userService || !userService.enabled || !userService.credentials) {
+          const sameTypeCount =
+            userData.presets?.filter((p) => p.type === this.METADATA.ID)
+              .length ?? 0;
+          // When multiple instances of the same preset exist (e.g. Newznab),
+          // prefer the user-configured name so the error identifies which one.
+          const displayName =
+            sameTypeCount > 1 && addonName ? addonName : this.METADATA.NAME;
           throw new Error(
-            `You have specified ${meta?.name || service} in your configuration for ${this.METADATA.NAME}, but it is not enabled or has missing credentials`
+            `You have specified ${meta?.name || service} in your configuration for ${displayName}, but it is not enabled or has missing credentials`
           );
         }
       }

--- a/packages/core/src/presets/prowlarr.ts
+++ b/packages/core/src/presets/prowlarr.ts
@@ -214,7 +214,7 @@ export class ProwlarrPreset extends BuiltinAddonPreset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service, but none were found. Please enable at least one of the following services: ${this.METADATA.SUPPORTED_SERVICES.join(

--- a/packages/core/src/presets/sootio.ts
+++ b/packages/core/src/presets/sootio.ts
@@ -159,7 +159,7 @@ export class SootioPreset extends Preset {
       return [this.generateAddon(userData, options, undefined)];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     if (
       (!options.httpProviders || options.httpProviders.length === 0) &&

--- a/packages/core/src/presets/streamasia.ts
+++ b/packages/core/src/presets/streamasia.ts
@@ -338,7 +338,7 @@ there is no need to provide these details here.
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (
       usableServices?.length === 0 &&
       options.ddlCatalogs &&

--- a/packages/core/src/presets/streamfusion.ts
+++ b/packages/core/src/presets/streamfusion.ts
@@ -166,7 +166,7 @@ export class StreamFusionPreset extends Preset {
     }
 
     const usableServices =
-      this.getUsableServices(userData, options.services) || [];
+      this.getUsableServices(userData, options.services, options.name) || [];
 
     return [
       this.generateAddon(

--- a/packages/core/src/presets/stremthruStore.ts
+++ b/packages/core/src/presets/stremthruStore.ts
@@ -154,7 +154,7 @@ export class StremthruStorePreset extends StremThruPreset {
       return [this.generateAddon(userData, options, undefined)];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     // if no services are usable, throw an error
     if (!usableServices || usableServices.length === 0) {
       throw new Error(

--- a/packages/core/src/presets/stremthruTorz.ts
+++ b/packages/core/src/presets/stremthruTorz.ts
@@ -125,7 +125,7 @@ export class StremthruTorzPreset extends StremThruPreset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     let serviceIds: (ServiceId | 'p2p')[] =
       usableServices?.map((s) => s.id) || [];
 

--- a/packages/core/src/presets/torboxSearch.ts
+++ b/packages/core/src/presets/torboxSearch.ts
@@ -155,7 +155,7 @@ export class TorBoxSearchPreset extends BuiltinAddonPreset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     // if no services are usable, return a single addon with no services
     if (!usableServices || usableServices.length === 0) {

--- a/packages/core/src/presets/torrentio.ts
+++ b/packages/core/src/presets/torrentio.ts
@@ -339,7 +339,7 @@ export class TorrentioPreset extends Preset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     // if no services are usable, return a single addon with no services
     if (!usableServices || usableServices.length === 0) {

--- a/packages/core/src/presets/torrentsDb.ts
+++ b/packages/core/src/presets/torrentsDb.ts
@@ -241,7 +241,7 @@ export class TorrentsDbPreset extends Preset {
       return [this.generateAddon(userData, options, [])];
     }
 
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
 
     // if no services are usable, return a single addon with no services
     if (!usableServices || usableServices.length === 0) {

--- a/packages/core/src/presets/torznab.ts
+++ b/packages/core/src/presets/torznab.ts
@@ -188,7 +188,7 @@ export class TorznabPreset extends BuiltinAddonPreset {
     userData: UserData,
     options: Record<string, any>
   ): Promise<Addon[]> {
-    const usableServices = this.getUsableServices(userData, options.services);
+    const usableServices = this.getUsableServices(userData, options.services, options.name);
     if (!usableServices || usableServices.length === 0) {
       throw new Error(
         `${this.METADATA.NAME} requires at least one usable service, but none were found. Please enable at least one of the following services: ${this.METADATA.SUPPORTED_SERVICES.join(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service validation across addon configurations.
  - Error messages now identify the specific addon instance when multiple instances share the same type.
  - Service availability is determined more accurately for individually named addon configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->