### PR TITLE
feat: add Torrin as a usenet-capable store

### DIFF
--- a/packages/core/src/debrid/index.ts
+++ b/packages/core/src/debrid/index.ts
@@ -82,6 +82,21 @@ export function getDebridService(
       return createStremThruNewzService(config, pollInterval, maxWaitTime);
     case constants.AIOSTREAMS_SERVICE:
       return new NativeUsenetService(config);
+    case constants.TORRIN_SERVICE:
+      return new StremThruService({
+        serviceName,
+        clientIp: config.clientIp,
+        stremthru: {
+          baseUrl: appConfig.builtins.stremthru.url,
+          store: serviceName,
+          token: config.token,
+        },
+        capabilities: { torrents: true, usenet: true },
+        cacheAndPlayOptions: {
+          pollingInterval: pollInterval,
+          maxWaitTime: maxWaitTime,
+        },
+      });
     default:
       if (StremThruPreset.supportedServices.includes(serviceName)) {
         return new StremThruService({


### PR DESCRIPTION
The `torrin` service currently falls to the default StremThru case, which has usenet disabled, so its newz store is never reached and usenet results are treated as torrents.

This routes `torrin` through `StremThruService` with usenet enabled, so uncached usenet is served from Torrin's newz store and typed as usenet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Torrin debrid service, including torrent and Usenet access.
  * Configured service connection, authentication, polling and wait times for reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->