### PR TITLE
fix: preserve word boundary when stripping : and ; in cleanTitle

### DIFF
--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -210,7 +210,7 @@ export function normaliseTitle(title: string) {
 export function cleanTitle(title: string, language?: string) {
   let cleaned = foldToAscii(title, language);
 
-  for (const char of ['♪', '♫', '★', '☆', '♡', '♥', '-']) {
+  for (const char of ['♪', '♫', '★', '☆', '♡', '♥', '-', ';',':']) {
     cleaned = cleaned.replaceAll(char, ' ');
   }
 


### PR DESCRIPTION
Problem

Titles with `:` or `;` and no surrounding space (e.g. "Word;Word") get
collapsed into one word by cleanTitle() — only ♪ ♫ ★ ☆ ♡ ♥ - are mapped to
spaces before the remaining-special-char regex strips everything else, so
"Word;Word" becomes "wordword" instead of "word word".

This breaks search queries for any Newznab/Torznab builtin addon that falls
back to (or is forced into) text search, since the indexer can no longer
match on the two separate words. Indexers without tv-search support are hit
hardest, since they're always on text search.

Fix

Add `;` and `:` to the existing space-substitution list, same treatment
already given to `-`. No behavior change for titles without these
characters any doubled spaces get collapsed by the existing `\s+`
normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title cleaning by treating colons and semicolons as separators, resulting in more consistent title formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->