### PR TITLE
fix(core): let real probe data override indexer and filename-derived language/subtitle guesses

### DIFF
--- a/packages/core/src/builtins/utils/debrid.ts
+++ b/packages/core/src/builtins/utils/debrid.ts
@@ -377,8 +377,8 @@ async function processTorrentsForDebridService(
 
     if (file) {
       const parsedMediaInfo = mergeParsedMediaInfos(
-        parseMediaInfo(file.mediaInfo),
-        torrent.parsedMediaInfo
+        torrent.parsedMediaInfo,
+        parseMediaInfo(file.mediaInfo)
       );
 
       results.push({

--- a/packages/core/src/utils/media-info.ts
+++ b/packages/core/src/utils/media-info.ts
@@ -355,14 +355,11 @@ export function mergeParsedMediaInfo(
   if (!base && !preferred) return undefined;
 
   const merged = normaliseParsedMediaInfo({
-    languages: [...(base?.languages ?? []), ...(preferred?.languages ?? [])],
-    subtitles: [...(base?.subtitles ?? []), ...(preferred?.subtitles ?? [])],
-    audioTags: [...(base?.audioTags ?? []), ...(preferred?.audioTags ?? [])],
-    audioChannels: [
-      ...(base?.audioChannels ?? []),
-      ...(preferred?.audioChannels ?? []),
-    ],
-    visualTags: [...(base?.visualTags ?? []), ...(preferred?.visualTags ?? [])],
+    languages: preferred?.languages ?? base?.languages,
+    subtitles: preferred?.subtitles ?? base?.subtitles,
+    audioTags: preferred?.audioTags ?? base?.audioTags,
+    audioChannels: preferred?.audioChannels ?? base?.audioChannels,
+    visualTags: preferred?.visualTags ?? base?.visualTags,
     encode: preferred?.encode ?? base?.encode,
     resolution: preferred?.resolution ?? base?.resolution,
     duration: preferred?.duration ?? base?.duration,


### PR DESCRIPTION
Centralize precedence in mergeParsedMediaInfo: preferred wins per array field instead of unioning, same as scalar fields already do. Real per-file probe now beats indexer-declared attrs, which beat filename/flag-derived guesses.

---

this fixes many cases of e.g. wrapped torrentio where the language flags, coming from subtitles, were overwriting correctly probed media info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved media information handling when combining torrent and selected-file details.
  - Corrected language, subtitle, audio, channel, and visual metadata so preferred information is displayed consistently.
  - Reduced duplicate or conflicting metadata values in media details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->