### PR TITLE
fix(streams): place seasonless releases by the season title they use

### DIFF
--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -12,6 +12,7 @@ import {
   enrichParsedIdWithAnimeEntry,
 } from '../utils/index.js';
 import { SeaDexResult } from '../utils/seadex.js';
+import { normaliseTitle } from '../parser/utils.js';
 import {
   calculateAbsoluteEpisode,
   isNonAnimeAbsoluteEligible,
@@ -21,12 +22,76 @@ import { iso6391ToLanguage } from '../utils/languages.js';
 const logger = createLogger('stream-context');
 
 /**
+ * Map the titles a season is released under to that season's number.
+ *
+ * Anime seasons frequently ship under a name of their own and are numbered
+ * from episode 1 rather than continuing the series count, so a release that
+ * carries an episode number but no season can only be placed by the name it
+ * uses. Each season's own AniDB entry supplies those names.
+ *
+ * A name claimed by more than one season identifies neither, so it is dropped.
+ */
+function buildSeasonTitleMap(
+  tvdbId: number,
+  seasons: { season_number: number }[]
+): Record<string, number> {
+  const db = AnimeDatabase.getInstance();
+  const map: Record<string, number> = {};
+  const ambiguous = new Set<string>();
+
+  for (const { season_number } of seasons) {
+    if (season_number < 1) continue;
+    const entry = db.getEntryById('thetvdbId', tvdbId, season_number);
+    if (!entry) continue;
+
+    // Trust the entry's own season rather than the one asked for, so a lookup
+    // that falls back to another season cannot mislabel its titles.
+    const entrySeason =
+      entry.tvdb?.seasonNumber ??
+      entry.imdb?.seasonNumber ??
+      entry.trakt?.seasonNumber ??
+      entry.tmdb?.seasonNumber;
+    if (entrySeason !== season_number) continue;
+
+    // Only season-specific names may be used. The imdb/trakt titles name the
+    // series as a whole and repeat across every season, so including them
+    // would mark the real per-season names ambiguous and discard them.
+    //
+    // `title` is romanised; releases outside fansub circles use the English
+    // broadcast name, which the Anime-Planet slug carries.
+    const planetSlug = entry.mappings?.animePlanetId;
+    const titles = [
+      entry.title,
+      typeof planetSlug === 'string' ? planetSlug : undefined,
+      ...(entry.synonyms ?? []),
+    ];
+
+    for (const title of titles) {
+      const norm = title ? normaliseTitle(title) : '';
+      if (!norm) continue;
+      if (map[norm] !== undefined && map[norm] !== season_number) {
+        ambiguous.add(norm);
+      } else {
+        map[norm] = season_number;
+      }
+    }
+  }
+
+  // A name claimed by more than one season identifies neither.
+  for (const norm of ambiguous) delete map[norm];
+  logger.debug({ tvdbId, map, ambiguous: [...ambiguous] }, 'season title map');
+  return map;
+}
+
+/**
  * Extended metadata that includes additional fields computed during context build
  */
 export interface ExtendedMetadata extends Metadata {
   absoluteEpisode?: number;
   relativeAbsoluteEpisode?: number; // Episode number within current AniDB entry (for split entries)
   seasonYear?: number; // For anime, the year of the season (e.g., 2021 for "Winter 2021")
+  /** Normalised title -> season number, for seasons released under their own name. */
+  seasonTitles?: Record<string, number>;
 }
 
 export interface ExpressionContext {
@@ -310,6 +375,10 @@ export class StreamContext {
           ...metadata,
           absoluteEpisode,
           relativeAbsoluteEpisode,
+          seasonTitles:
+            this.isAnime && metadata.tvdbId && metadata.seasons
+              ? buildSeasonTitleMap(metadata.tvdbId, metadata.seasons)
+              : undefined,
           seasonYear: this.animeEntry?.animeSeason?.year ?? undefined,
         };
 

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -1152,6 +1152,20 @@ class StreamFilterer {
 
       let seasons = stream.parsedFile?.seasons;
 
+      // A seasonless release may still name its season; that title is the
+      // only thing separating it from a sibling season's same episode number.
+      let seasonFromTitle = false;
+      if (!seasons?.length && stream.parsedFile?.title) {
+        const inferred =
+          requestedMetadata?.seasonTitles?.[
+            normaliseTitle(stream.parsedFile.title)
+          ];
+        if (inferred !== undefined) {
+          seasons = [inferred];
+          seasonFromTitle = true;
+        }
+      }
+
       // if the requested content is series and no season or episode info is present, filter out if strict is true
       if (type === 'series' && seasonEpisodeMatchingOptions.strict) {
         if (
@@ -1163,9 +1177,11 @@ class StreamFilterer {
 
         if (
           !stream.parsedFile.seasons?.length &&
-          stream.parsedFile.episodes?.length
+          stream.parsedFile.episodes?.length &&
+          !seasonFromTitle
         ) {
-          // assume season is 1 when empty and episode is present in strict mode.
+          // assume season is 1 when empty and episode is present in strict
+          // mode, unless the title already placed it in a specific season
           seasons = [1];
         }
       }
@@ -1177,14 +1193,20 @@ class StreamFilterer {
         !seasons.includes(requestedSeason)
       ) {
         if (
-          seasons[0] === 1 &&
+          (seasons[0] === 1 || seasonFromTitle) &&
           stream.parsedFile?.episodes?.length &&
           requestedMetadata?.absoluteEpisode &&
           stream.parsedFile?.episodes?.includes(
             requestedMetadata.absoluteEpisode
           )
         ) {
-          // allow if absolute episode matches AND season is 1
+          // allow if absolute episode matches AND season is 1, or the title
+          // named a season but the release is numbered continuously across the
+          // series, which outranks the name
+        } else if (seasonFromTitle) {
+          // the title named a different season and the episode number is not
+          // series-absolute, so this is that other season's episode
+          return false;
         } else if (
           seasons[0] === 1 &&
           stream.parsedFile?.episodes?.length &&


### PR DESCRIPTION
Anime seasons frequently ship under a title of their own and are numbered from episode 1 rather than continuing the series count. `Beyblade Metal Masters - 02` therefore carries an episode number and no season, and strict season/episode matching assumes season 1 for it:

```ts
if (!stream.parsedFile.seasons?.length && stream.parsedFile.episodes?.length) {
  // assume season is 1 when empty and episode is present in strict mode.
  seasons = [1];
}
```

That assumption cannot tell it apart from `Beyblade Metal Fusion - 02` or `Beyblade Metal Fury - 02`, which are the same episode number of two *other* seasons of the same series. Requesting S2E2 either rejects all three or accepts all three, depending on how the absolute-episode escape hatches happen to line up. Neither is right.

### Approach

The information that separates them is the title, and it is already on hand: each season has its own AniDB entry with its own names. Build a normalised title → season map from the series' entries and use it to place a release that carries no season of its own.

Three constraints fell out of testing against real data:

1. **Only season-specific names may be used.** The imdb/trakt titles name the series as a whole and repeat across every season. Including them marked the genuine per-season names ambiguous and discarded them — the exact titles the feature depends on.
2. **`title` is romanised.** Releases outside fansub circles use the English broadcast name, which the Anime-Planet slug carries (`beyblade-metal-masters`). Both are indexed.
3. **A name claimed by two seasons identifies neither**, so it is dropped rather than guessed.

Each entry's season is taken from its own mapping rather than the one queried, so a lookup that falls back to a different season cannot mislabel its titles.

### Series-absolute numbering still wins

A release whose episode number matches `absoluteEpisode` is accepted even when its title names another season, so shows released under one name and numbered straight through (`Attack on Titan - 30` for S2E5) are unaffected. Only the relative-episode case defers to the title.

### Verification

Against `kitsu:5326:2` (Beyblade Metal Saga season 2) on a live instance, before and after:

```
before                                                    after
Metal.Fight.Beyblade.S02E02…      ✓      ✓
Beyblade.Metal.Masters.S02E02.……   ✓      ✓
Beyblade: Metal Fusion /… - 02            ✗ S1   rejected
Beyblade Metal Fury (4D) 1-39/… - 02               ✗ S3   rejected
Beyblade Shogun Steel (Zero G)/… - 02              ✗ S4   rejected
```

The generated map for that series:

```
1  metalfightbeyblade, beyblademetalfusion, beyblade…
2  metalfightbeybladebaku, beyblademetalmasters, metalfightbeybladeexplosion…
3  metalfightbeyblade4d, beyblademetalfury…
4  metalfightbeybladezerog, beybladeshogunsteel…
```

Same result at S2E5. Non-anime series are untouched — the map is only built when the entry is anime and a TVDB id and season list are present.

`tsc --noEmit` on `packages/core` passes.


### Interaction with the strict-mode fallback

Strict mode assumes season 1 for a release that has an episode number and no season. That assignment re-reads the raw parsed seasons, so it has to skip releases this change has already placed, otherwise every seasonless release collapses to season 1 and is then rejected as belonging to another season — including the ones whose title names the requested season. The fallback is now conditional on the title not having placed it.

Verified against `kitsu:5326:2` and `:5`, where the correct release is a season pack carrying no season in its name:

```
Beyblade: Metal Masters (Metal Fight Beyblade: Baku) 1-51/… - 02 - …   accepted for S2E2
Beyblade: Metal Masters (Metal Fight Beyblade: Baku) 1-51/… - 05 - …   accepted for S2E5
Beyblade: Metal Fusion /… - 02                                           rejected (S1)
Beyblade Metal Fury (4D) 1-39/… - 02                                        rejected (S3)
Beyblade Shogun Steel (Zero G)/… - 02                                       rejected (S4)
```

A non-anime control (`tt0121955:3:3`) is unchanged at 24 streams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anime titles are now normalised across romanised, Anime-Planet and alternative titles.
  * Season information can be inferred directly from stream titles when metadata is incomplete.
* **Bug Fixes**
  * Improved matching for season and episode releases, including absolute episode numbering.
  * Reduced incorrect assignments to season 1 when a different season is identified from the title.
  * Ambiguous titles shared across multiple seasons are excluded to prevent inaccurate matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->