### PR TITLE
fix(torrent): lower the default get-torrent concurrency

### DIFF
--- a/packages/core/src/config/schema/builtins.ts
+++ b/packages/core/src/config/schema/builtins.ts
@@ -393,7 +393,7 @@ export const builtinsSchema = {
     },
     concurrency: {
       schema: positiveInt,
-      default: 100,
+      default: 5,
       label: 'Get-torrent concurrency',
       description: 'Maximum concurrent torrent fetches.',
       env: 'BUILTIN_GET_TORRENT_CONCURRENCY',

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -875,7 +875,7 @@ neither the environment variable nor a stored value is present.
 | Environment Variable              | UI Setting                | Type    | Default | Description                                                                                       |
 | --------------------------------- | ------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `BUILTIN_GET_TORRENT_TIMEOUT`     | Get Torrent › Timeout     | number  | `5000`  | Timeout for fetching torrent files.                                                               |
-| `BUILTIN_GET_TORRENT_CONCURRENCY` | Get Torrent › Concurrency | number  | `100`   | Maximum concurrent torrent fetches.                                                               |
+| `BUILTIN_GET_TORRENT_CONCURRENCY` | Get Torrent › Concurrency | number  | `5`     | Maximum concurrent torrent fetches.                                                               |
 | `BUILTIN_GET_TORRENT_LAZILY`      | Get Torrent › Lazily      | boolean | `true`  | Fetch torrents lazily in the background. First search returns immediately with available results. |
 
 #### Torrent


### PR DESCRIPTION
### Problem

Results with no infohash have their `.torrent` downloaded to recover one. The default permits 100 of those in flight at once, per search.

Nothing client-side serialises them, but indexers do — Prowlarr applies its per-indexer request delay to downloads as well as searches. The requests then queue *inside the indexer* while their fetch timeout is already running, so past the first handful every request spends its entire timeout waiting for a slot and is abandoned — after the indexer has already served it.

Observed against a rate-limited indexer with a 4.1s delay: a single stream request produced a steady 4-second cadence of downloads that continued for minutes after the request had returned, and the grab cache gained nothing from any of them.

On a such an indexer that is a burst of ~100 downloads per search, none of which are used.

### Change

Default lowered to 5. That keeps a rate-limited indexer inside the fetch timeout while remaining ample for fast ones: `.torrent` files are small, and in the default lazy mode these fetches are background work that no request is waiting on.

Operators who want the old behaviour can set `BUILTIN_GET_TORRENT_CONCURRENCY=100`.

`pnpm gen:env-docs` output updated. `tsc --noEmit` on `packages/core` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Reduced the default torrent retrieval concurrency from 100 to 5.
  - Updated the environment variable documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->