### PR TITLE
feat(frontend): support drag-and-drop for filter input lists

### DIFF
--- a/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
+++ b/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
@@ -1,7 +1,22 @@
-import { ReactNode, useCallback, useRef } from 'react';
+import { ReactNode, useCallback, useMemo, useRef } from 'react';
 import { useDisclosure } from '@/hooks/disclosure';
 import { toast } from 'sonner';
-import { arrayMove } from '@dnd-kit/sortable';
+import {
+  DndContext,
+  useSensors,
+  useSensor,
+  PointerSensor,
+  TouchSensor,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import { CSS } from '@dnd-kit/utilities';
 import { IconButton } from '../../../ui/button';
 import { TextInput } from '../../../ui/text-input';
 import { NumberInput } from '../../../ui/number-input';
@@ -16,8 +31,6 @@ import {
   FaRegTrashAlt,
   FaFileExport,
   FaFileImport,
-  FaArrowUp,
-  FaArrowDown,
   FaLink,
 } from 'react-icons/fa';
 import { UserData } from '@aiostreams/core';
@@ -137,31 +150,6 @@ function PlaceholderRow<T>({
   );
 }
 
-/** Map items, rendering PlaceholderRow for synced-URL entries and a custom render for normal items. */
-function renderItemsWithPlaceholders<T>(
-  items: T[],
-  getField: (item: T) => string,
-  onItemsChange: (items: T[]) => void,
-  renderItem: (item: T, index: number) => React.ReactNode,
-  options?: { syncEnabled?: boolean; iconPosition?: 'inside' | 'outside' }
-): React.ReactNode[] {
-  return items.map((item, index) => {
-    const url = options?.syncEnabled ? parseSyncedUrl(getField(item)) : null;
-    if (url) {
-      return (
-        <PlaceholderRow
-          key={index}
-          items={items}
-          index={index}
-          onItemsChange={onItemsChange}
-          url={url}
-          iconPosition={options?.iconPosition}
-        />
-      );
-    }
-    return renderItem(item, index);
-  });
-}
 
 /** Derive a filename from a label, e.g. "Required Keywords" → "required-keywords-2026-02-08.14-56".json */
 function labelToFilename(label: string) {
@@ -173,6 +161,61 @@ function labelToFilename(label: string) {
   const min = String(now.getMinutes()).padStart(2, '0');
   const dateStr = `${yyyy}-${mm}-${dd}.${hh}-${min}`;
   return `${label.toLowerCase().replace(/\s+/g, '-')}-${dateStr}.json`;
+}
+
+// --- Drag-and-drop shared helpers ---
+
+/** Create pointer + touch sensors shared by all sortable lists. */
+function useDragSensors() {
+  return useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 8 },
+    })
+  );
+}
+
+/**
+ * Wraps children with a drag handle and `useSortable` inside a bordered
+ * card, matching the visual style of the sorting primary-sort-order editor.
+ * The caller must wrap the list in `<DndContext>` + `<SortableContext>`.
+ */
+function SortableItemWrapper({
+  id,
+  children,
+}: {
+  id: string;
+  children: ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div className="px-2.5 py-2 bg-[var(--background)] rounded-[--radius-md] border flex gap-3 relative">
+        <div
+          className="rounded-full w-6 h-auto bg-[--muted] md:bg-[--subtle] md:hover:bg-[--subtle-highlight] cursor-move shrink-0"
+          {...attributes}
+          {...listeners}
+        />
+        <div className="flex-1 min-w-0 flex gap-2">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -210,36 +253,18 @@ interface ItemActionsProps<T> {
   onItemsChange: (items: T[]) => void;
 }
 
-/** Move-up / Move-down / Delete buttons shared by every list item. */
+/** Delete button shared by every list item. */
 function ItemActions<T>({ items, index, onItemsChange }: ItemActionsProps<T>) {
   return (
-    <>
-      <IconButton
-        size="sm"
-        rounded
-        icon={<FaArrowUp />}
-        intent="primary-subtle"
-        disabled={index === 0}
-        onClick={() => onItemsChange(arrayMove(items, index, index - 1))}
-      />
-      <IconButton
-        size="sm"
-        rounded
-        icon={<FaArrowDown />}
-        intent="primary-subtle"
-        disabled={index === items.length - 1}
-        onClick={() => onItemsChange(arrayMove(items, index, index + 1))}
-      />
-      <IconButton
-        size="sm"
-        rounded
-        icon={<FaRegTrashAlt />}
-        intent="alert-subtle"
-        onClick={() =>
-          onItemsChange([...items.slice(0, index), ...items.slice(index + 1)])
-        }
-      />
-    </>
+    <IconButton
+      size="sm"
+      rounded
+      icon={<FaRegTrashAlt />}
+      intent="alert-subtle"
+      onClick={() =>
+        onItemsChange([...items.slice(0, index), ...items.slice(index + 1)])
+      }
+    />
   );
 }
 
@@ -328,6 +353,49 @@ export function TextInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
+  const sensors = useDragSensors();
+
+  const stableKeysRef = useRef<string[]>([]);
+  const keyCounterRef = useRef(0);
+
+  // Sync stable keys with values array length
+  if (stableKeysRef.current.length < values.length) {
+    for (
+      let i = stableKeysRef.current.length;
+      i < values.length;
+      i++
+    ) {
+      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
+    }
+  } else if (stableKeysRef.current.length > values.length) {
+    stableKeysRef.current.length = values.length;
+  }
+
+  const isSynced = useCallback(
+    (v: string) => (syncConfig ? parseSyncedUrl(v) !== null : false),
+    [syncConfig]
+  );
+
+  const sortableIds = useMemo(
+    () =>
+      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
+    [values, isSynced]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const keys = stableKeysRef.current;
+      const oldIndex = keys.findIndex((k) => k === active.id);
+      const newIndex = keys.findIndex((k) => k === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
+      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
+    },
+    [onValuesChange]
+  );
+
   const getExportData = useCallback(() => ({ values: valuesRef.current }), []);
   const handleImportData = useCallback(
     (data: any) => {
@@ -364,31 +432,56 @@ export function TextInputs({
       description={help}
       key={label}
     >
-      {renderItemsWithPlaceholders(
-        values,
-        (v) => v,
-        onValuesChange,
-        (value, index) => (
-          <div key={index} className="flex gap-2">
-            <div className="flex-1">
-              <TextInput
-                value={value}
-                label={itemName}
-                placeholder={placeholder}
-                onValueChange={(newValue) => handleValueChange(newValue, index)}
-              />
-            </div>
-            <div className="flex gap-1 items-end pb-1">
-              <ItemActions
-                items={values}
-                index={index}
-                onItemsChange={onValuesChange}
-              />
-            </div>
+      <DndContext
+        sensors={sensors}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={sortableIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+          {values.map((value, index) => {
+            const syncedUrl = syncConfig ? parseSyncedUrl(value) : null;
+            if (syncedUrl) {
+              return (
+                <PlaceholderRow
+                  key={index}
+                  items={values}
+                  index={index}
+                  onItemsChange={onValuesChange}
+                  url={syncedUrl}
+                  iconPosition="inside"
+                />
+              );
+            }
+            const itemKey = stableKeysRef.current[index];
+            return (
+              <SortableItemWrapper key={itemKey} id={itemKey}>
+                <div className="flex-1">
+                  <TextInput
+                    value={value}
+                    label={itemName}
+                    placeholder={placeholder}
+                    onValueChange={(newValue) =>
+                      handleValueChange(newValue, index)
+                    }
+                  />
+                </div>
+                <div className="flex gap-1 items-end pb-1">
+                  <ItemActions
+                    items={values}
+                    index={index}
+                    onItemsChange={onValuesChange}
+                  />
+                </div>
+              </SortableItemWrapper>
+            );
+          })}
           </div>
-        ),
-        { syncEnabled: !!syncConfig, iconPosition: 'inside' }
-      )}
+        </SortableContext>
+      </DndContext>
       <ListFooter
         onAdd={() => onValuesChange([...values, ''])}
         onImportClick={modal.open}
@@ -433,6 +526,49 @@ export function ToggleableTextInputs({
 }: ToggleableTextInputProps) {
   const valuesRef = useRef(values);
   valuesRef.current = values;
+
+  const sensors = useDragSensors();
+
+  const stableKeysRef = useRef<string[]>([]);
+  const keyCounterRef = useRef(0);
+
+  if (stableKeysRef.current.length < values.length) {
+    for (
+      let i = stableKeysRef.current.length;
+      i < values.length;
+      i++
+    ) {
+      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
+    }
+  } else if (stableKeysRef.current.length > values.length) {
+    stableKeysRef.current.length = values.length;
+  }
+
+  const isSynced = useCallback(
+    (v: { expression: string; enabled: boolean }) =>
+      syncConfig ? parseSyncedUrl(v.expression) !== null : false,
+    [syncConfig]
+  );
+
+  const sortableIds = useMemo(
+    () =>
+      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
+    [values, isSynced]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const keys = stableKeysRef.current;
+      const oldIndex = keys.findIndex((k) => k === active.id);
+      const newIndex = keys.findIndex((k) => k === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
+      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
+    },
+    [onValuesChange]
+  );
 
   const getExportData = useCallback(
     () =>
@@ -482,46 +618,71 @@ export function ToggleableTextInputs({
       title={title}
       description={description}
     >
-      {renderItemsWithPlaceholders(
-        values,
-        (v) => v.expression,
-        onValuesChange,
-        (value, index) => (
-          <div key={index} className="flex gap-2 items-end">
-            <div className="flex items-center pb-0.5">
-              <Checkbox
-                value={value.enabled ?? true}
-                defaultValue={true}
-                size="lg"
-                onValueChange={(v) => {
-                  if (onEnabledChange) {
-                    onEnabledChange(v === true, index);
-                  }
-                }}
-              />
-            </div>
-            <div className="flex-1">
-              <TextInput
-                value={value.expression}
-                label="Expression"
-                placeholder={placeholder}
-                disabled={value.enabled === false}
-                onValueChange={(newValue) =>
-                  onExpressionChange(newValue, index)
-                }
-              />
-            </div>
-            <div className="flex gap-1 items-end pb-1">
-              <ItemActions
-                items={values}
-                index={index}
-                onItemsChange={onValuesChange}
-              />
-            </div>
+      <DndContext
+        sensors={sensors}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={sortableIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+          {values.map((value, index) => {
+            const syncedUrl =
+              syncConfig
+                ? parseSyncedUrl(value.expression)
+                : null;
+            if (syncedUrl) {
+              return (
+                <PlaceholderRow
+                  key={index}
+                  items={values as any}
+                  index={index}
+                  onItemsChange={onValuesChange as any}
+                  url={syncedUrl}
+                />
+              );
+            }
+            const itemKey = stableKeysRef.current[index];
+            return (
+              <SortableItemWrapper key={itemKey} id={itemKey}>
+                <div className="flex items-end pb-1">
+                  <Checkbox
+                    value={value.enabled ?? true}
+                    defaultValue={true}
+                    size="lg"
+                    onValueChange={(v) => {
+                      if (onEnabledChange) {
+                        onEnabledChange(v === true, index);
+                      }
+                    }}
+                  />
+                </div>
+                <div className="flex-1">
+                  <TextInput
+                    value={value.expression}
+                    label="Expression"
+                    placeholder={placeholder}
+                    disabled={value.enabled === false}
+                    onValueChange={(newValue) =>
+                      onExpressionChange(newValue, index)
+                    }
+                  />
+                </div>
+                <div className="flex gap-1 items-end pb-1">
+                  <ItemActions
+                    items={values}
+                    index={index}
+                    onItemsChange={onValuesChange}
+                  />
+                </div>
+              </SortableItemWrapper>
+            );
+          })}
           </div>
-        ),
-        { syncEnabled: !!syncConfig }
-      )}
+        </SortableContext>
+      </DndContext>
       <ListFooter
         onAdd={() =>
           onValuesChange([...values, { expression: '', enabled: true }])
@@ -579,6 +740,49 @@ export function TwoTextInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
+  const sensors = useDragSensors();
+
+  const stableKeysRef = useRef<string[]>([]);
+  const keyCounterRef = useRef(0);
+
+  if (stableKeysRef.current.length < values.length) {
+    for (
+      let i = stableKeysRef.current.length;
+      i < values.length;
+      i++
+    ) {
+      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
+    }
+  } else if (stableKeysRef.current.length > values.length) {
+    stableKeysRef.current.length = values.length;
+  }
+
+  const isSynced = useCallback(
+    (v: { name: string; value: string }) =>
+      syncConfig ? parseSyncedUrl(v.value) !== null : false,
+    [syncConfig]
+  );
+
+  const sortableIds = useMemo(
+    () =>
+      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
+    [values, isSynced]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const keys = stableKeysRef.current;
+      const oldIndex = keys.findIndex((k) => k === active.id);
+      const newIndex = keys.findIndex((k) => k === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
+      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
+    },
+    [onValuesChange]
+  );
+
   const getExportData = useCallback(
     () =>
       valuesRef.current.map((v) => ({ [keyId]: v.name, [valueId]: v.value })),
@@ -613,39 +817,66 @@ export function TwoTextInputs({
 
   return (
     <SettingsCard title={title} description={description}>
-      {renderItemsWithPlaceholders(
-        values,
-        (v) => v.value,
-        onValuesChange,
-        (value, index) => (
-          <div key={index} className="flex gap-2">
-            <div className="flex-1">
-              <TextInput
-                value={value.name}
-                label={keyName}
-                placeholder={keyPlaceholder}
-                onValueChange={(newValue) => onKeyChange(newValue, index)}
-              />
-            </div>
-            <div className="flex-1">
-              <TextInput
-                value={value.value}
-                label={valueName}
-                placeholder={valuePlaceholder}
-                onValueChange={(newValue) => onValueChange(newValue, index)}
-              />
-            </div>
-            <div className="flex gap-1 items-end pb-1">
-              <ItemActions
-                items={values}
-                index={index}
-                onItemsChange={onValuesChange}
-              />
-            </div>
+      <DndContext
+        sensors={sensors}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={sortableIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+          {values.map((value, index) => {
+            const syncedUrl = syncConfig
+              ? parseSyncedUrl(value.value)
+              : null;
+            if (syncedUrl) {
+              return (
+                <PlaceholderRow
+                  key={index}
+                  items={values as any}
+                  index={index}
+                  onItemsChange={onValuesChange as any}
+                  url={syncedUrl}
+                  iconPosition="inside"
+                />
+              );
+            }
+            const itemKey = stableKeysRef.current[index];
+            return (
+              <SortableItemWrapper key={itemKey} id={itemKey}>
+                <div className="flex-1">
+                  <TextInput
+                    value={value.name}
+                    label={keyName}
+                    placeholder={keyPlaceholder}
+                    onValueChange={(newValue) => onKeyChange(newValue, index)}
+                  />
+                </div>
+                <div className="flex-1">
+                  <TextInput
+                    value={value.value}
+                    label={valueName}
+                    placeholder={valuePlaceholder}
+                    onValueChange={(newValue) =>
+                      onValueChange(newValue, index)
+                    }
+                  />
+                </div>
+                <div className="flex gap-1 items-end pb-1">
+                  <ItemActions
+                    items={values}
+                    index={index}
+                    onItemsChange={onValuesChange}
+                  />
+                </div>
+              </SortableItemWrapper>
+            );
+          })}
           </div>
-        ),
-        { syncEnabled: !!syncConfig, iconPosition: 'inside' }
-      )}
+        </SortableContext>
+      </DndContext>
       <ListFooter
         onAdd={() => onValuesChange([...values, { name: '', value: '' }])}
         onImportClick={modal.open}
@@ -693,6 +924,50 @@ export function RankedExpressionInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
+  const sensors = useDragSensors();
+
+  const stableKeysRef = useRef<string[]>([]);
+  const keyCounterRef = useRef(0);
+
+  if (stableKeysRef.current.length < values.length) {
+    for (
+      let i = stableKeysRef.current.length;
+      i < values.length;
+      i++
+    ) {
+      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
+    }
+  } else if (stableKeysRef.current.length > values.length) {
+    stableKeysRef.current.length = values.length;
+  }
+
+  const isSynced = useCallback(
+    (
+      v: { expression: string; score: number; enabled: boolean }
+    ) => (syncConfig ? parseSyncedUrl(v.expression) !== null : false),
+    [syncConfig]
+  );
+
+  const sortableIds = useMemo(
+    () =>
+      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
+    [values, isSynced]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const keys = stableKeysRef.current;
+      const oldIndex = keys.findIndex((k) => k === active.id);
+      const newIndex = keys.findIndex((k) => k === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
+      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
+    },
+    [onValuesChange]
+  );
+
   const getExportData = useCallback(
     () =>
       valuesRef.current.map((v) => ({
@@ -738,60 +1013,85 @@ export function RankedExpressionInputs({
       title={title}
       description={description}
     >
-      {renderItemsWithPlaceholders(
-        values,
-        (v) => v.expression,
-        onValuesChange,
-        (value, index) => (
-          <div key={index} className="flex gap-2 items-end">
-            <div className="flex items-center pb-0.5">
-              <Checkbox
-                value={value.enabled ?? true}
-                defaultValue={true}
-                size="lg"
-                onValueChange={(v) => {
-                  if (onEnabledChange) {
-                    onEnabledChange(v === true, index);
-                  }
-                }}
-              />
-            </div>
-            <div className="flex-[3]">
-              <TextInput
-                value={value.expression}
-                label="Expression"
-                placeholder="addon(type(streams, 'debrid'), 'TorBox')"
-                disabled={value.enabled === false}
-                onValueChange={(newValue) =>
-                  onExpressionChange(newValue, index)
-                }
-              />
-            </div>
-            <div className="flex-1 min-w-[100px]">
-              <NumberInput
-                value={value.score || 0}
-                defaultValue={0}
-                label="Score"
-                disabled={value.enabled === false}
-                onValueChange={(newValue) =>
-                  onScoreChange(newValue || 0, index)
-                }
-                min={-1_000_000}
-                max={1_000_000}
-                step={50}
-              />
-            </div>
-            <div className="pb-1 gap-1 flex items-end">
-              <ItemActions
-                items={values}
-                index={index}
-                onItemsChange={onValuesChange}
-              />
-            </div>
+      <DndContext
+        sensors={sensors}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={sortableIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+          {values.map((value, index) => {
+            const syncedUrl =
+              syncConfig
+                ? parseSyncedUrl(value.expression)
+                : null;
+            if (syncedUrl) {
+              return (
+                <PlaceholderRow
+                  key={index}
+                  items={values as any}
+                  index={index}
+                  onItemsChange={onValuesChange as any}
+                  url={syncedUrl}
+                />
+              );
+            }
+            const itemKey = stableKeysRef.current[index];
+            return (
+              <SortableItemWrapper key={itemKey} id={itemKey}>
+                <div className="flex items-center pb-0.5">
+                  <Checkbox
+                    value={value.enabled ?? true}
+                    defaultValue={true}
+                    size="lg"
+                    onValueChange={(v) => {
+                      if (onEnabledChange) {
+                        onEnabledChange(v === true, index);
+                      }
+                    }}
+                  />
+                </div>
+                <div className="flex-[3]">
+                  <TextInput
+                    value={value.expression}
+                    label="Expression"
+                    placeholder="addon(type(streams, 'debrid'), 'TorBox')"
+                    disabled={value.enabled === false}
+                    onValueChange={(newValue) =>
+                      onExpressionChange(newValue, index)
+                    }
+                  />
+                </div>
+                <div className="flex-1 min-w-[100px]">
+                  <NumberInput
+                    value={value.score || 0}
+                    defaultValue={0}
+                    label="Score"
+                    disabled={value.enabled === false}
+                    onValueChange={(newValue) =>
+                      onScoreChange(newValue || 0, index)
+                    }
+                    min={-1_000_000}
+                    max={1_000_000}
+                    step={50}
+                  />
+                </div>
+                <div className="pb-1 gap-1 flex items-end">
+                  <ItemActions
+                    items={values}
+                    index={index}
+                    onItemsChange={onValuesChange}
+                  />
+                </div>
+              </SortableItemWrapper>
+            );
+          })}
           </div>
-        ),
-        { syncEnabled: !!syncConfig }
-      )}
+        </SortableContext>
+      </DndContext>
       <ListFooter
         onAdd={() =>
           onValuesChange([
@@ -842,6 +1142,50 @@ export function RankedRegexInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
+  const sensors = useDragSensors();
+
+  const stableKeysRef = useRef<string[]>([]);
+  const keyCounterRef = useRef(0);
+
+  if (stableKeysRef.current.length < values.length) {
+    for (
+      let i = stableKeysRef.current.length;
+      i < values.length;
+      i++
+    ) {
+      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
+    }
+  } else if (stableKeysRef.current.length > values.length) {
+    stableKeysRef.current.length = values.length;
+  }
+
+  const isSynced = useCallback(
+    (
+      v: NonNullable<UserData['rankedRegexPatterns']>[number]
+    ) => (syncConfig ? parseSyncedUrl(v.pattern) !== null : false),
+    [syncConfig]
+  );
+
+  const sortableIds = useMemo(
+    () =>
+      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
+    [values, isSynced]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const keys = stableKeysRef.current;
+      const oldIndex = keys.findIndex((k) => k === active.id);
+      const newIndex = keys.findIndex((k) => k === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
+      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
+    },
+    [onValuesChange]
+  );
+
   const getExportData = useCallback(
     () =>
       valuesRef.current.map((v) => ({
@@ -881,56 +1225,84 @@ export function RankedRegexInputs({
 
   return (
     <SettingsCard title={title} description={description}>
-      {renderItemsWithPlaceholders(
-        values,
-        (v) => v.pattern,
-        onValuesChange,
-        (value, index) => (
-          <div
-            key={index}
-            className="flex flex-col gap-2 p-3 border rounded-md border-[--border]"
-          >
-            <div className="w-full">
-              <TextInput
-                value={value.pattern}
-                label="Pattern"
-                placeholder="Regex Pattern"
-                onValueChange={(newValue) => onPatternChange(newValue, index)}
-              />
-            </div>
-            <div className="flex gap-2 items-end">
-              <div className="flex-1">
-                <TextInput
-                  value={value.name || ''}
-                  label="Name"
-                  placeholder="Name (Optional)"
-                  onValueChange={(newValue) => onNameChange(newValue, index)}
-                />
-              </div>
-              <div className="w-[20%] min-w-[100px]">
-                <NumberInput
-                  value={value.score}
-                  label="Score"
-                  onValueChange={(newValue) =>
-                    onScoreChange(newValue ?? 0, index)
-                  }
-                  min={-1_000_000}
-                  max={1_000_000}
-                  step={50}
-                />
-              </div>
-              <div className="flex gap-1 pb-1">
-                <ItemActions
-                  items={values}
+      <DndContext
+        sensors={sensors}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={sortableIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+          {values.map((value, index) => {
+            const syncedUrl = syncConfig
+              ? parseSyncedUrl(value.pattern)
+              : null;
+            if (syncedUrl) {
+              return (
+                <PlaceholderRow
+                  key={index}
+                  items={values as any}
                   index={index}
-                  onItemsChange={onValuesChange}
+                  onItemsChange={onValuesChange as any}
+                  url={syncedUrl}
+                  iconPosition="inside"
                 />
-              </div>
-            </div>
+              );
+            }
+            const itemKey = stableKeysRef.current[index];
+            return (
+              <SortableItemWrapper key={itemKey} id={itemKey}>
+                <div className="flex-1 flex flex-col gap-2">
+                  <div className="w-full">
+                    <TextInput
+                      value={value.pattern}
+                      label="Pattern"
+                      placeholder="Regex Pattern"
+                      onValueChange={(newValue) =>
+                        onPatternChange(newValue, index)
+                      }
+                    />
+                  </div>
+                  <div className="flex gap-2 items-end">
+                    <div className="flex-1">
+                      <TextInput
+                        value={value.name || ''}
+                        label="Name"
+                        placeholder="Name (Optional)"
+                        onValueChange={(newValue) =>
+                          onNameChange(newValue, index)
+                        }
+                      />
+                    </div>
+                    <div className="w-[20%] min-w-[100px]">
+                      <NumberInput
+                        value={value.score}
+                        label="Score"
+                        onValueChange={(newValue) =>
+                          onScoreChange(newValue ?? 0, index)
+                        }
+                        min={-1_000_000}
+                        max={1_000_000}
+                        step={50}
+                      />
+                    </div>
+                    <div className="flex gap-1 pb-1">
+                      <ItemActions
+                        items={values}
+                        index={index}
+                        onItemsChange={onValuesChange}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </SortableItemWrapper>
+            );
+          })}
           </div>
-        ),
-        { syncEnabled: !!syncConfig, iconPosition: 'inside' }
-      )}
+        </SortableContext>
+      </DndContext>
       <ListFooter
         onAdd={() =>
           onValuesChange([...values, { pattern: '', name: '', score: 0 }])

--- a/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
+++ b/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useDisclosure } from '@/hooks/disclosure';
 import { toast } from 'sonner';
 import {
@@ -22,7 +22,6 @@ import { TextInput } from '../../../ui/text-input';
 import { NumberInput } from '../../../ui/number-input';
 import { Tooltip } from '../../../ui/tooltip';
 import { Checkbox } from '../../../ui/checkbox';
-import { cn } from '../../../ui/core/styling';
 import { SettingsCard } from '../../../shared/settings-card';
 import { ImportModal } from '../../../shared/import-modal';
 import { SyncedUrlInputs, type SyncConfig } from './synced-patterns';
@@ -31,6 +30,8 @@ import {
   FaRegTrashAlt,
   FaFileExport,
   FaFileImport,
+  FaArrowUp,
+  FaArrowDown,
   FaLink,
 } from 'react-icons/fa';
 import { UserData } from '@aiostreams/core';
@@ -62,17 +63,192 @@ function downloadJson(data: unknown, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-/** Read-only label for an inline synced-URL placeholder. */
-function PlaceholderRow<T>({
-  items,
+/** Derive a filename from a label, e.g. "Required Keywords" → "required-keywords-2026-02-08.14-56".json */
+function labelToFilename(label: string) {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  const dateStr = `${yyyy}-${mm}-${dd}.${hh}-${min}`;
+  return `${label.toLowerCase().replace(/\s+/g, '-')}-${dateStr}.json`;
+}
+
+// Drag and drop
+
+const rowClass =
+  'px-2.5 py-2 bg-[var(--background)] rounded-[--radius-md] border flex gap-3 relative';
+const gripClass =
+  'rounded-full w-6 h-auto bg-[--muted] md:bg-[--subtle] md:hover:bg-[--subtle-highlight] cursor-move shrink-0';
+/**
+ * Rows are a single line: the card title names the field, so the inputs carry
+ * a placeholder and an aria-label instead of a visible one.
+ */
+const rowContentClass = 'flex-1 min-w-0 flex gap-2 items-center';
+
+interface SortableRows {
+  /** Row count, including synced placeholders. */
+  count: number;
+  /** Stable React key and sortable id for the row at `index`. */
+  keyAt: (index: number) => string;
+  /** Ids registered with `SortableContext`, in render order. */
+  sortableIds: string[];
+  move: (from: number, to: number) => void;
+  removeAt: (index: number) => void;
+  dndProps: Pick<
+    React.ComponentProps<typeof DndContext>,
+    'sensors' | 'modifiers' | 'onDragStart' | 'onDragEnd'
+  >;
+}
+
+/**
+ * Owns row identity and reordering for a draggable list.
+ *
+ * Rows hold free-form text, so there is nothing in a value to key on: keys are
+ * synthetic and every reorder or removal has to carry them, otherwise React
+ * reuses a row's DOM (and the caret inside it) for a different entry.
+ */
+function useSortableRows<T>(
+  values: T[],
+  onValuesChange: (values: T[]) => void
+): SortableRows {
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
+  const keysRef = useRef<string[]>([]);
+  const counterRef = useRef(0);
+  // Values also change from outside the list (import, sync, reset); top up or
+  // trim to match, keeping the keys already handed out.
+  while (keysRef.current.length < values.length) {
+    keysRef.current.push(`row-${counterRef.current++}`);
+  }
+  keysRef.current.length = values.length;
+
+  const [isDragging, setIsDragging] = useState(false);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 8 },
+    })
+  );
+
+  // Stop the page scrolling out from under a touch drag.
+  useEffect(() => {
+    if (!isDragging) return;
+    const preventTouchMove = (e: TouchEvent) => e.preventDefault();
+    document.body.addEventListener('touchmove', preventTouchMove, {
+      passive: false,
+    });
+    return () =>
+      document.body.removeEventListener('touchmove', preventTouchMove);
+  }, [isDragging]);
+
+  const move = useCallback(
+    (from: number, to: number) => {
+      keysRef.current = arrayMove(keysRef.current, from, to);
+      onValuesChange(arrayMove(valuesRef.current, from, to));
+    },
+    [onValuesChange]
+  );
+
+  const removeAt = useCallback(
+    (index: number) => {
+      keysRef.current = keysRef.current.filter((_, i) => i !== index);
+      onValuesChange(valuesRef.current.filter((_, i) => i !== index));
+    },
+    [onValuesChange]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setIsDragging(false);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const from = keysRef.current.indexOf(String(active.id));
+      const to = keysRef.current.indexOf(String(over.id));
+      if (from === -1 || to === -1) return;
+      move(from, to);
+    },
+    [move]
+  );
+
+  return {
+    count: values.length,
+    keyAt: (index) => keysRef.current[index],
+    sortableIds: [...keysRef.current],
+    move,
+    removeAt,
+    dndProps: {
+      sensors,
+      modifiers: [restrictToVerticalAxis],
+      onDragStart: () => setIsDragging(true),
+      onDragEnd: handleDragEnd,
+    },
+  };
+}
+
+/** `DndContext` + `SortableContext` shell wrapping every list. */
+function SortableList({
+  rows,
+  children,
+}: {
+  rows: SortableRows;
+  children: ReactNode;
+}) {
+  return (
+    <DndContext {...rows.dndProps}>
+      <SortableContext
+        items={rows.sortableIds}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-2">{children}</div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+/** Draggable row card, styled to match the sort order editors. */
+function SortableRow({ id, children }: { id: string; children: ReactNode }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div className={rowClass}>
+        <div className={gripClass} {...attributes} {...listeners} />
+        <div className={rowContentClass}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Read-only cells for an inline synced-URL placeholder. Synced rows have no
+ * checkbox, so on lists that have one the link icon takes that column to keep
+ * the fields lined up; elsewhere it sits inside the field.
+ */
+function PlaceholderRow({
+  rows,
   index,
-  onItemsChange,
   url,
   iconPosition,
 }: {
-  items: T[];
+  rows: SortableRows;
   index: number;
-  onItemsChange: (items: T[]) => void;
   url: string;
   iconPosition?: 'inside' | 'outside';
 }) {
@@ -81,8 +257,9 @@ function PlaceholderRow<T>({
       const container = (e.currentTarget as HTMLElement).closest(
         '[data-settings-card]'
       );
+      // `window.` qualified: the dnd-kit `CSS` import shadows the DOM one.
       const row = (container ?? document).querySelector(
-        `[data-synced-url="${CSS.escape(url)}"]`
+        `[data-synced-url="${window.CSS.escape(url)}"]`
       );
       if (!row) return;
       row.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -117,105 +294,50 @@ function PlaceholderRow<T>({
   );
 
   return (
-    <div
-      className={cn(
-        'grid gap-2 items-end w-full',
-        iconPosition !== 'inside'
-          ? 'grid-cols-[auto_minmax(0,1fr)_auto]'
-          : 'grid-cols-[minmax(0,1fr)_auto]'
-      )}
-    >
-      {iconPosition !== 'inside' && (
-        <div className="flex items-center pb-2">{linkButton}</div>
-      )}
-      <div className="relative space-y-1 min-w-0">
-        <label className="text-base w-fit font-semibold self-start">
-          Synced URL
-        </label>
-        <div className="flex items-center gap-2 w-full rounded-[--radius] bg-[--paper] border border-[--border] shadow-sm h-10 px-3 opacity-75 overflow-hidden">
-          {iconPosition === 'inside' && linkButton}
-          <span className="text-sm text-[--muted] font-mono truncate min-w-0 flex-1">
-            {url}
-          </span>
-        </div>
+    <>
+      {iconPosition !== 'inside' && linkButton}
+      <div className="flex-1 min-w-0 flex items-center gap-2 rounded-[--radius] bg-[--paper] border border-[--border] shadow-sm h-10 px-3 opacity-75 overflow-hidden">
+        {iconPosition === 'inside' && linkButton}
+        <span className="text-sm text-[--muted] font-mono truncate min-w-0 flex-1">
+          {url}
+        </span>
       </div>
-      <div className="flex gap-1 items-end pb-1">
-        <ItemActions
-          items={items}
-          index={index}
-          onItemsChange={onItemsChange}
-        />
+      <div className="flex gap-1">
+        <ItemActions rows={rows} index={index} />
       </div>
-    </div>
-  );
-}
-
-
-/** Derive a filename from a label, e.g. "Required Keywords" → "required-keywords-2026-02-08.14-56".json */
-function labelToFilename(label: string) {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, '0');
-  const dd = String(now.getDate()).padStart(2, '0');
-  const hh = String(now.getHours()).padStart(2, '0');
-  const min = String(now.getMinutes()).padStart(2, '0');
-  const dateStr = `${yyyy}-${mm}-${dd}.${hh}-${min}`;
-  return `${label.toLowerCase().replace(/\s+/g, '-')}-${dateStr}.json`;
-}
-
-// --- Drag-and-drop shared helpers ---
-
-/** Create pointer + touch sensors shared by all sortable lists. */
-function useDragSensors() {
-  return useSensors(
-    useSensor(PointerSensor),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 150, tolerance: 8 },
-    })
+    </>
   );
 }
 
 /**
- * Wraps children with a drag handle and `useSortable` inside a bordered
- * card, matching the visual style of the sorting primary-sort-order editor.
- * The caller must wrap the list in `<DndContext>` + `<SortableContext>`.
+ * Map items into draggable cards, substituting a read-only body for
+ * synced-URL entries.
  */
-function SortableItemWrapper({
-  id,
-  children,
-}: {
-  id: string;
-  children: ReactNode;
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style}>
-      <div className="px-2.5 py-2 bg-[var(--background)] rounded-[--radius-md] border flex gap-3 relative">
-        <div
-          className="rounded-full w-6 h-auto bg-[--muted] md:bg-[--subtle] md:hover:bg-[--subtle-highlight] cursor-move shrink-0"
-          {...attributes}
-          {...listeners}
-        />
-        <div className="flex-1 min-w-0 flex gap-2">
-          {children}
-        </div>
-      </div>
-    </div>
-  );
+function renderRows<T>(
+  rows: SortableRows,
+  items: T[],
+  getField: (item: T) => string,
+  renderItem: (item: T, index: number) => ReactNode,
+  options?: { syncEnabled?: boolean; iconPosition?: 'inside' | 'outside' }
+): ReactNode[] {
+  return items.map((item, index) => {
+    const key = rows.keyAt(index);
+    const url = options?.syncEnabled ? parseSyncedUrl(getField(item)) : null;
+    return (
+      <SortableRow key={key} id={key}>
+        {url ? (
+          <PlaceholderRow
+            rows={rows}
+            index={index}
+            url={url}
+            iconPosition={options?.iconPosition}
+          />
+        ) : (
+          renderItem(item, index)
+        )}
+      </SortableRow>
+    );
+  });
 }
 
 /**
@@ -247,24 +369,37 @@ function useImportExport<T>(
 
 // Reusable item-list action buttons
 
-interface ItemActionsProps<T> {
-  items: T[];
-  index: number;
-  onItemsChange: (items: T[]) => void;
-}
-
-/** Delete button shared by every list item. */
-function ItemActions<T>({ items, index, onItemsChange }: ItemActionsProps<T>) {
+/** Move-up / move-down / delete buttons shared by every list item. */
+function ItemActions({ rows, index }: { rows: SortableRows; index: number }) {
   return (
-    <IconButton
-      size="sm"
-      rounded
-      icon={<FaRegTrashAlt />}
-      intent="alert-subtle"
-      onClick={() =>
-        onItemsChange([...items.slice(0, index), ...items.slice(index + 1)])
-      }
-    />
+    <>
+      <IconButton
+        size="sm"
+        rounded
+        icon={<FaArrowUp />}
+        intent="primary-subtle"
+        aria-label="Move up"
+        disabled={index === 0}
+        onClick={() => rows.move(index, index - 1)}
+      />
+      <IconButton
+        size="sm"
+        rounded
+        icon={<FaArrowDown />}
+        intent="primary-subtle"
+        aria-label="Move down"
+        disabled={index === rows.count - 1}
+        onClick={() => rows.move(index, index + 1)}
+      />
+      <IconButton
+        size="sm"
+        rounded
+        icon={<FaRegTrashAlt />}
+        intent="alert-subtle"
+        aria-label="Remove"
+        onClick={() => rows.removeAt(index)}
+      />
+    </>
   );
 }
 
@@ -353,48 +488,7 @@ export function TextInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
-  const sensors = useDragSensors();
-
-  const stableKeysRef = useRef<string[]>([]);
-  const keyCounterRef = useRef(0);
-
-  // Sync stable keys with values array length
-  if (stableKeysRef.current.length < values.length) {
-    for (
-      let i = stableKeysRef.current.length;
-      i < values.length;
-      i++
-    ) {
-      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
-    }
-  } else if (stableKeysRef.current.length > values.length) {
-    stableKeysRef.current.length = values.length;
-  }
-
-  const isSynced = useCallback(
-    (v: string) => (syncConfig ? parseSyncedUrl(v) !== null : false),
-    [syncConfig]
-  );
-
-  const sortableIds = useMemo(
-    () =>
-      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
-    [values, isSynced]
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const keys = stableKeysRef.current;
-      const oldIndex = keys.findIndex((k) => k === active.id);
-      const newIndex = keys.findIndex((k) => k === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
-      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
-    },
-    [onValuesChange]
-  );
+  const rows = useSortableRows(values, onValuesChange);
 
   const getExportData = useCallback(() => ({ values: valuesRef.current }), []);
   const handleImportData = useCallback(
@@ -432,56 +526,31 @@ export function TextInputs({
       description={help}
       key={label}
     >
-      <DndContext
-        sensors={sensors}
-        modifiers={[restrictToVerticalAxis]}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={sortableIds}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="space-y-2">
-          {values.map((value, index) => {
-            const syncedUrl = syncConfig ? parseSyncedUrl(value) : null;
-            if (syncedUrl) {
-              return (
-                <PlaceholderRow
-                  key={index}
-                  items={values}
-                  index={index}
-                  onItemsChange={onValuesChange}
-                  url={syncedUrl}
-                  iconPosition="inside"
+      <SortableList rows={rows}>
+        {renderRows(
+          rows,
+          values,
+          (v) => v,
+          (value, index) => (
+            <>
+              <div className="flex-1">
+                <TextInput
+                  value={value}
+                  aria-label={itemName}
+                  placeholder={placeholder ?? itemName}
+                  onValueChange={(newValue) =>
+                    handleValueChange(newValue, index)
+                  }
                 />
-              );
-            }
-            const itemKey = stableKeysRef.current[index];
-            return (
-              <SortableItemWrapper key={itemKey} id={itemKey}>
-                <div className="flex-1">
-                  <TextInput
-                    value={value}
-                    label={itemName}
-                    placeholder={placeholder}
-                    onValueChange={(newValue) =>
-                      handleValueChange(newValue, index)
-                    }
-                  />
-                </div>
-                <div className="flex gap-1 items-end pb-1">
-                  <ItemActions
-                    items={values}
-                    index={index}
-                    onItemsChange={onValuesChange}
-                  />
-                </div>
-              </SortableItemWrapper>
-            );
-          })}
-          </div>
-        </SortableContext>
-      </DndContext>
+              </div>
+              <div className="flex gap-1">
+                <ItemActions rows={rows} index={index} />
+              </div>
+            </>
+          ),
+          { syncEnabled: !!syncConfig, iconPosition: 'inside' }
+        )}
+      </SortableList>
       <ListFooter
         onAdd={() => onValuesChange([...values, ''])}
         onImportClick={modal.open}
@@ -527,48 +596,7 @@ export function ToggleableTextInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
-  const sensors = useDragSensors();
-
-  const stableKeysRef = useRef<string[]>([]);
-  const keyCounterRef = useRef(0);
-
-  if (stableKeysRef.current.length < values.length) {
-    for (
-      let i = stableKeysRef.current.length;
-      i < values.length;
-      i++
-    ) {
-      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
-    }
-  } else if (stableKeysRef.current.length > values.length) {
-    stableKeysRef.current.length = values.length;
-  }
-
-  const isSynced = useCallback(
-    (v: { expression: string; enabled: boolean }) =>
-      syncConfig ? parseSyncedUrl(v.expression) !== null : false,
-    [syncConfig]
-  );
-
-  const sortableIds = useMemo(
-    () =>
-      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
-    [values, isSynced]
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const keys = stableKeysRef.current;
-      const oldIndex = keys.findIndex((k) => k === active.id);
-      const newIndex = keys.findIndex((k) => k === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
-      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
-    },
-    [onValuesChange]
-  );
+  const rows = useSortableRows(values, onValuesChange);
 
   const getExportData = useCallback(
     () =>
@@ -618,71 +646,45 @@ export function ToggleableTextInputs({
       title={title}
       description={description}
     >
-      <DndContext
-        sensors={sensors}
-        modifiers={[restrictToVerticalAxis]}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={sortableIds}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="space-y-2">
-          {values.map((value, index) => {
-            const syncedUrl =
-              syncConfig
-                ? parseSyncedUrl(value.expression)
-                : null;
-            if (syncedUrl) {
-              return (
-                <PlaceholderRow
-                  key={index}
-                  items={values as any}
-                  index={index}
-                  onItemsChange={onValuesChange as any}
-                  url={syncedUrl}
-                />
-              );
-            }
-            const itemKey = stableKeysRef.current[index];
-            return (
-              <SortableItemWrapper key={itemKey} id={itemKey}>
-                <div className="flex items-end pb-1">
-                  <Checkbox
-                    value={value.enabled ?? true}
-                    defaultValue={true}
-                    size="lg"
-                    onValueChange={(v) => {
-                      if (onEnabledChange) {
-                        onEnabledChange(v === true, index);
-                      }
-                    }}
-                  />
-                </div>
-                <div className="flex-1">
-                  <TextInput
-                    value={value.expression}
-                    label="Expression"
-                    placeholder={placeholder}
-                    disabled={value.enabled === false}
-                    onValueChange={(newValue) =>
-                      onExpressionChange(newValue, index)
+      <SortableList rows={rows}>
+        {renderRows(
+          rows,
+          values,
+          (v) => v.expression,
+          (value, index) => (
+            <>
+              <div className="shrink-0">
+                <Checkbox
+                  value={value.enabled ?? true}
+                  defaultValue={true}
+                  size="lg"
+                  aria-label="Enabled"
+                  onValueChange={(v) => {
+                    if (onEnabledChange) {
+                      onEnabledChange(v === true, index);
                     }
-                  />
-                </div>
-                <div className="flex gap-1 items-end pb-1">
-                  <ItemActions
-                    items={values}
-                    index={index}
-                    onItemsChange={onValuesChange}
-                  />
-                </div>
-              </SortableItemWrapper>
-            );
-          })}
-          </div>
-        </SortableContext>
-      </DndContext>
+                  }}
+                />
+              </div>
+              <div className="flex-1">
+                <TextInput
+                  value={value.expression}
+                  aria-label="Expression"
+                  placeholder={placeholder}
+                  disabled={value.enabled === false}
+                  onValueChange={(newValue) =>
+                    onExpressionChange(newValue, index)
+                  }
+                />
+              </div>
+              <div className="flex gap-1">
+                <ItemActions rows={rows} index={index} />
+              </div>
+            </>
+          ),
+          { syncEnabled: !!syncConfig }
+        )}
+      </SortableList>
       <ListFooter
         onAdd={() =>
           onValuesChange([...values, { expression: '', enabled: true }])
@@ -740,48 +742,7 @@ export function TwoTextInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
-  const sensors = useDragSensors();
-
-  const stableKeysRef = useRef<string[]>([]);
-  const keyCounterRef = useRef(0);
-
-  if (stableKeysRef.current.length < values.length) {
-    for (
-      let i = stableKeysRef.current.length;
-      i < values.length;
-      i++
-    ) {
-      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
-    }
-  } else if (stableKeysRef.current.length > values.length) {
-    stableKeysRef.current.length = values.length;
-  }
-
-  const isSynced = useCallback(
-    (v: { name: string; value: string }) =>
-      syncConfig ? parseSyncedUrl(v.value) !== null : false,
-    [syncConfig]
-  );
-
-  const sortableIds = useMemo(
-    () =>
-      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
-    [values, isSynced]
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const keys = stableKeysRef.current;
-      const oldIndex = keys.findIndex((k) => k === active.id);
-      const newIndex = keys.findIndex((k) => k === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
-      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
-    },
-    [onValuesChange]
-  );
+  const rows = useSortableRows(values, onValuesChange);
 
   const getExportData = useCallback(
     () =>
@@ -817,66 +778,37 @@ export function TwoTextInputs({
 
   return (
     <SettingsCard title={title} description={description}>
-      <DndContext
-        sensors={sensors}
-        modifiers={[restrictToVerticalAxis]}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={sortableIds}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="space-y-2">
-          {values.map((value, index) => {
-            const syncedUrl = syncConfig
-              ? parseSyncedUrl(value.value)
-              : null;
-            if (syncedUrl) {
-              return (
-                <PlaceholderRow
-                  key={index}
-                  items={values as any}
-                  index={index}
-                  onItemsChange={onValuesChange as any}
-                  url={syncedUrl}
-                  iconPosition="inside"
+      <SortableList rows={rows}>
+        {renderRows(
+          rows,
+          values,
+          (v) => v.value,
+          (value, index) => (
+            <>
+              <div className="flex-1">
+                <TextInput
+                  value={value.name}
+                  aria-label={keyName}
+                  placeholder={keyPlaceholder}
+                  onValueChange={(newValue) => onKeyChange(newValue, index)}
                 />
-              );
-            }
-            const itemKey = stableKeysRef.current[index];
-            return (
-              <SortableItemWrapper key={itemKey} id={itemKey}>
-                <div className="flex-1">
-                  <TextInput
-                    value={value.name}
-                    label={keyName}
-                    placeholder={keyPlaceholder}
-                    onValueChange={(newValue) => onKeyChange(newValue, index)}
-                  />
-                </div>
-                <div className="flex-1">
-                  <TextInput
-                    value={value.value}
-                    label={valueName}
-                    placeholder={valuePlaceholder}
-                    onValueChange={(newValue) =>
-                      onValueChange(newValue, index)
-                    }
-                  />
-                </div>
-                <div className="flex gap-1 items-end pb-1">
-                  <ItemActions
-                    items={values}
-                    index={index}
-                    onItemsChange={onValuesChange}
-                  />
-                </div>
-              </SortableItemWrapper>
-            );
-          })}
-          </div>
-        </SortableContext>
-      </DndContext>
+              </div>
+              <div className="flex-1">
+                <TextInput
+                  value={value.value}
+                  aria-label={valueName}
+                  placeholder={valuePlaceholder}
+                  onValueChange={(newValue) => onValueChange(newValue, index)}
+                />
+              </div>
+              <div className="flex gap-1">
+                <ItemActions rows={rows} index={index} />
+              </div>
+            </>
+          ),
+          { syncEnabled: !!syncConfig, iconPosition: 'inside' }
+        )}
+      </SortableList>
       <ListFooter
         onAdd={() => onValuesChange([...values, { name: '', value: '' }])}
         onImportClick={modal.open}
@@ -924,49 +856,7 @@ export function RankedExpressionInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
-  const sensors = useDragSensors();
-
-  const stableKeysRef = useRef<string[]>([]);
-  const keyCounterRef = useRef(0);
-
-  if (stableKeysRef.current.length < values.length) {
-    for (
-      let i = stableKeysRef.current.length;
-      i < values.length;
-      i++
-    ) {
-      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
-    }
-  } else if (stableKeysRef.current.length > values.length) {
-    stableKeysRef.current.length = values.length;
-  }
-
-  const isSynced = useCallback(
-    (
-      v: { expression: string; score: number; enabled: boolean }
-    ) => (syncConfig ? parseSyncedUrl(v.expression) !== null : false),
-    [syncConfig]
-  );
-
-  const sortableIds = useMemo(
-    () =>
-      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
-    [values, isSynced]
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const keys = stableKeysRef.current;
-      const oldIndex = keys.findIndex((k) => k === active.id);
-      const newIndex = keys.findIndex((k) => k === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
-      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
-    },
-    [onValuesChange]
-  );
+  const rows = useSortableRows(values, onValuesChange);
 
   const getExportData = useCallback(
     () =>
@@ -1013,85 +903,59 @@ export function RankedExpressionInputs({
       title={title}
       description={description}
     >
-      <DndContext
-        sensors={sensors}
-        modifiers={[restrictToVerticalAxis]}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={sortableIds}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="space-y-2">
-          {values.map((value, index) => {
-            const syncedUrl =
-              syncConfig
-                ? parseSyncedUrl(value.expression)
-                : null;
-            if (syncedUrl) {
-              return (
-                <PlaceholderRow
-                  key={index}
-                  items={values as any}
-                  index={index}
-                  onItemsChange={onValuesChange as any}
-                  url={syncedUrl}
+      <SortableList rows={rows}>
+        {renderRows(
+          rows,
+          values,
+          (v) => v.expression,
+          (value, index) => (
+            <>
+              <div className="shrink-0">
+                <Checkbox
+                  value={value.enabled ?? true}
+                  defaultValue={true}
+                  size="lg"
+                  aria-label="Enabled"
+                  onValueChange={(v) => {
+                    if (onEnabledChange) {
+                      onEnabledChange(v === true, index);
+                    }
+                  }}
                 />
-              );
-            }
-            const itemKey = stableKeysRef.current[index];
-            return (
-              <SortableItemWrapper key={itemKey} id={itemKey}>
-                <div className="flex items-center pb-0.5">
-                  <Checkbox
-                    value={value.enabled ?? true}
-                    defaultValue={true}
-                    size="lg"
-                    onValueChange={(v) => {
-                      if (onEnabledChange) {
-                        onEnabledChange(v === true, index);
-                      }
-                    }}
-                  />
-                </div>
-                <div className="flex-[3]">
-                  <TextInput
-                    value={value.expression}
-                    label="Expression"
-                    placeholder="addon(type(streams, 'debrid'), 'TorBox')"
-                    disabled={value.enabled === false}
-                    onValueChange={(newValue) =>
-                      onExpressionChange(newValue, index)
-                    }
-                  />
-                </div>
-                <div className="flex-1 min-w-[100px]">
-                  <NumberInput
-                    value={value.score || 0}
-                    defaultValue={0}
-                    label="Score"
-                    disabled={value.enabled === false}
-                    onValueChange={(newValue) =>
-                      onScoreChange(newValue || 0, index)
-                    }
-                    min={-1_000_000}
-                    max={1_000_000}
-                    step={50}
-                  />
-                </div>
-                <div className="pb-1 gap-1 flex items-end">
-                  <ItemActions
-                    items={values}
-                    index={index}
-                    onItemsChange={onValuesChange}
-                  />
-                </div>
-              </SortableItemWrapper>
-            );
-          })}
-          </div>
-        </SortableContext>
-      </DndContext>
+              </div>
+              <div className="flex-[3]">
+                <TextInput
+                  value={value.expression}
+                  aria-label="Expression"
+                  placeholder="addon(type(streams, 'debrid'), 'TorBox')"
+                  disabled={value.enabled === false}
+                  onValueChange={(newValue) =>
+                    onExpressionChange(newValue, index)
+                  }
+                />
+              </div>
+              <div className="flex-1 min-w-[100px]">
+                <NumberInput
+                  value={value.score || 0}
+                  defaultValue={0}
+                  aria-label="Score"
+                  disabled={value.enabled === false}
+                  onValueChange={(newValue) =>
+                    onScoreChange(newValue || 0, index)
+                  }
+                  min={-1_000_000}
+                  max={1_000_000}
+                  step={50}
+                />
+              </div>
+              <div className="flex gap-1">
+                <ItemActions rows={rows} index={index} />
+              </div>
+            </>
+          ),
+          { syncEnabled: !!syncConfig }
+        )}
+      </SortableList>
       <ListFooter
         onAdd={() =>
           onValuesChange([
@@ -1142,49 +1006,7 @@ export function RankedRegexInputs({
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
-  const sensors = useDragSensors();
-
-  const stableKeysRef = useRef<string[]>([]);
-  const keyCounterRef = useRef(0);
-
-  if (stableKeysRef.current.length < values.length) {
-    for (
-      let i = stableKeysRef.current.length;
-      i < values.length;
-      i++
-    ) {
-      stableKeysRef.current.push(`k-${keyCounterRef.current++}`);
-    }
-  } else if (stableKeysRef.current.length > values.length) {
-    stableKeysRef.current.length = values.length;
-  }
-
-  const isSynced = useCallback(
-    (
-      v: NonNullable<UserData['rankedRegexPatterns']>[number]
-    ) => (syncConfig ? parseSyncedUrl(v.pattern) !== null : false),
-    [syncConfig]
-  );
-
-  const sortableIds = useMemo(
-    () =>
-      stableKeysRef.current.filter((_, i) => !isSynced(values[i])),
-    [values, isSynced]
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const keys = stableKeysRef.current;
-      const oldIndex = keys.findIndex((k) => k === active.id);
-      const newIndex = keys.findIndex((k) => k === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      stableKeysRef.current = arrayMove(keys, oldIndex, newIndex);
-      onValuesChange(arrayMove(valuesRef.current, oldIndex, newIndex));
-    },
-    [onValuesChange]
-  );
+  const rows = useSortableRows(values, onValuesChange);
 
   const getExportData = useCallback(
     () =>
@@ -1225,84 +1047,49 @@ export function RankedRegexInputs({
 
   return (
     <SettingsCard title={title} description={description}>
-      <DndContext
-        sensors={sensors}
-        modifiers={[restrictToVerticalAxis]}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={sortableIds}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="space-y-2">
-          {values.map((value, index) => {
-            const syncedUrl = syncConfig
-              ? parseSyncedUrl(value.pattern)
-              : null;
-            if (syncedUrl) {
-              return (
-                <PlaceholderRow
-                  key={index}
-                  items={values as any}
-                  index={index}
-                  onItemsChange={onValuesChange as any}
-                  url={syncedUrl}
-                  iconPosition="inside"
+      <SortableList rows={rows}>
+        {renderRows(
+          rows,
+          values,
+          (v) => v.pattern,
+          (value, index) => (
+            <>
+              <div className="flex-[3]">
+                <TextInput
+                  value={value.pattern}
+                  aria-label="Pattern"
+                  placeholder="Regex Pattern"
+                  onValueChange={(newValue) => onPatternChange(newValue, index)}
                 />
-              );
-            }
-            const itemKey = stableKeysRef.current[index];
-            return (
-              <SortableItemWrapper key={itemKey} id={itemKey}>
-                <div className="flex-1 flex flex-col gap-2">
-                  <div className="w-full">
-                    <TextInput
-                      value={value.pattern}
-                      label="Pattern"
-                      placeholder="Regex Pattern"
-                      onValueChange={(newValue) =>
-                        onPatternChange(newValue, index)
-                      }
-                    />
-                  </div>
-                  <div className="flex gap-2 items-end">
-                    <div className="flex-1">
-                      <TextInput
-                        value={value.name || ''}
-                        label="Name"
-                        placeholder="Name (Optional)"
-                        onValueChange={(newValue) =>
-                          onNameChange(newValue, index)
-                        }
-                      />
-                    </div>
-                    <div className="w-[20%] min-w-[100px]">
-                      <NumberInput
-                        value={value.score}
-                        label="Score"
-                        onValueChange={(newValue) =>
-                          onScoreChange(newValue ?? 0, index)
-                        }
-                        min={-1_000_000}
-                        max={1_000_000}
-                        step={50}
-                      />
-                    </div>
-                    <div className="flex gap-1 pb-1">
-                      <ItemActions
-                        items={values}
-                        index={index}
-                        onItemsChange={onValuesChange}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </SortableItemWrapper>
-            );
-          })}
-          </div>
-        </SortableContext>
-      </DndContext>
+              </div>
+              <div className="flex-[2]">
+                <TextInput
+                  value={value.name || ''}
+                  aria-label="Name"
+                  placeholder="Name (Optional)"
+                  onValueChange={(newValue) => onNameChange(newValue, index)}
+                />
+              </div>
+              <div className="flex-1 min-w-[100px]">
+                <NumberInput
+                  value={value.score}
+                  aria-label="Score"
+                  onValueChange={(newValue) =>
+                    onScoreChange(newValue ?? 0, index)
+                  }
+                  min={-1_000_000}
+                  max={1_000_000}
+                  step={50}
+                />
+              </div>
+              <div className="flex gap-1">
+                <ItemActions rows={rows} index={index} />
+              </div>
+            </>
+          ),
+          { syncEnabled: !!syncConfig, iconPosition: 'inside' }
+        )}
+      </SortableList>
       <ListFooter
         onAdd={() =>
           onValuesChange([...values, { pattern: '', name: '', score: 0 }])

--- a/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
+++ b/packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx
@@ -82,10 +82,20 @@ const rowClass =
 const gripClass =
   'rounded-full w-6 h-auto bg-[--muted] md:bg-[--subtle] md:hover:bg-[--subtle-highlight] cursor-move shrink-0';
 /**
- * Rows are a single line: the card title names the field, so the inputs carry
- * a placeholder and an aria-label instead of a visible one.
+ * A row is one line on desktop: the card title names the field, so the inputs
+ * carry a placeholder and an aria-label instead of a visible one. There is no
+ * room for that below `md`, so the row stacks: the controls take the first
+ * line and every field gets the full width underneath.
  */
-const rowContentClass = 'flex-1 min-w-0 flex gap-2 items-center';
+const rowContentClass =
+  'flex-1 min-w-0 flex flex-col md:flex-row gap-2 md:items-center';
+/** Control strip above the fields while stacked; dissolves into the row at `md`. */
+const rowControlsClass = 'flex items-center justify-end gap-2 md:contents';
+/** The control the strip leads with, opposite the actions. */
+const rowLeadControlClass = 'shrink-0 mr-auto md:mr-0';
+/** Actions head the stack but trail the row, so they are reordered at `md`. */
+const rowActionsClass = 'flex gap-1 justify-end md:order-last';
+const scoreFieldClass = 'md:flex-1 md:min-w-[100px]';
 
 interface SortableRows {
   /** Row count, including synced placeholders. */
@@ -295,15 +305,19 @@ function PlaceholderRow({
 
   return (
     <>
-      {iconPosition !== 'inside' && linkButton}
-      <div className="flex-1 min-w-0 flex items-center gap-2 rounded-[--radius] bg-[--paper] border border-[--border] shadow-sm h-10 px-3 opacity-75 overflow-hidden">
+      <div className={rowControlsClass}>
+        {iconPosition !== 'inside' && (
+          <div className={rowLeadControlClass}>{linkButton}</div>
+        )}
+        <div className={rowActionsClass}>
+          <ItemActions rows={rows} index={index} />
+        </div>
+      </div>
+      <div className="md:flex-1 min-w-0 flex items-center gap-2 rounded-[--radius] bg-[--paper] border border-[--border] shadow-sm h-10 px-3 opacity-75 overflow-hidden">
         {iconPosition === 'inside' && linkButton}
         <span className="text-sm text-[--muted] font-mono truncate min-w-0 flex-1">
           {url}
         </span>
-      </div>
-      <div className="flex gap-1">
-        <ItemActions rows={rows} index={index} />
       </div>
     </>
   );
@@ -533,7 +547,10 @@ export function TextInputs({
           (v) => v,
           (value, index) => (
             <>
-              <div className="flex-1">
+              <div className={rowActionsClass}>
+                <ItemActions rows={rows} index={index} />
+              </div>
+              <div className="md:flex-1">
                 <TextInput
                   value={value}
                   aria-label={itemName}
@@ -542,9 +559,6 @@ export function TextInputs({
                     handleValueChange(newValue, index)
                   }
                 />
-              </div>
-              <div className="flex gap-1">
-                <ItemActions rows={rows} index={index} />
               </div>
             </>
           ),
@@ -653,20 +667,25 @@ export function ToggleableTextInputs({
           (v) => v.expression,
           (value, index) => (
             <>
-              <div className="shrink-0">
-                <Checkbox
-                  value={value.enabled ?? true}
-                  defaultValue={true}
-                  size="lg"
-                  aria-label="Enabled"
-                  onValueChange={(v) => {
-                    if (onEnabledChange) {
-                      onEnabledChange(v === true, index);
-                    }
-                  }}
-                />
+              <div className={rowControlsClass}>
+                <div className={rowLeadControlClass}>
+                  <Checkbox
+                    value={value.enabled ?? true}
+                    defaultValue={true}
+                    size="lg"
+                    aria-label="Enabled"
+                    onValueChange={(v) => {
+                      if (onEnabledChange) {
+                        onEnabledChange(v === true, index);
+                      }
+                    }}
+                  />
+                </div>
+                <div className={rowActionsClass}>
+                  <ItemActions rows={rows} index={index} />
+                </div>
               </div>
-              <div className="flex-1">
+              <div className="md:flex-1">
                 <TextInput
                   value={value.expression}
                   aria-label="Expression"
@@ -676,9 +695,6 @@ export function ToggleableTextInputs({
                     onExpressionChange(newValue, index)
                   }
                 />
-              </div>
-              <div className="flex gap-1">
-                <ItemActions rows={rows} index={index} />
               </div>
             </>
           ),
@@ -785,7 +801,10 @@ export function TwoTextInputs({
           (v) => v.value,
           (value, index) => (
             <>
-              <div className="flex-1">
+              <div className={rowActionsClass}>
+                <ItemActions rows={rows} index={index} />
+              </div>
+              <div className="md:flex-1">
                 <TextInput
                   value={value.name}
                   aria-label={keyName}
@@ -793,16 +812,13 @@ export function TwoTextInputs({
                   onValueChange={(newValue) => onKeyChange(newValue, index)}
                 />
               </div>
-              <div className="flex-1">
+              <div className="md:flex-1">
                 <TextInput
                   value={value.value}
                   aria-label={valueName}
                   placeholder={valuePlaceholder}
                   onValueChange={(newValue) => onValueChange(newValue, index)}
                 />
-              </div>
-              <div className="flex gap-1">
-                <ItemActions rows={rows} index={index} />
               </div>
             </>
           ),
@@ -910,20 +926,25 @@ export function RankedExpressionInputs({
           (v) => v.expression,
           (value, index) => (
             <>
-              <div className="shrink-0">
-                <Checkbox
-                  value={value.enabled ?? true}
-                  defaultValue={true}
-                  size="lg"
-                  aria-label="Enabled"
-                  onValueChange={(v) => {
-                    if (onEnabledChange) {
-                      onEnabledChange(v === true, index);
-                    }
-                  }}
-                />
+              <div className={rowControlsClass}>
+                <div className={rowLeadControlClass}>
+                  <Checkbox
+                    value={value.enabled ?? true}
+                    defaultValue={true}
+                    size="lg"
+                    aria-label="Enabled"
+                    onValueChange={(v) => {
+                      if (onEnabledChange) {
+                        onEnabledChange(v === true, index);
+                      }
+                    }}
+                  />
+                </div>
+                <div className={rowActionsClass}>
+                  <ItemActions rows={rows} index={index} />
+                </div>
               </div>
-              <div className="flex-[3]">
+              <div className="md:flex-[3]">
                 <TextInput
                   value={value.expression}
                   aria-label="Expression"
@@ -934,7 +955,7 @@ export function RankedExpressionInputs({
                   }
                 />
               </div>
-              <div className="flex-1 min-w-[100px]">
+              <div className={scoreFieldClass}>
                 <NumberInput
                   value={value.score || 0}
                   defaultValue={0}
@@ -947,9 +968,6 @@ export function RankedExpressionInputs({
                   max={1_000_000}
                   step={50}
                 />
-              </div>
-              <div className="flex gap-1">
-                <ItemActions rows={rows} index={index} />
               </div>
             </>
           ),
@@ -1054,7 +1072,10 @@ export function RankedRegexInputs({
           (v) => v.pattern,
           (value, index) => (
             <>
-              <div className="flex-[3]">
+              <div className={rowActionsClass}>
+                <ItemActions rows={rows} index={index} />
+              </div>
+              <div className="md:flex-[3]">
                 <TextInput
                   value={value.pattern}
                   aria-label="Pattern"
@@ -1062,7 +1083,7 @@ export function RankedRegexInputs({
                   onValueChange={(newValue) => onPatternChange(newValue, index)}
                 />
               </div>
-              <div className="flex-[2]">
+              <div className="md:flex-[2]">
                 <TextInput
                   value={value.name || ''}
                   aria-label="Name"
@@ -1070,7 +1091,7 @@ export function RankedRegexInputs({
                   onValueChange={(newValue) => onNameChange(newValue, index)}
                 />
               </div>
-              <div className="flex-1 min-w-[100px]">
+              <div className={scoreFieldClass}>
                 <NumberInput
                   value={value.score}
                   aria-label="Score"
@@ -1081,9 +1102,6 @@ export function RankedRegexInputs({
                   max={1_000_000}
                   step={50}
                 />
-              </div>
-              <div className="flex gap-1">
-                <ItemActions rows={rows} index={index} />
               </div>
             </>
           ),


### PR DESCRIPTION
Adds `@dnd-kit` drag-and-drop support to all five filter input components in the Filters menu, replacing the previous up/down arrow buttons.
 
### Changes
 
- **Drag-and-drop via `@dnd-kit`** — All five input list components (`TextInputs`, `ToggleableTextInputs`, `TwoTextInputs`, `RankedExpressionInputs`, `RankedRegexInputs`) now support dragging rows to reorder them. Uses the same pill grip handle and bordered card container design as the existing Primary Sort Order component.
 
- **Ref-based stable keys** — Uses `useRef`-backed persistent IDs for each row, mirroring the approach in `sorting.tsx`. This keeps drag animations smooth (key and sortable ID match) while preventing focus loss during text editing (key stays stable across keystrokes).
 
- **Excluded synced/placeholder rows from sortable context** — Placeholder rows (synced URLs) are visually rendered inside the list but excluded from `SortableContext`, preventing `@dnd-kit` from trying to animate phantom DOM nodes.
 
- **Removed up/down arrow buttons** — The `ItemActions` component now only shows a delete button. Reordering is handled entirely by drag-and-drop.
 
- **Fixed checkbox alignment** — Checkbox wrappers now use `items-end pb-1` to bottom-align with labeled text inputs, matching the action button alignment.
 
### Visual design
 
Each draggable row now renders with:
- A **rounded pill grip handle** (`rounded-full`, `bg-[--muted]` / `bg-[--subtle]`) that spans the full row height
- A **bordered card container** (`px-2.5 py-2 border rounded-[--radius-md]`) providing clear visual boundaries during drag transitions
- A `space-y-2` wrapper for consistent vertical spacing
 
### File changed
 
| File | + | − |
|------|---|---|
| `packages/frontend/src/components/menu/filters/_components/filter-inputs.tsx` | +624 | −252 |
 
### Priority behavior
 
For most fields, row position determines priority — drag a row higher to give it higher ranking in the sort/score pipeline. This applies to encodes, resolutions, qualities, visual/audio tags, languages, subtitles, stream types, services, release groups, stream expressions, and regex patterns. All of these use `findIndex()` or `.index` in the sorter.
 
**Exception: Keywords** — keyword matching is binary (contains/doesn't contain), so row order has no effect on filtering or sorting. The drag grip is still present on keyword lists for visual organization consistency across all `TextInputs` components.

Example UI change:
<img width="2074" height="837" alt="image" src="https://github.com/user-attachments/assets/f120b890-0988-4598-bff2-11c18fdae1c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for supported filter input lists.
  * Preserved synced placeholder rows while allowing other entries to be reordered.

* **UI Improvements**
  * Simplified item controls by using drag-and-drop for moving entries.
  * Retained delete actions for individual entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->