### PR TITLE
Fix link to config expressions documentation

### DIFF
--- a/packages/frontend/src/components/menu/miscellaneous/_components/variants/index.tsx
+++ b/packages/frontend/src/components/menu/miscellaneous/_components/variants/index.tsx
@@ -91,7 +91,7 @@ export function Variants() {
           for a second formatter, a different debrid account, or a tighter
           filter set without maintaining a second config.{' '}
           <a
-            href="https://aiostreams.viren070.me/docs/reference/config-expressions"
+            href="https://docs.aiostreams.viren070.me/reference/config-expressions"
             target="_blank"
             rel="noreferrer"
             className="underline"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the configuration expressions documentation link in the variants interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->