### PR TITLE
fix(builtins/nab): break down ID search support by media type in connection test

### DIFF
--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -275,9 +275,30 @@ export type NabTestResult = {
   server?: Capabilities['server'];
   limits?: Capabilities['limits'];
   searchModes?: string[];
-  idSearchParams?: string[];
+  /** ID params actually usable per media type - movie-search/tv-search each advertise their own supportedParams, and one may support IDs while the other doesn't. */
+  idSearchParams?: { movie: string[]; series: string[] };
   resultCount?: number;
   error?: { code?: number; message: string };
+};
+
+/**
+ * Mirrors BaseNabAddon.getSearchFunction's matching: a keyword-matching
+ * function (e.g. "movie"/"tv") if available, else the generic `search`.
+ */
+const findIdSearchParams = (
+  searching: Capabilities['searching'],
+  keyword: string
+): string[] => {
+  const key = Object.keys(searching).find((s) =>
+    s.toLowerCase().includes(keyword)
+  );
+  const fn =
+    (key && searching[key]?.available && searching[key]) ||
+    (searching.search?.available && searching.search) ||
+    undefined;
+  return (fn?.supportedParams ?? []).filter((param) =>
+    NAB_ID_SEARCH_PARAMS.includes(param)
+  );
 };
 
 const resolveTestStage = (
@@ -487,15 +508,10 @@ export class BaseNabApi<N extends 'torznab' | 'newznab'> {
       server: capabilities.server,
       limits: capabilities.limits,
       searchModes: available.map(([name]) => name),
-      idSearchParams: [
-        ...new Set(
-          available.flatMap(([, fn]) =>
-            (fn.supportedParams ?? []).filter((param) =>
-              NAB_ID_SEARCH_PARAMS.includes(param)
-            )
-          )
-        ),
-      ],
+      idSearchParams: {
+        movie: findIdSearchParams(capabilities.searching, 'movie'),
+        series: findIdSearchParams(capabilities.searching, 'tv'),
+      },
     };
 
     try {

--- a/packages/frontend/src/components/shared/template-option.tsx
+++ b/packages/frontend/src/components/shared/template-option.tsx
@@ -692,7 +692,7 @@ interface NabTestResult {
     max?: number | string | boolean;
   };
   searchModes?: string[];
-  idSearchParams?: string[];
+  idSearchParams?: { movie: string[]; series: string[] };
   resultCount?: number;
   error?: { code?: number; message: string };
 }
@@ -702,6 +702,22 @@ const NAB_TEST_STAGE_HINTS: Record<string, string> = {
   auth: 'The endpoint is reachable, but the API key was rejected.',
   search: 'The endpoint is reachable, but the search request failed.',
 };
+
+function describeIdSearch(
+  idSearchParams: NabTestResult['idSearchParams']
+): string {
+  const movie = idSearchParams?.movie ?? [];
+  const series = idSearchParams?.series ?? [];
+  if (movie.length === 0 && series.length === 0) {
+    return 'No ID search, results are matched by title only';
+  }
+  const sameForBoth =
+    movie.length === series.length && movie.every((p) => series.includes(p));
+  if (sameForBoth) {
+    return `ID search: ${movie.join(', ')}`;
+  }
+  return `ID search: ${movie.length ? movie.join(', ') : 'none'} (movies), ${series.length ? series.join(', ') : 'none'} (series)`;
+}
 
 export interface NabEndpointInputProps {
   option: Option;
@@ -866,12 +882,8 @@ function NabTestSummary({ result }: { result: NabTestResult }) {
     );
   }
 
-  const supportsIdSearch = !!result.idSearchParams?.length;
-
   const details = [
-    supportsIdSearch
-      ? `ID search: ${result.idSearchParams!.join(', ')}`
-      : 'No ID search, results are matched by title only',
+    describeIdSearch(result.idSearchParams),
     result.resultCount !== undefined && `${result.resultCount} results`,
     result.limits?.max !== undefined && `max ${result.limits.max} per request`,
     result.searchModes?.length && `supports ${result.searchModes.join(', ')}`,


### PR DESCRIPTION
The Test button aggregated idSearchParams across all search modes (movie-search, tv-search, etc.), so an indexer supporting imdbid only for movie-search (like TorrentLeech) misleadingly reported ID search as available in general - even though series searches, which use tv-search specifically, had no ID support at all and silently fell back to query search. Resolve ID params per media type the same way the runtime search does (type-specific function, falling back to the generic search function), and show movie/series separately in the UI when they differ.

---

found this while working on https://github.com/Viren070/AIOStreams/pull/1165

before

<img width="492" height="196" alt="image" src="https://github.com/user-attachments/assets/c854f0f8-283f-4f6f-b8b3-2f761c86fdc9" />


after

<img width="480" height="210" alt="image" src="https://github.com/user-attachments/assets/1a28da45-7c8e-49a7-9344-ed1a4dbfb65d" />

---


couple more examples

PrivateHD

<img width="480" height="159" alt="image" src="https://github.com/user-attachments/assets/413ba526-71fd-4ae4-b24d-595bdc5c120b" />


FileList

<img width="482" height="156" alt="image" src="https://github.com/user-attachments/assets/e8bddbf5-478f-4bcf-8516-6a13470e2ce9" />


RocketHD

<img width="479" height="142" alt="image" src="https://github.com/user-attachments/assets/b923a933-32fe-464d-abab-350b74076207" />


ThePirateBay

<img width="493" height="185" alt="image" src="https://github.com/user-attachments/assets/360df173-be83-4743-8e87-70c8664e45cd" />


Nyaa.si

<img width="494" height="198" alt="image" src="https://github.com/user-attachments/assets/b0183f3d-8165-45e9-8086-8fcedebdab6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NAB connection test results now show supported ID-search options separately for movies and series.
  - Results distinguish between no ID search, shared search options, and media-specific options.

- **Bug Fixes**
  - Improved reporting of supported ID fields by selecting recognised, media-appropriate search parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->