### PR TITLE
fix(torbox): route usenet resolve through StremThru like torrent resolve

### DIFF
--- a/packages/core/src/debrid/torbox.ts
+++ b/packages/core/src/debrid/torbox.ts
@@ -633,7 +633,7 @@ export class TorboxDebridService
     autoRemoveDownloads?: boolean,
     signal?: AbortSignal
   ): Promise<string | undefined> {
-    if (playbackInfo.type === 'torrent') {
+    if (playbackInfo.type === 'torrent' || playbackInfo.type === 'usenet') {
       return this.stremthru.resolve(
         playbackInfo,
         filename,


### PR DESCRIPTION
```markdown
## What
Routes TorBox usenet-type resolve through `StremThruService.resolve()`,
the same path torrent-type resolve already uses — instead of calling
TorBox's own usenet API directly.

## Why
Fixes #1135 (and likely the same root cause as #891). The direct
TorBox usenet API path (`addNzb()` -> `generateUsenetLink()` ->
`requestDownloadLink()`) has proven unreliable in practice across
multiple independent reproductions (see #1135 for the full evidence
chain: NZBHydra2 bypassed, fresh-NZB vs. already-downloaded-library-item
both isolated to the same final call, confirmed not a stale-credential
issue).

`StremThruService` already has a complete, working usenet resolve
implementation (`_resolveUsenet()`/`addNzb()`), currently only used
for the `torbox` service's torrent-type playback. The
`capabilities: { usenet: false }` flag set on the `TorboxDebridService`
constructor's internal `StremThruService` instance only gates
`refreshLibraryCache()` (a cache warm-up helper) — it does not gate
`resolve()`, which already branches on `playbackInfo.type` internally
and handles both torrent and usenet regardless of that flag.

This change is a minimal routing change: it does not remove the
existing direct-TorBox usenet path (`_resolve()`, `addNzb()`,
`generateUsenetLink()`), which is now unused but left in place in case
there's a reason to keep it (happy to remove in a follow-up if
preferred).

## Testing
- `tsc --noEmit` on the changed file shows the same error count before
  and after (16, all pre-existing/unrelated to this change — missing
  local dependency type declarations, not from this edit).
- Could not run a full live end-to-end test against TorBox's API from
  my environment (no ability to run the full stack locally with a
  live TorBox Pro account in this context) — would appreciate someone
  with a working TorBox Pro + usenet setup testing this against a
  real NZB before merge.

## Related
#1135, #891
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback resolution for Usenet content, providing more consistent handling alongside torrent content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->