### PR TITLE
fix(builtins/nab): apply seasonEpisodeStrategy for indexers without ID support

### DIFF
--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -193,6 +193,31 @@ export abstract class BaseNabAddon<
       queryParams.ep = `${mm}/${dd}`;
     }
 
+    queryParams.extended = '1';
+
+    const canApplySeasonPackStrategy =
+      parsedId.mediaType === 'series' &&
+      !this.userData.forceQuerySearch &&
+      !isDailySearch &&
+      searchCapabilities.supportedParams.includes('season') &&
+      queryParams.season &&
+      queryParams.ep;
+
+    let primaryParams = queryParams;
+    let fallbackParams: Record<string, string> | undefined;
+    if (canApplySeasonPackStrategy) {
+      const { ep, ...seasonOnlyParams } = queryParams;
+      let strategy = this.userData.seasonEpisodeStrategy;
+      if (strategy === 'dynamic') {
+        strategy = metadata.ongoingSeason ? 'episode' : 'season';
+      }
+      if (strategy === 'season') {
+        primaryParams = seasonOnlyParams;
+      } else if (strategy === 'episodeFirst') {
+        fallbackParams = seasonOnlyParams;
+      }
+    }
+
     let queries: string[] = [];
     if (
       !queryParams.imdbid &&
@@ -215,41 +240,26 @@ export abstract class BaseNabAddon<
       });
       searchType = 'query';
     }
-    queryParams.extended = '1';
     let results: SearchResultItem<A['namespace']>[] = [];
     if (queries.length > 0) {
-      this.logger.debug('Performing queries', { queries });
-      const searchPromises = queries.map((q) =>
-        queryLimit(() =>
-          this.fetchResults(searchFunction, { ...queryParams, q })
-        )
-      );
-      const allResults = await Promise.all(searchPromises);
-      results = allResults.flat();
-    } else {
-      const canApplySeasonPackStrategy =
-        parsedId.mediaType === 'series' &&
-        !this.userData.forceQuerySearch &&
-        !isDailySearch &&
-        searchCapabilities.supportedParams.includes('season') &&
-        queryParams.season &&
-        queryParams.ep;
+      const runQueries = (params: Record<string, string>) => {
+        this.logger.debug('Performing queries', { queries });
+        return Promise.all(
+          queries.map((q) =>
+            queryLimit(() => this.fetchResults(searchFunction, { ...params, q }))
+          )
+        ).then((allResults) => allResults.flat());
+      };
 
-      let primaryParams = queryParams;
-      let fallbackParams: Record<string, string> | undefined;
-      if (canApplySeasonPackStrategy) {
-        const { ep, ...seasonOnlyParams } = queryParams;
-        let strategy = this.userData.seasonEpisodeStrategy;
-        if (strategy === 'dynamic') {
-          strategy = metadata.ongoingSeason ? 'episode' : 'season';
-        }
-        if (strategy === 'season') {
-          primaryParams = seasonOnlyParams;
-        } else if (strategy === 'episodeFirst') {
-          fallbackParams = seasonOnlyParams;
-        }
+      results = await runQueries(primaryParams);
+      if (results.length === 0 && fallbackParams) {
+        this.logger.debug(
+          'No results for initial queries, retrying with alternate season/episode params',
+          { season: queryParams.season, episode: queryParams.ep }
+        );
+        results = await runQueries(fallbackParams);
       }
-
+    } else {
       results = await this.fetchResults(searchFunction, primaryParams);
       if (results.length === 0 && fallbackParams) {
         this.logger.debug(


### PR DESCRIPTION
Indexers that support season/ep params but no ID field (e.g. TorrentLeech) always fell into the text-query branch, which merged raw season/ep params untouched - silently ignoring seasonEpisodeStrategy regardless of what was configured. Hoist the strategy resolution (primary/fallback params) so it runs once before the query-vs-ID branch split, and have both branches consume the same resolved params. Default (episode) behavior is unchanged.

---

I also manually tested this with TL for tt2861424:1:1. Before no result was returned, after it rerturns 14 results.

While working on this I noticed another edge case thing. The torznab test button returned that TL supports ID search. While it does do so for movies, it does not for tv shows. I might open another PR to improve the test button behaviour slightly.

fyi @Damian-11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search accuracy for TV seasons and episodes.
  * Added fallback searches when initial query results are empty.
  * Preserved reliable handling for endpoint-based and daily searches.

* **Performance**
  * Search requests now run efficiently while limiting concurrent activity.
  * Results include expanded information where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->