### PR TITLE
fix(debrid): fall back to manual traversal when a deep WebDAV listing returns no files

### DIFF
--- a/packages/core/src/debrid/usenet-stream-base.ts
+++ b/packages/core/src/debrid/usenet-stream-base.ts
@@ -525,6 +525,25 @@ export abstract class UsenetStreamService implements UsenetDebridService {
 
       const files = contents.filter((item) => item.type === 'file');
 
+      // Some WebDAV servers (e.g. NWebDav-based ones like NzbDAV) answer a
+      // `Depth: infinity` PROPFIND with 207 but only depth-1 results instead
+      // of the RFC 4918 403 propfind-finite-depth rejection. A "successful"
+      // deep listing that contains directories but no files is therefore
+      // indistinguishable from a truncated one — fall back to manual
+      // traversal rather than reporting an empty download (bites releases
+      // whose video sits inside a nested folder, e.g.
+      // Release.Name/Release.Name/video.mkv scene layouts).
+      if (
+        files.length === 0 &&
+        contents.some((item) => item.type === 'directory')
+      ) {
+        this.serviceLogger.debug(
+          `Deep listing returned directories but no files; falling back to manual traversal`,
+          { path }
+        );
+        return this.collectFilesManually(path, 0);
+      }
+
       return { files, depth: 0 };
     } catch (error) {
       this.serviceLogger.warn(


### PR DESCRIPTION
### The bug
`UsenetStreamService.collectFiles` first tries `getDirectoryContents(path, { deep: true })`, which sends a `Depth: infinity` PROPFIND — and trusts any successful response. Some WebDAV servers (NWebDav-based ones like NzbDAV among them) don't support infinite depth but, instead of the RFC 4918 §9.1 rejection (403 + `propfind-finite-depth`), answer **207 with only depth-1 results**. For releases whose video sits inside a nested folder (the classic `Release.Name/Release.Name/video.mkv` + `Subs/` scene layout), the "successful" listing contains only directories, so `_resolve` throws `NO_MATCHING_FILE` ("No files found in NZB download") — even though the video is reachable one level down and `collectFilesManually` would have found it.

Observed in production against NzbDAV: flat releases play fine, nested-layout releases fail on every attempt.

### The fix
If the deep listing succeeds but yields zero files while containing at least one directory, fall back to `collectFilesManually` (the existing depth-limited recursive walk) instead of returning the empty result. Well-behaved servers are unaffected (a genuine empty download still resolves empty — the manual walk confirms it), and servers that soft-fail infinite depth now get the same treatment as servers that reject it outright.

We're also fixing the server side in NzbDAV (returning the RFC-compliant 403 so clients' existing catch-and-fallback paths engage), but this client-side guard protects against every server with this behavior, not just that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebDAV file discovery when directory-only listings are returned.
  * Automatically retries file collection in these cases, preventing valid files from being missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->