### PR TITLE
feat(presets): ingest Easynews++ subtitle languages from the 💬 line

### DIFF
--- a/packages/core/src/presets/easynewsPlusPlus.ts
+++ b/packages/core/src/presets/easynewsPlusPlus.ts
@@ -1,9 +1,15 @@
-import { ParsedStream, PresetMetadata, Stream } from '../db/index.js';
+import {
+  ParsedFile,
+  ParsedStream,
+  PresetMetadata,
+  Stream,
+} from '../db/index.js';
 import { EasynewsPreset, EasynewsParser } from './easynews.js';
 import { constants } from '../utils/index.js';
 import { baseOptions } from './preset.js';
 import { config as appConfig } from '../config/index.js';
 import { StreamParser } from '../parser/index.js';
+import { arrayMerge } from '../parser/merge.js';
 
 class EasynewsPlusPlusParser extends EasynewsParser {
   protected override get ageRegex(): RegExp {
@@ -26,6 +32,33 @@ class EasynewsPlusPlusParser extends EasynewsParser {
         ?.map((lang) => this.convertISO6392ToLanguage(lang.trim()))
         .filter((lang) => lang !== undefined) || []
     );
+  }
+
+  protected override getParsedFile(
+    stream: Stream,
+    parsedStream: ParsedStream
+  ): ParsedFile | undefined {
+    const parsedFile = super.getParsedFile(stream, parsedStream);
+    if (!parsedFile) {
+      return undefined;
+    }
+
+    // Easynews++ emits a `💬` subtitle-language line alongside the `🌐` audio
+    // line, using the same comma-separated ISO 639-2 codes. Parse it the same way
+    // getLanguages() handles audio, and merge into the file's subtitle languages.
+    const regex = this.getRegexForTextAfterEmojis(['💬']);
+    const subtitles =
+      stream.description
+        ?.match(regex)?.[1]
+        ?.split(',')
+        ?.map((lang) => this.convertISO6392ToLanguage(lang.trim()))
+        .filter((lang) => lang !== undefined) || [];
+
+    if (subtitles.length > 0) {
+      parsedFile.subtitles = arrayMerge(parsedFile.subtitles, subtitles);
+    }
+
+    return parsedFile;
   }
 }
 


### PR DESCRIPTION
## What

`EasynewsPlusPlusParser` reads audio languages from the `🌐` description line but has no path to subtitle languages, so `parsedFile.subtitles` stays empty for Easynews++.

As of v2.8.0 the Easynews++ addon emits a `💬` subtitle line parallel to `🌐`, using the same comma-separated ISO 639-2 codes:

```
🌐 deu, eng        ← audio (already parsed)
💬 eng, fra, deu   ← subtitles (new)
```

This overrides `getParsedFile()` — the same pattern `TorrentioParser` uses — to parse that line with the existing `getRegexForTextAfterEmojis` + `convertISO6392ToLanguage` helpers and merge into `parsedFile.subtitles` via `arrayMerge`.

## Why it's low-risk

- **Mirrors existing code:** identical parsing to `getLanguages()`, identical merge shape to `TorrentioParser.getParsedFile()`.
- **Backward-compatible:** instances/versions that don't emit a `💬` line produce no change (regex misses → `[]` → `subtitles` untouched). No effect on the default public instance or other forks.
- **Doesn't disturb the `🌐` audio parse:** `💬` has the `Emoji_Presentation` property, so it terminates the `🌐` capture; description lines are newline-joined.
- **Codes resolve directly:** the addon emits ISO 639-2/T codes, matching `convertISO6392ToLanguage`.

## Notes

- The `💬` marker is a convention chosen for symmetry with the existing `🌐` audio line — happy to switch it (`📝`/`🔤`, etc.) if you'd prefer.
- Verified locally: `pnpm -F core build` (tsc) passes and Prettier is clean.
- The `💬` line is emitted by the actively-maintained Easynews++ fork that panteLx handed the addon over to: https://github.com/Varming73/easynews-plus-plus (v2.8.0+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting subtitle language information in Easynews++ results.
  * Subtitle languages are now parsed and displayed when provided in the source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->