### PR TITLE
fix(failover): wrap to the top of the list when the tail is exhausted

### DIFF
--- a/packages/core/src/main/play-chain.ts
+++ b/packages/core/src/main/play-chain.ts
@@ -309,6 +309,9 @@ function targetIdentity(it: PlayChainItem): string {
  * de-duplication by resolvable target (so a release surviving dedup or harvested
  * under multiple winners is never tried twice), and the overall `maxAttempts` cap
  * — done last so dedup never shrinks the effective budget.
+ *
+ * Targets run from the clicked item to the end of the list, then wrap around
+ * from the top.
  */
 export async function getPlayChain(
   decoded: { index: number; count: number; listKey: string },
@@ -356,8 +359,13 @@ export async function getPlayChain(
   addVariants(clickedItem?.variants, 0);
 
   // Then each subsequent distinct release (increasing rank) + its variants.
+  // Tail first, then wrap to the head; a click near the bottom has little below it.
+  const ordered = [
+    ...record.items.slice(decoded.index + 1),
+    ...record.items.slice(0, Math.max(decoded.index, 0)),
+  ];
   let rank = 1;
-  for (const item of record.items.slice(decoded.index + 1)) {
+  for (const item of ordered) {
     if (fallbacks.length >= maxAttempts) break;
     if (!passesFilter(item)) continue;
     const key = targetIdentity(item);


### PR DESCRIPTION
Closes #1139.

`getPlayChain` built its failover candidates from `record.items.slice(decoded.index + 1)`, so only releases below the clicked one were ever considered. Clicking near the bottom of the list left very few targets and clicking the last entry left none, which made failover silently do nothing on exactly the clicks most likely to need it.

The candidate list now continues from the top of the list once the tail is exhausted, skipping the clicked item itself.

Ordering is unchanged for anyone whose forward slice already fills the attempt budget: the items below the click still come first, and the wrapped items are only appended after those run out. Everything downstream (type filtering, `sameReleaseLimit`, dedup by target identity, the `maxAttempts` cap) is untouched and still applies to the combined list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failover target selection by checking remaining targets from the clicked position first, then wrapping around to earlier targets.
  * Preserved existing filtering, deduplication and variant handling during fallback selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->