### PR TITLE
fix(torrent): key the grab cache on the indexer's stable identifier

### DIFF
--- a/packages/core/src/builtins/base/nab/api.ts
+++ b/packages/core/src/builtins/base/nab/api.ts
@@ -133,6 +133,17 @@ const createTorznabItemSchema = () =>
         .transform((arr) =>
           arr?.[0] ? { name: arr[0]._, id: arr[0].$.id } : undefined
         ),
+      prowlarrindexer: z
+        .array(
+          z.object({
+            _: z.string(),
+            $: z.object({ id: z.string() }),
+          })
+        )
+        .optional()
+        .transform((arr) =>
+          arr?.[0] ? { name: arr[0]._, id: arr[0].$.id } : undefined
+        ),
       type: z
         .array(z.string()) // usually "public", "semi-private" or "private" in Jackett responses
         .optional()
@@ -163,6 +174,7 @@ const createTorznabItemSchema = () =>
       guid: item.guid,
       pubDate: item.pubDate,
       jackettindexer: item.jackettindexer,
+      prowlarrindexer: item.prowlarrindexer,
       type: item.type,
       size: item.size,
       enclosure: item.enclosure,

--- a/packages/core/src/builtins/prowlarr/addon.ts
+++ b/packages/core/src/builtins/prowlarr/addon.ts
@@ -256,6 +256,7 @@ export class ProwlarrAddon extends BaseDebridAddon<ProwlarrAddonConfig> {
       torrents.push({
         hash: infoHash,
         downloadUrl: downloadUrl,
+        guid: result.guid,
         sources: magnetUrl ? extractTrackersFromMagnet(magnetUrl) : [],
         seeders: result.seeders,
         title: result.title,

--- a/packages/core/src/builtins/torznab/addon.ts
+++ b/packages/core/src/builtins/torznab/addon.ts
@@ -69,6 +69,7 @@ export class TorznabAddon extends BaseNabAddon<NabAddonConfig, TorznabApi> {
         confirmed: meta.searchType === 'id',
         hash: infoHash,
         downloadUrl,
+        guid: result.guid,
         sources: result.torznab?.magneturl?.toString()
           ? extractTrackersFromMagnet(result.torznab.magneturl.toString())
           : [],
@@ -81,7 +82,10 @@ export class TorznabAddon extends BaseNabAddon<NabAddonConfig, TorznabApi> {
           typeof result.torznab?.downloadvolumefactor === 'number'
             ? result.torznab.downloadvolumefactor
             : undefined,
-        indexer: result.jackettindexer?.name ?? undefined,
+        indexer:
+          result.jackettindexer?.name ??
+          result.prowlarrindexer?.name ??
+          undefined,
         title: result.title,
         size:
           result.size ??

--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -198,6 +198,12 @@ export interface UnprocessedTorrent extends BaseFile {
   type: 'torrent';
   hash?: string;
   downloadUrl?: string;
+  /**
+   * Stable per-release identifier from the indexer, where one is published.
+   * Unlike `downloadUrl`, which some indexers re-sign on every response, this
+   * is safe to use as a cache key.
+   */
+  guid?: string;
   sources: string[];
   private?: boolean;
   serviceItemId?: string;

--- a/packages/core/src/utils/torrent.ts
+++ b/packages/core/src/utils/torrent.ts
@@ -83,18 +83,24 @@ export class TorrentGrabber {
 
     const cache = this.#cache;
     const url = torrent.downloadUrl;
+    // Proxying indexers re-sign the download URL per response, so it cannot
+    // key a cache. A guid is only unique within its indexer, so both are
+    // required; otherwise fall back to the URL.
+    const guid = torrent.guid?.trim();
+    const indexer = torrent.indexer?.trim();
+    const key = guid && indexer ? `${indexer}\u0000${guid}` : url;
     const lazy = appConfig.builtins.getTorrent.lazily;
 
     // Cache hit — done.
-    const cached = await cache.cached(url);
+    const cached = await cache.cached(key);
     if (cached) return cached;
 
-    // Already fetching this URL: lazy callers bail, eager callers join.
-    const inFlight = cache.inFlight(url);
+    // Already fetching this release: lazy callers bail, eager callers join.
+    const inFlight = cache.inFlight(key);
     if (inFlight) return lazy ? undefined : inFlight.catch(() => undefined);
 
     // Kick off a single-flighted, concurrency-limited grab+parse.
-    const fetchPromise = cache.fetch(url, () =>
+    const fetchPromise = cache.fetch(key, () =>
       this.#fetchLimit(() => this.#fetchMetadata(torrent))
     );
 


### PR DESCRIPTION
### Problem

`TorrentGrabber` keys its metadata cache on `downloadUrl`:

```ts
const url = torrent.downloadUrl;
const cached = await cache.cached(url);
```

That URL is not stable for indexer proxies. Prowlarr encrypts the upstream link into the `link=` query parameter and re-encrypts it per response, so the same release has a different URL on every search. Two identical back-to-back torznab queries returned 100 common releases and **0** identical download links.

The cache therefore never hits for those indexers.

### Why it matters

Results with no infohash have their `.torrent` downloaded to recover one. That is the normal case for some indexers, whose torznab feeds publish neither a `magneturl` nor an infohash attribute — in one sampled feed, 0 of 100 items carried either.

So every search re-downloads every `.torrent`. Where the indexer also rate-limits (Prowlarr applies its per-indexer request delay to downloads as well as searches) the queue outlives the fetch timeout, and the grabs are abandoned after the tracker has already served them — the cache stays empty and the next search repeats the whole thing.

### Change

Prefer the RSS `guid`, falling back to the download URL. `guid` is already parsed for both torznab and Prowlarr results, and `nab/addon.ts` already treats it as a release's identity for pagination de-duplication:

```ts
const identity = (r) => r.guid ?? r.enclosure?.[0]?.url ?? r.link ?? r.title;
```

Indexers that publish no `guid` keep the previous behaviour.

`tsc --noEmit` on `packages/core` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Torrent search results now retain their original source identifier.
  * Stable release identifiers are included in torrent metadata where available.
  * Metadata caching now uses these identifiers for more consistent reuse across requests.
  * Caching falls back to the download URL when no source identifier is available.
  * Indexer details are now preserved more reliably, including Prowlarr information where available.
  * Existing fetching behaviour, concurrency controls, and loading options remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->