### PR TITLE
feat(presets/newznab): group indexers by api key requirement, link nzb-sources

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -324,6 +324,10 @@ const OptionDefinition = z.looseObject({
         label: z.string().min(1),
         // for 'nab-endpoint': where this indexer shows the user their api key
         apiKeyUrl: z.string().url().optional(),
+        // for 'nab-endpoint': true if this indexer needs no api key at all
+        noApiKeyRequired: z.boolean().optional(),
+        // non-selectable, e.g. a section header separating grouped options
+        disabled: z.boolean().optional(),
       })
     )
     .optional(),

--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -30,21 +30,33 @@ const NEWZNAB_INDEXERS: {
   label: string;
   value: string;
   apiKeyUrl?: string;
+  noApiKeyRequired?: boolean;
 }[] = [
   {
     label: 'altHUB',
     value: 'https://api.althub.co.za/api',
     apiKeyUrl: 'https://althub.co.za/profile',
   },
-  // AnimeTosho needs no key at all
-  { label: 'AnimeTosho', value: 'https://feed.animetosho.org/api' },
+  {
+    label: 'AnimeTosho',
+    value: 'https://feed.animetosho.org/api',
+    noApiKeyRequired: true,
+  },
   {
     label: 'AnimeTosho (NEW)',
     value: 'https://feed.animetosho.xyz/api',
     apiKeyUrl: 'https://animetosho.xyz/profile',
   },
-  { label: 'Aninzb', value: 'https://aninzb.moe/api' },
-  { label: 'ClubNZB', value: 'https://clubnzb.com/api' },
+  {
+    label: 'Aninzb',
+    value: 'https://aninzb.moe/api',
+    noApiKeyRequired: true,
+  },
+  {
+    label: 'ClubNZB',
+    value: 'https://clubnzb.com/api',
+    noApiKeyRequired: true,
+  },
   { label: 'DOGnzb', value: 'https://api.dognzb.cr/api' },
   {
     label: 'DrunkenSlug',
@@ -86,10 +98,15 @@ const NEWZNAB_INDEXERS: {
     value: 'https://api.nzbplanet.net/api',
     apiKeyUrl: 'https://nzbplanet.net/profile',
   },
-  { label: 'NZBStars', value: 'https://nzbstars.com/api' },
+  {
+    label: 'NZBStars',
+    value: 'https://nzbstars.com/api',
+    noApiKeyRequired: true,
+  },
   {
     label: 'Treasure Maps (formerly SceneNZBs)',
     value: 'https://treasure-maps.com/api',
+    apiKeyUrl: 'https://treasure-maps.com/account',
   },
   {
     label: 'Tabula Rasa',
@@ -106,6 +123,13 @@ const NEWZNAB_INDEXERS: {
     value: 'https://www.usenet-crawler.com/api',
     apiKeyUrl: 'https://www.usenet-crawler.com/profile',
   },
+];
+
+const NEWZNAB_INDEXER_OPTIONS = [
+  { label: 'No API key required', value: '__group_no_key__', disabled: true },
+  ...NEWZNAB_INDEXERS.filter((indexer) => indexer.noApiKeyRequired),
+  { label: 'Requires API key', value: '__group_needs_key__', disabled: true },
+  ...NEWZNAB_INDEXERS.filter((indexer) => !indexer.noApiKeyRequired),
 ];
 
 export class NewznabPreset extends BuiltinAddonPreset {
@@ -144,10 +168,10 @@ export class NewznabPreset extends BuiltinAddonPreset {
             id: 'url',
             name: 'Newznab URL',
             description:
-              'Pick an indexer, or choose `Custom` to enter the full URL of the Newznab API endpoint (including the path, usually `/api`).',
+              'Pick an indexer, or choose `Custom` to enter the full URL of the Newznab API endpoint (including the path, usually `/api`). New to Usenet indexers? Compare options at [nzb-sources](https://hampelmen.github.io/nzb-sources/).',
             type: 'select-with-custom',
             required: true,
-            options: NEWZNAB_INDEXERS,
+            options: NEWZNAB_INDEXER_OPTIONS,
           },
           {
             id: 'apiKey',

--- a/packages/frontend/src/components/shared/template-option.tsx
+++ b/packages/frontend/src/components/shared/template-option.tsx
@@ -757,6 +757,14 @@ export function NabEndpointInput({
   const selectedIndexer = urlOption?.options?.find(
     (entry) => entry.value === current.url
   );
+
+  const handleUrlChange = (url: string | undefined) => {
+    const selected = urlOption?.options?.find((entry) => entry.value === url);
+    update({
+      url,
+      ...(selected?.noApiKeyRequired ? { apiKey: undefined } : {}),
+    });
+  };
   // only point at a key page for indexers we have a confirmed link for
   const apiKeyUrl = selectedIndexer?.apiKeyUrl;
   const apiKeyDescription = [
@@ -807,7 +815,7 @@ export function NabEndpointInput({
             <SelectWithCustom
               label={urlOption.name}
               value={current.url}
-              onChange={(url) => update({ url })}
+              onChange={handleUrlChange}
               options={urlOption.options}
               required={urlOption.required}
               disabled={disabled}

--- a/packages/frontend/src/components/shared/template-option.tsx
+++ b/packages/frontend/src/components/shared/template-option.tsx
@@ -188,7 +188,7 @@ interface SelectWithCustomProps {
   label: string;
   value: any;
   onChange: (value: string | undefined) => void;
-  options?: { label: string; value: any }[];
+  options?: { label: string; value: any; disabled?: boolean }[];
   required?: boolean;
   disabled?: boolean;
 }
@@ -215,7 +215,11 @@ function SelectWithCustom({
   };
 
   const optionsWithCustom = [
-    ...(options?.map((opt) => ({ label: opt.label, value: opt.value })) ?? []),
+    ...(options?.map((opt) => ({
+      label: opt.label,
+      value: opt.value,
+      disabled: opt.disabled,
+    })) ?? []),
     { label: 'Custom', value: 'Custom' },
   ];
 
@@ -750,10 +754,11 @@ export function NabEndpointInput({
     onChange({ ...current, ...patch });
   };
 
-  // only point at a key page for indexers we have a confirmed link for
-  const apiKeyUrl = urlOption?.options?.find(
+  const selectedIndexer = urlOption?.options?.find(
     (entry) => entry.value === current.url
-  )?.apiKeyUrl;
+  );
+  // only point at a key page for indexers we have a confirmed link for
+  const apiKeyUrl = selectedIndexer?.apiKeyUrl;
   const apiKeyDescription = [
     apiKeyOption?.description,
     apiKeyUrl && `[Find your API key](${apiKeyUrl})`,
@@ -841,7 +846,7 @@ export function NabEndpointInput({
         </div>
       )}
 
-      {apiKeyOption && (
+      {apiKeyOption && !selectedIndexer?.noApiKeyRequired && (
         <div>
           <PasswordInput
             label={apiKeyOption.name}


### PR DESCRIPTION
Groups the Newznab URL picker into "No API key required" / "Requires API key" sections (derived from a per-indexer flag, not list position), hides the API Key field when the selected indexer doesn't need one, and points users to the community-maintained nzb-sources list for discovery.

---

I know this is like 3 changes at once, the grouping is maybe questionable? let me know what makes sense here and I can split things out.. the main goal is to simplify usenet indexer configuration and picking indexers a bit for beginners

the linked "nzb-sources": https://hampelmen.github.io/nzb-sources/

after

<img width="560" height="346" alt="image" src="https://github.com/user-attachments/assets/a60ca948-5ed2-47f3-a090-46fe6685ed35" />

<img width="572" height="488" alt="image" src="https://github.com/user-attachments/assets/b189d8c6-d61e-4b11-851e-d65f8d7aeaf1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Newznab indexers that do not require an API key.
  - API key fields are now hidden when an indexer does not require one.
  - Existing API key details are cleared when switching to an indexer that does not require one.
  - Indexer options are grouped by API key requirement, with unavailable options clearly marked.
  - Added a link to external Newznab indexer comparisons in the URL guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->