### PR TITLE
fix(dashboard/blocklist): disable certain batch actions on local source selection

### DIFF
--- a/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
+++ b/packages/frontend/src/app/dashboard/blocklist/sources-page.tsx
@@ -245,6 +245,14 @@ function SourcesView({
   const hasRemoteSelected = [...selectedIds].some(
     (id) => sources.find((s) => s.id === id)?.kind === 'remote'
   );
+  const hasLocalSelected = [...selectedIds].some(
+    (id) => sources.find((s) => s.id === id)?.kind === 'local'
+  );
+  // When any local source is in the selection, only Clear applies;
+  // the other batch actions (Refresh, Edit, Remove) are unavailable.
+  const canBatchEdit = !hasLocalSelected;
+  const canBatchRemove = !hasLocalSelected;
+  const canBatchRefresh = !hasLocalSelected && hasRemoteSelected;
 
   return (
     <div className="space-y-4">
@@ -289,18 +297,29 @@ function SourcesView({
               intent="gray-subtle"
               icon={<BiRefresh />}
               aria-label="Refresh selected"
-              title="Refresh selected"
+              title={
+                canBatchRefresh
+                  ? 'Refresh selected'
+                  : hasLocalSelected
+                    ? 'Cannot refresh local sources'
+                    : 'No remote sources selected'
+              }
               loading={refreshSources.isPending}
               onClick={askBatchRefresh}
-              disabled={!hasRemoteSelected}
+              disabled={!canBatchRefresh}
             />
             <IconButton
               size="sm"
               intent="gray-subtle"
               icon={<BiPencil />}
               aria-label="Edit selected"
-              title="Edit selected"
+              title={
+                canBatchEdit
+                  ? 'Edit selected'
+                  : 'Cannot edit the local source'
+              }
               onClick={() => setBatchEditOpen(true)}
+              disabled={!canBatchEdit}
             />
             <IconButton
               size="sm"
@@ -316,9 +335,14 @@ function SourcesView({
               intent="alert-subtle"
               icon={<BiTrash />}
               aria-label="Remove selected"
-              title="Remove selected"
+              title={
+                canBatchRemove
+                  ? 'Remove selected'
+                  : 'Cannot remove the local source'
+              }
               loading={removeSources.isPending}
               onClick={askBatchRemove}
+              disabled={!canBatchRemove}
             />
           </div>
           {selectedIds.size === 0 && nonLocalSources.length > 0 && (


### PR DESCRIPTION
When multi-selecting sources in the blocklist sources page, batch action
buttons are now contextually disabled when they don't apply to every
selected source. The local source cannot be refreshed, edited, or removed —
so those buttons are grayed out whenever local is part of the selection.
Only **Clear** remains available in all scenarios.
 
Disabled buttons show an explanatory tooltip describing why the action is
unavailable.
 
**Selection → Availability:**
 
| Selected | Refresh | Edit | Clear | Remove |
|---|---|---|---|---|
| Remote only | ✅ | ✅ | ✅ | ✅ |
| Imported only | ❌ (no remote URL) | ✅ | ✅ | ✅ |
| Local only | ❌ | ❌ | ✅ | ❌ |
| Any + local | ❌ | ❌ | ✅ | ❌ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated batch actions for blocklist sources to prevent editing or removing the local source.
  * Refreshing selected sources is now disabled when only the local source is selected.
  * Added clearer tooltips explaining why restricted actions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->