### PR TITLE
feat(library): classify debridge usenet rows

### DIFF
--- a/packages/core/src/builtins/library/catalog.test.ts
+++ b/packages/core/src/builtins/library/catalog.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { libraryCatalogItemType } from './catalog.js';
+
+describe('libraryCatalogItemType', () => {
+  it('renders debridge usenet library rows in the usenet lane', () => {
+    assert.equal(libraryCatalogItemType({ libraryType: 'usenet' }), 'usenet');
+  });
+
+  it('keeps existing library rows in the torrent lane by default', () => {
+    assert.equal(libraryCatalogItemType({}), 'torrent');
+  });
+});

--- a/packages/core/src/builtins/library/catalog.ts
+++ b/packages/core/src/builtins/library/catalog.ts
@@ -45,6 +45,12 @@ interface ParsedCatalogItem {
   normalisedTitle: string;
 }
 
+export function libraryCatalogItemType(
+  item: Pick<DebridDownload, 'libraryType'>
+): 'torrent' | 'usenet' {
+  return item.libraryType === 'usenet' ? 'usenet' : 'torrent';
+}
+
 function parseCatalogItems(items: CatalogItem[]): ParsedCatalogItem[] {
   return items.map((item) => {
     const parsed = parseTorrentTitle(item.name ?? '');
@@ -159,7 +165,7 @@ export async function fetchCatalog(
         ...item,
         serviceId,
         serviceCredential,
-        itemType: 'torrent',
+        itemType: libraryCatalogItemType(item),
       });
     }
   } else {

--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -161,6 +161,7 @@ export type DebridFile = z.infer<typeof DebridFileSchema>;
 export interface DebridDownload {
   id: string | number;
   library?: boolean;
+  libraryType?: 'torrent' | 'usenet';
   hash?: string;
   name?: string;
   private?: boolean;

--- a/packages/core/src/debrid/stremthru.test.ts
+++ b/packages/core/src/debrid/stremthru.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { mapStremThruLibraryItems } from './stremthru.js';
+
+describe('mapStremThruLibraryItems', () => {
+  it('marks debridge usenet rows carried by the StremThru library list', () => {
+    const rows = [
+      {
+        id: 'rd-1',
+        hash: 'torrent-hash',
+        name: 'Torrent.Movie.2024.mkv',
+        size: 100,
+        status: 'downloaded',
+        added_at: '2026-07-29T00:00:00Z',
+        kind: 'realdebrid',
+      },
+      {
+        id: 'usenet-hash',
+        hash: 'usenet-hash',
+        name: 'Usenet.Movie.2024.mkv',
+        size: 200,
+        status: 'downloaded',
+        added_at: '2026-07-29T01:00:00Z',
+        // Debridge /v1/library uses kind=usenet for recent usenet mints.
+        kind: 'usenet',
+      },
+    ];
+
+    const mapped = mapStremThruLibraryItems(rows, 'torrent');
+
+    assert.deepEqual(
+      mapped.map((item) => [item.id, item.libraryType]),
+      [
+        ['rd-1', 'torrent'],
+        ['usenet-hash', 'usenet'],
+      ]
+    );
+  });
+
+  it('treats untyped rows from native newz endpoints as usenet', () => {
+    const rows = [
+      {
+        id: 'newz-1',
+        hash: 'nzb-hash',
+        name: 'NZB.Movie.2024.mkv',
+        size: 200,
+        status: 'downloaded',
+        added_at: '2026-07-29T01:00:00Z',
+      },
+    ];
+
+    assert.deepEqual(mapStremThruLibraryItems(rows, 'usenet'), [
+      {
+        id: 'newz-1',
+        hash: 'nzb-hash',
+        name: 'NZB.Movie.2024.mkv',
+        size: 200,
+        status: 'downloaded',
+        private: undefined,
+        addedAt: '2026-07-29T01:00:00Z',
+        libraryType: 'usenet',
+      },
+    ]);
+  });
+});

--- a/packages/core/src/debrid/stremthru.ts
+++ b/packages/core/src/debrid/stremthru.ts
@@ -42,6 +42,48 @@ function convertStremThruError(error: StremThruError): DebridError {
   });
 }
 
+type StremThruLibraryType = 'torrent' | 'usenet';
+
+type RawStremThruLibraryItem = {
+  id: string | number;
+  hash?: string;
+  name?: string;
+  size?: number;
+  status: DebridDownload['status'];
+  private?: boolean;
+  added_at?: string;
+  kind?: string;
+  type?: string;
+  source?: string;
+};
+
+function stremThruLibraryType(
+  item: RawStremThruLibraryItem,
+  fallback: StremThruLibraryType
+): StremThruLibraryType {
+  return [item.kind, item.type, item.source].some(
+    (value) => typeof value === 'string' && value.toLowerCase() === 'usenet'
+  )
+    ? 'usenet'
+    : fallback;
+}
+
+export function mapStremThruLibraryItems(
+  items: RawStremThruLibraryItem[],
+  fallbackType: StremThruLibraryType
+): DebridDownload[] {
+  return items.map((item) => ({
+    id: item.id,
+    hash: item.hash,
+    name: item.name,
+    size: item.size,
+    status: item.status as DebridDownload['status'],
+    private: item.private,
+    addedAt: item.added_at,
+    libraryType: stremThruLibraryType(item, fallbackType),
+  }));
+}
+
 export interface StremThruServiceConfig {
   serviceName: ServiceId;
   clientIp?: string;
@@ -450,17 +492,12 @@ export class StremThruService
         offset,
       });
       totalItems = Math.min(result.data.total_items, maxItems);
-      for (const item of result.data.items) {
-        allItems.push({
-          id: item.id,
-          hash: item.hash,
-          name: item.name,
-          size: (item as any).size,
-          status: item.status,
-          private: item.private,
-          addedAt: item.added_at,
-        });
-      }
+      allItems.push(
+        ...mapStremThruLibraryItems(
+          result.data.items as RawStremThruLibraryItem[],
+          'torrent'
+        )
+      );
       offset += limit;
       if (result.data.items.length < limit) break;
     }
@@ -721,16 +758,12 @@ export class StremThruService
           offset,
         });
         totalItems = Math.min(result.data.total_items, maxItems);
-        for (const item of result.data.items) {
-          allItems.push({
-            id: item.id,
-            hash: item.hash,
-            name: item.name,
-            size: item.size,
-            status: item.status as DebridDownload['status'],
-            addedAt: item.added_at,
-          });
-        }
+        allItems.push(
+          ...mapStremThruLibraryItems(
+            result.data.items as RawStremThruLibraryItem[],
+            'usenet'
+          )
+        );
         offset += limit;
         if (result.data.items.length < limit) break;
       } catch (error) {


### PR DESCRIPTION
## Summary
- Preserve a `libraryType` on StremThru library rows.
- Treat mixed StremThru/Debridge rows with `kind|type|source = usenet` as usenet in AIOStreams' Library catalog.
- Keep normal torrent rows defaulting to torrent and native `listNewz` rows defaulting to usenet.

## Test Plan
- `corepack pnpm -F core test -- --test-name-pattern 'mapStremThruLibraryItems|libraryCatalogItemType'`
- `corepack pnpm -F core test`
- `corepack pnpm -F core build`

## Notes
This pairs with Debridge's existing `/v1/library` mixed library response, where recent usenet mints are emitted with `kind: "usenet"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Library items are now correctly identified as either torrents or Usenet downloads.
  - StremThru library entries are mapped consistently across torrent and Usenet sources.
  - Download details such as status, size, privacy, and added date are handled consistently when displaying library items.

- **Bug Fixes**
  - Fixed magnet catalog entries being incorrectly labelled as torrents when they belong to the Usenet library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->