### PR TITLE
fix: use the static middleware by express

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -259,15 +259,13 @@ app.use('/blocklist', publicBlocklistRouter);
 // change, so they are immutable and safe to cache aggressively. Deliberately
 // NOT behind staticRateLimiter: a single page load pulls many of these and
 // rate-limiting them is what caused asset fetch failures + the logo flash.
-app.get('/assets/*any', (req, res, next) => {
-  const filePath = path.resolve(frontendRoot, req.path.replace(/^\//, ''));
-  if (filePath.startsWith(frontendRoot) && fs.existsSync(filePath)) {
-    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-    res.sendFile(filePath);
-    return;
-  }
-  next();
-});
+app.use(
+  '/assets',
+  express.static(path.join(frontendRoot, 'assets'), {
+    immutable: true,
+    maxAge: '1y',
+  })
+);
 
 // Root-level static files (not content-hashed). Short cache; kept behind the
 // static rate limiter. The logo honours the alternate-design branding flag.
@@ -297,29 +295,10 @@ app.get(
     '/logo_alt.png',
   ],
   staticRateLimiter,
-  (req, res, next) => {
-    const filePath = path.resolve(frontendRoot, req.path.replace(/^\//, ''));
-    if (filePath.startsWith(frontendRoot) && fs.existsSync(filePath)) {
-      res.setHeader('Cache-Control', 'public, max-age=3600');
-      res.sendFile(filePath);
-      return;
-    }
-    next();
-  }
+  express.static(frontendRoot, { index: false, maxAge: '1h' })
 );
 
-app.get('/static/*any', corsMiddleware, (req, res, next) => {
-  const filePath = path.resolve(
-    staticRoot,
-    req.path.replace(/^\/static\//, '')
-  );
-  logger.debug(`Static file requested: ${filePath}`);
-  if (filePath.startsWith(staticRoot) && fs.existsSync(filePath)) {
-    res.sendFile(filePath);
-    return;
-  }
-  next();
-});
+app.use('/static', corsMiddleware, express.static(staticRoot));
 
 // legacy route handlers
 app.get(


### PR DESCRIPTION
this should theoretically help with performance, since static is async

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching for frontend assets, helping pages and static resources load faster.
  * Added long-term caching for versioned assets while retaining shorter caching for core frontend files.

* **Compatibility**
  * Improved cross-origin access for static resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->