### PR TITLE
fix: preserve addon-provided subtitles field on Stream objects

### DIFF
--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -109,6 +109,7 @@ class StreamParser {
       servers: stream.servers ?? undefined,
       externalUrl: stream.externalUrl ?? undefined,
       ytId: stream.ytId ?? undefined,
+      subtitles: stream.subtitles ?? undefined,
       requestHeaders: stream.behaviorHints?.proxyHeaders?.request,
       responseHeaders: stream.behaviorHints?.proxyHeaders?.response,
       notWebReady: stream.behaviorHints?.notWebReady ?? undefined,


### PR DESCRIPTION
## Summary
- `StreamParser.parse()` builds `parsedStream` by explicitly copying a set of optional fields from the raw addon `stream` (`nzbUrl`, `tarUrls`, `tgzUrls`, `7zipUrls`, `rarUrls`, `servers`, `externalUrl`, `ytId`, ...) but never copied `subtitles`, even though both the raw `Stream` schema and the internal `ParsedStream` schema define an identical `subtitles: z.array(SubtitleSchema).optional()` field, and the Stremio output transformer already unconditionally passes it through (`subtitles: stream.subtitles` in `transformers/stremio.ts`).
- This silently drops subtitles for any addon that embeds them directly on `Stream` objects (per the Stremio protocol) instead of exclusively serving them through the dedicated `subtitles` resource.
- One-line fix: copy `stream.subtitles` into `parsedStream.subtitles`, coalescing `null` to `undefined` to match the internal schema.

## Test plan
- [x] Confirmed via a custom addon (Yukistreams) that raw stream responses include a populated `subtitles` array, but AIOStreams' output previously never carried it through.
- [x] Confirmed this is unrelated to `Format Passthrough` / `Result Passthrough`, since both operate on the already-constructed `ParsedStream`, after the field would already have been dropped.
- [ ] Would appreciate a maintainer sanity-check on the `?? undefined` null-coalescing against the exact `SubtitleSchema` typing, and a run through CI.

Fixes #1154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parsed streams now retain subtitle information when available.
  * Streams without subtitles continue to be handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->