### PR TITLE
fix(core): preserve DebridError identity across distributed lock

### DIFF
--- a/packages/core/src/debrid/base.ts
+++ b/packages/core/src/debrid/base.ts
@@ -1,5 +1,6 @@
 ﻿import { z } from 'zod';
 import { constants, ServiceId, Cache, appConfig } from '../utils/index.js';
+import { registerLockErrorClass } from '../utils/lock-error-registry.js';
 import { WD1_KEY_REGEX } from '../release-blocklist/keys.js';
 
 type DebridErrorCode =
@@ -76,6 +77,7 @@ export class DebridError extends Error {
     }
   }
 }
+registerLockErrorClass(DebridError);
 
 export const convertStatusCodeToError = (code: number): DebridError['code'] => {
   switch (code) {

--- a/packages/core/src/utils/distributed-lock.test.ts
+++ b/packages/core/src/utils/distributed-lock.test.ts
@@ -98,6 +98,17 @@ describe('distributed-lock error serialization', () => {
     assert.equal((revived.error as any).cause, undefined);
   });
 
+  test('an error field named like a protocol key cannot clobber it', () => {
+    const err = new TestDebridError('collision', 'UNKNOWN', 500);
+    (err as any).__lockError = false;
+    (err as any).className = 'not-the-real-class-name';
+
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+    assert.ok(revived.error instanceof TestDebridError);
+    assert.equal(revived.error.message, 'collision');
+  });
+
   test('a circular field elsewhere (e.g. body) falls back to a minimal error instead of throwing', () => {
     const circular: any = {};
     circular.self = circular;

--- a/packages/core/src/utils/distributed-lock.test.ts
+++ b/packages/core/src/utils/distributed-lock.test.ts
@@ -1,0 +1,121 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  registerLockErrorClass,
+  resolveErrorCtor,
+  flattenError,
+  stringifyLockResult,
+  parseLockResult,
+} from './distributed-lock.js';
+
+class TestDebridError extends Error {
+  code: string;
+  type: string;
+  statusCode: number;
+  constructor(message: string, code: string, statusCode: number) {
+    super(message);
+    this.code = code;
+    this.type = 'api_error';
+    this.statusCode = statusCode;
+  }
+}
+registerLockErrorClass(TestDebridError);
+
+class UnregisteredError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+    this.name = 'UnregisteredError';
+  }
+}
+
+describe('distributed-lock error serialization', () => {
+  test('a registered class survives a value-shaped round-trip with prototype, message, and fields intact', () => {
+    const err = new TestDebridError('ACTIVE_LIMIT: too many downloads', 'STORE_LIMIT_EXCEEDED', 500);
+    const wire = stringifyLockResult({ value: { error: err, failedOver: true } });
+    const revived = parseLockResult<{ value: { error: Error; failedOver: boolean } }>(wire);
+
+    assert.ok(revived.value.error instanceof TestDebridError);
+    assert.equal(revived.value.error.message, 'ACTIVE_LIMIT: too many downloads');
+    assert.equal((revived.value.error as TestDebridError).code, 'STORE_LIMIT_EXCEEDED');
+    assert.equal((revived.value.error as TestDebridError).statusCode, 500);
+    assert.equal(revived.value.failedOver, true);
+  });
+
+  test('a registered class survives a thrown-error round-trip too', () => {
+    const err = new TestDebridError('rate limited', 'TOO_MANY_REQUESTS', 429);
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+
+    assert.ok(revived.error instanceof TestDebridError);
+    assert.equal(revived.error.message, 'rate limited');
+    assert.equal((revived.error as TestDebridError).code, 'TOO_MANY_REQUESTS');
+  });
+
+  test('an unregistered class loses its exact prototype but keeps its data', () => {
+    const err = new UnregisteredError('boom', 'X1');
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+
+    assert.equal(revived.error instanceof UnregisteredError, false);
+    assert.ok(revived.error instanceof Error);
+    assert.equal(revived.error.message, 'boom');
+    assert.equal((revived.error as any).code, 'X1');
+  });
+
+  test('native Error subclasses resolve via globalThis with zero registration', () => {
+    const err = new TypeError('bad argument');
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+
+    assert.ok(revived.error instanceof TypeError);
+    assert.equal(revived.error.message, 'bad argument');
+  });
+
+  test('resolveErrorCtor resolves registered, native, and unresolvable names', () => {
+    assert.equal(resolveErrorCtor('TestDebridError'), TestDebridError);
+    assert.equal(resolveErrorCtor('TypeError'), TypeError);
+    assert.equal(resolveErrorCtor('SomeClassThatDoesNotExist'), undefined);
+    assert.equal(resolveErrorCtor(undefined), undefined);
+    // a global non-Error function must never be mistaken for one
+    assert.equal(resolveErrorCtor('Array'), undefined);
+  });
+
+  test('a circular `cause` is dropped, never reaching the wire, and the rest of the error still round-trips', () => {
+    const circular: any = {};
+    circular.self = circular;
+    const err = new TestDebridError('with circular cause', 'UNKNOWN', 500);
+    (err as any).cause = circular;
+
+    const flat = flattenError(err);
+    assert.equal('cause' in flat, false);
+
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+    assert.ok(revived.error instanceof TestDebridError);
+    assert.equal(revived.error.message, 'with circular cause');
+    assert.equal((revived.error as any).cause, undefined);
+  });
+
+  test('a circular field elsewhere (e.g. body) falls back to a minimal error instead of throwing', () => {
+    const circular: any = {};
+    circular.self = circular;
+    const err = new TestDebridError('with circular body', 'UNKNOWN', 500);
+    (err as any).body = circular;
+
+    const wire = stringifyLockResult({ error: err });
+    assert.doesNotThrow(() => JSON.parse(wire));
+
+    const revived = parseLockResult<{ error: Error }>(wire);
+    assert.ok(revived.error instanceof Error);
+    assert.equal(revived.error.message, 'Unserializable lock result');
+  });
+
+  test('plain, error-free values round-trip unchanged', () => {
+    const value = { url: 'https://example.com/stream', failedOver: false, label: 'A' };
+    const wire = stringifyLockResult({ value });
+    const revived = parseLockResult<{ value: typeof value }>(wire);
+    assert.deepEqual(revived.value, value);
+  });
+});

--- a/packages/core/src/utils/distributed-lock.ts
+++ b/packages/core/src/utils/distributed-lock.ts
@@ -56,8 +56,11 @@ export function flattenError(err: Error) {
     message: err.message,
   };
   for (const [k, v] of Object.entries(err)) {
-    // cause may hold a raw, non-JSON-safe SDK error (circular refs) - skip it.
-    if (k !== 'cause') flat[k] = v;
+    // cause may hold a non-JSON-safe SDK error (circular refs) - drop it,
+    // and never let a field clobber a protocol key.
+    if (k !== 'cause' && k !== '__lockError' && k !== 'className') {
+      flat[k] = v;
+    }
   }
   return flat;
 }

--- a/packages/core/src/utils/distributed-lock.ts
+++ b/packages/core/src/utils/distributed-lock.ts
@@ -5,8 +5,11 @@ import { RedisClientType } from 'redis';
 import { Cache, REDIS_PREFIX } from './index.js';
 import { createLogger } from '../logging/logger.js';
 import { Time } from './time.js';
+import { registerLockErrorClass, resolveErrorCtor } from './lock-error-registry.js';
 import fs from 'fs/promises';
 import path from 'path';
+
+export { registerLockErrorClass, resolveErrorCtor };
 
 const logger = createLogger('distributed-lock');
 const lockPrefix = `${REDIS_PREFIX}lock:`;
@@ -26,10 +29,66 @@ export interface LockResult<T> {
 
 interface StoredResult<T> {
   value?: T;
-  error?: string;
-  errorCode?: string;
-  errorType?: string;
-  errorStatusCode?: number;
+  error?: Error;
+}
+
+const warnedUnregisteredClasses = new Set<string>();
+
+// message/name are non-enumerable, so flatten Errors into a revivable,
+// class-tagged object before JSON.stringify drops them.
+export function flattenError(err: Error) {
+  const className = err.constructor?.name;
+  if (
+    className &&
+    className !== 'Error' &&
+    !resolveErrorCtor(className) &&
+    !warnedUnregisteredClasses.has(className)
+  ) {
+    warnedUnregisteredClasses.add(className);
+    logger.warn(
+      `Error class '${className}' crossed a distributed lock without being registered via registerLockErrorClass - a waiter reviving it will get a plain Error instead, so any 'instanceof ${className}' check downstream will silently fail for concurrent duplicate requests.`
+    );
+  }
+  const flat: Record<string, unknown> = {
+    __lockError: true,
+    className,
+    name: err.name,
+    message: err.message,
+  };
+  for (const [k, v] of Object.entries(err)) {
+    // cause may hold a raw, non-JSON-safe SDK error (circular refs) - skip it.
+    if (k !== 'cause') flat[k] = v;
+  }
+  return flat;
+}
+
+export function stringifyLockResult(value: unknown): string {
+  try {
+    return JSON.stringify(value, (_key, val) =>
+      val instanceof Error ? flattenError(val) : val
+    );
+  } catch (e: any) {
+    // e.g. an unanticipated circular field - must not crash the lock.
+    logger.error(
+      `Failed to serialize lock result, falling back to a minimal error: ${e.message}`
+    );
+    return JSON.stringify({
+      error: flattenError(new Error('Unserializable lock result')),
+    });
+  }
+}
+
+export function parseLockResult<T>(json: string): T {
+  return JSON.parse(json, (_key, val) => {
+    if (!val || typeof val !== 'object' || !val.__lockError) return val;
+    const ctor = resolveErrorCtor(val.className);
+    const err = (ctor ? Object.create(ctor.prototype) : new Error()) as Error;
+    for (const [k, v] of Object.entries(val)) {
+      if (k === '__lockError' || k === 'className') continue;
+      (err as any)[k] = v;
+    }
+    return err;
+  });
 }
 
 export class DistributedLock {
@@ -140,14 +199,16 @@ export class DistributedLock {
       try {
         result = await fn();
         const storedResult: StoredResult<T> = { value: result };
-        await this.redis!.publish(doneChannel, JSON.stringify(storedResult));
+        await this.redis!.publish(
+          doneChannel,
+          stringifyLockResult(storedResult)
+        );
       } catch (e: any) {
-        const errorResult: StoredResult<T> = { error: e.message || 'Error' };
-        if (e.code !== undefined) errorResult.errorCode = String(e.code);
-        if (e.type !== undefined) errorResult.errorType = String(e.type);
-        if (e.statusCode !== undefined)
-          errorResult.errorStatusCode = Number(e.statusCode);
-        await this.redis!.publish(doneChannel, JSON.stringify(errorResult));
+        const errorResult: StoredResult<T> = { error: e };
+        await this.redis!.publish(
+          doneChannel,
+          stringifyLockResult(errorResult)
+        );
         throw e;
       } finally {
         if ((await this.redis!.get(redisKey)) === owner) {
@@ -171,19 +232,12 @@ export class DistributedLock {
 
       const subscriber = (message: string) => {
         cleanup();
-        const storedResult: StoredResult<T> = JSON.parse(message);
+        const storedResult: StoredResult<T> = parseLockResult(message);
         if (storedResult.error) {
           logger.warn(
             `Received error result for key: ${key} from lock holder.`
           );
-          const err = new Error(storedResult.error);
-          if (storedResult.errorCode !== undefined)
-            (err as any).code = storedResult.errorCode;
-          if (storedResult.errorType !== undefined)
-            (err as any).type = storedResult.errorType;
-          if (storedResult.errorStatusCode !== undefined)
-            (err as any).statusCode = storedResult.errorStatusCode;
-          reject(err);
+          reject(storedResult.error);
         } else {
           logger.debug(`Received cached result for key: ${key} via pub/sub.`);
           resolve({ result: storedResult.value!, cached: true });
@@ -502,19 +556,15 @@ export class DistributedLock {
 
         await db.exec(
           sql`UPDATE distributed_locks
-              SET result = ${JSON.stringify({ value: result })}
+              SET result = ${stringifyLockResult({ value: result })}
               WHERE key = ${key} AND owner = ${owner}`
         );
       } catch (e: any) {
         try {
-          const errorEntry: StoredResult<T> = { error: e.message || 'Error' };
-          if (e.code !== undefined) errorEntry.errorCode = String(e.code);
-          if (e.type !== undefined) errorEntry.errorType = String(e.type);
-          if (e.statusCode !== undefined)
-            errorEntry.errorStatusCode = Number(e.statusCode);
+          const errorEntry: StoredResult<T> = { error: e };
           await db.exec(
             sql`UPDATE distributed_locks
-                SET result = ${JSON.stringify(errorEntry)}
+                SET result = ${stringifyLockResult(errorEntry)}
                 WHERE key = ${key} AND owner = ${owner}`
           );
         } catch (err) {
@@ -542,17 +592,12 @@ export class DistributedLock {
         sql`SELECT result FROM distributed_locks WHERE key = ${key}`
       );
       if (lockRow && lockRow.result) {
-        const storedResult: StoredResult<T> = JSON.parse(lockRow.result);
+        const storedResult: StoredResult<T> = parseLockResult(
+          lockRow.result
+        );
         if (storedResult.error) {
           logger.warn(`Polled error result for key: ${key} from SQL lock.`);
-          const err = new Error(storedResult.error);
-          if (storedResult.errorCode !== undefined)
-            (err as any).code = storedResult.errorCode;
-          if (storedResult.errorType !== undefined)
-            (err as any).type = storedResult.errorType;
-          if (storedResult.errorStatusCode !== undefined)
-            (err as any).statusCode = storedResult.errorStatusCode;
-          throw err;
+          throw storedResult.error;
         }
         logger.debug(`Polled cached result for key: ${key} from SQL lock.`);
         return { result: storedResult.value!, cached: true };

--- a/packages/core/src/utils/lock-error-registry.ts
+++ b/packages/core/src/utils/lock-error-registry.ts
@@ -1,0 +1,22 @@
+// Dependency-free so a class can self-register without a circular-import
+// risk via the utils barrel.
+export type ErrorCtor = new (...args: any[]) => Error;
+
+const registry = new Map<string, ErrorCtor>();
+
+// Preserves a custom Error subclass's prototype/instanceof across a lock's
+// JSON round-trip. Natives (TypeError, ...) resolve via globalThis instead.
+export function registerLockErrorClass(ctor: ErrorCtor): void {
+  registry.set(ctor.name, ctor);
+}
+
+export function resolveErrorCtor(
+  className: string | undefined
+): ErrorCtor | undefined {
+  if (!className) return undefined;
+  if (registry.has(className)) return registry.get(className);
+  const global = (globalThis as any)[className];
+  return typeof global === 'function' && global.prototype instanceof Error
+    ? global
+    : undefined;
+}


### PR DESCRIPTION
Errors crossing the lock's JSON round-trip lost their prototype and message, so waiters on concurrent duplicate requests got a generic 500 instead of the correct error page.

---

I kept wondering why maxing out my slots lead to 500s. this was the reason, the serialization didn't preseve the DebridError. I'm not sure if this is the best fix, because I really wanted to achieve it in a simpler way and with less code, but I did confirm that it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved distributed-lock error handling across Redis and SQL locks.
  - Errors now retain their type, message and relevant details when shared between lock participants.
  - Added support for recognising and restoring registered custom error classes.
  - Added safe fallbacks for unknown, circular or unserialisable errors.

- **Bug Fixes**
  - Prevented loss of error information when lock results are serialised and restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->