### PR TITLE
fix: make request body size limit configurable, raise default to 1mb

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,6 +57,11 @@ DATABASE_URI=sqlite://./data/db.sqlite
 # The port the addon listens on.
 # PORT=3000
 
+# Maximum request body size accepted by the server. Large configurations can
+# exceed Express' 100kb default, causing config saves to fail with
+# "request entity too large".
+# MAX_REQUEST_BODY_SIZE=1mb
+
 # Optionally override the internal URL used when communicating with built-in
 # addons. The default is fine for almost all setups.
 # INTERNAL_URL=http://localhost:3000

--- a/packages/core/src/config/bootstrap.ts
+++ b/packages/core/src/config/bootstrap.ts
@@ -7,6 +7,7 @@ import { Env } from '../utils/env.js';
 export const bootstrap = {
   nodeEnv: Env.NODE_ENV,
   port: Env.PORT,
+  maxRequestBodySize: Env.MAX_REQUEST_BODY_SIZE,
   baseUrl: Env.BASE_URL,
   internalUrl: Env.INTERNAL_URL,
   internalSecret: Env.INTERNAL_SECRET,

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -245,6 +245,10 @@ export const Env = cleanEnv(process.env, {
     default: 3000,
     desc: 'Port to run the addon on',
   }),
+  MAX_REQUEST_BODY_SIZE: str({
+    default: '1mb',
+    desc: 'Maximum request body size accepted by the server (e.g. 500kb, 1mb). Large configurations can exceed the previous 100kb default, causing config saves to fail with PayloadTooLargeError.',
+  }),
   SECRET_KEY: secretKey({
     desc: 'Session/encryption secret used to derive keys for stored configurations. Must be a 64-character hex string. Generate with `openssl rand -hex 32`. Cannot be changed after first run. (Legacy alias `SESSION_SECRET` is still accepted for one minor release.)',
     example: 'Generate using: openssl rand -hex 32',

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -97,8 +97,13 @@ export const staticRoot = path.join(__dirname, './static');
 
 app.use(ipMiddleware);
 app.use(loggerMiddleware);
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: appConfig.bootstrap.maxRequestBodySize }));
+app.use(
+  express.urlencoded({
+    extended: true,
+    limit: appConfig.bootstrap.maxRequestBodySize,
+  })
+);
 
 // Allow all origins in development for easier testing
 if (appConfig.bootstrap.nodeEnv === 'development') {


### PR DESCRIPTION
## Problem

A user reported being unable to save their configuration — the save request failed with:

```
PayloadTooLargeError: request entity too large
```

Their config payload was ~102KB. `express.json()` / `express.urlencoded()` are registered with no options in `packages/server/src/app.ts`, so they inherit Express' built-in **100kb** body limit. Any config with enough addons/groups/regex filters to push the JSON past 100KB becomes unsaveable, and the limit isn't tunable.

## Fix

- New env var `MAX_REQUEST_BODY_SIZE` (default `1mb`), exposed via the bootstrap config (it's needed at middleware-registration time, before the settings store is up).
- Applied to both `express.json()` and `express.urlencoded()`.
- Documented in `.env.sample`.

The 1mb default matches nginx's default `client_max_body_size`, so typical reverse-proxy setups won't need any accompanying proxy change.

## Verification

- `pnpm --filter @aiostreams/core --filter @aiostreams/server run build` passes.
- Booted the built server and exercised the parser directly:
  - 150KB JSON `PUT /api/v1/user` → passes the body parser (proceeds to auth validation) — previously 413.
  - 2MB JSON → still rejected by the parser, confirming the limit remains enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)