### PR TITLE
fix(builtins): keep relativeAbsoluteEpisode when it equals the episode

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -750,11 +750,9 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
           totalEpisodesBeforeCurrentSeason += s.episodes;
         }
 
-        const calculated = totalEpisodesBeforeCurrentSeason + episodeNum;
-        // Only set if different from regular episode number
-        if (calculated !== episodeNum) {
-          relativeAbsoluteEpisode = calculated;
-        }
+        // Set even when equal to the requested episode: an entry starting at
+        // that season numbers it from 1. Query building dedupes separately.
+        relativeAbsoluteEpisode = totalEpisodesBeforeCurrentSeason + episodeNum;
       }
 
       const parsedSeasonRecord = seasons.find(

--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -266,11 +266,8 @@ export class StreamContext {
               totalEpisodesBeforeCurrentSeason += s.episodes;
             }
 
-            const calculated = totalEpisodesBeforeCurrentSeason + episodeNum;
-            // Only set if different from regular episode number
-            if (calculated !== episodeNum) {
-              relativeAbsoluteEpisode = calculated;
-            }
+            // See the matching computation in builtins/base/debrid.ts.
+            relativeAbsoluteEpisode = totalEpisodesBeforeCurrentSeason + episodeNum;
           }
 
           // Adjust for non-IMDB episodes if they exist.


### PR DESCRIPTION
`relativeAbsoluteEpisode` is the episode number within the current AniDB entry. It was only assigned when the computed value differed from the requested episode number:

```ts
const calculated = totalEpisodesBeforeCurrentSeason + episodeNum;
// Only set if different from regular episode number
if (calculated !== episodeNum) {
  relativeAbsoluteEpisode = calculated;
}
```

When the entry's starting season *is* the requested season, nothing is summed, so `calculated === episodeNum` and the value is dropped — precisely for the entries that need it.

### Why it matters

`StreamFilterer` treats a release carrying an episode number but no season as season 1 in strict mode, then relies on `relativeAbsoluteEpisode` to accept it anyway:

```ts
} else if (
  seasons[0] === 1 &&
  stream.parsedFile?.episodes?.length &&
  requestedMetadata?.relativeAbsoluteEpisode &&
  stream.parsedFile?.episodes?.includes(requestedMetadata.relativeAbsoluteEpisode)
) {
  // allow if relative absolute episode (AniDB episode) matches AND season is 1
```

With the value unset that branch is unreachable, so releases named after the season rather than the series — the normal shape for anime whose seasons ship under their own titles, numbered from E01 — are rejected.

### The guard exists in two places

The computation is duplicated. `builtins/base/debrid.ts` feeds query building; `streams/context.ts` builds the metadata `StreamFilterer` actually reads. Both carried the identical guard, so fixing either alone changes nothing for the filter. Both commits are needed; they are split only to keep each diff reviewable.

### Does this add duplicate queries?

No. `buildQueries` already skips the relative-absolute query when the number matches `absoluteEpisode` or `parsedId.episode`:

```ts
if (
  metadata.relativeAbsoluteEpisode &&
  [metadata.absoluteEpisode, parsedId.episode].every(
    (v) => v !== metadata.relativeAbsoluteEpisode
  )
) {
```

The de-duplication already lives at the point of use. Discarding the value at the point of computation only removed information the filter needed.

### Verification

Against `kitsu:5326:2` — Beyblade Metal Saga season 2, an entry whose starting season is the requested one. `relativeAbsoluteEpisode` now resolves to `2` instead of `undefined`, and the filter accepts the seasonless releases it is meant to:

```
Beyblade.Metal.Masters.S02E02.……              (explicit season, matched before)
Beyblade Metal Masters (Metal Fight Beyblade: Baku) 1-51/…-02  (seasonless, now matched)
```

Note the branch this re-enables is title-blind by construction: it accepts any seasonless release whose episode number matches, so sibling seasons of the same franchise numbered from E01 also pass. Separating those needs season inference from *which* title alias matched, which is a larger change and deliberately not attempted here.

`tsc --noEmit` on `packages/core` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved episode mapping for anime sourced from AniDB and other known season-based metadata.
  - Episode references are now retained consistently, including when the mapped episode number matches the requested episode.
  - This helps ensure streams and episode details resolve correctly across more anime series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->