### PR TITLE
fix(streams): only judge an episode title when every language is known

### DIFF
--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -782,17 +782,19 @@ class StreamFilterer {
         return true;
       }
 
-      // A release names its episode in its own language, so a mismatch only
-      // means something when that language is among the known names.
-      const specificLanguages = (stream.parsedFile?.languages ?? []).filter(
-        (language) => !NON_SPECIFIC_LANGUAGES.includes(language)
-      );
+      // A release names its episode in one of its languages, and which one is
+      // unknown, so a mismatch only means something when every language it
+      // carries has a known name to have been compared against. Languages
+      // that resolve to no code name nothing comparable and are skipped.
+      const comparableLanguages = (stream.parsedFile?.languages ?? [])
+        .filter((language) => !NON_SPECIFIC_LANGUAGES.includes(language))
+        .map((language) => languageToCode(language)?.toLowerCase())
+        .filter((code): code is string => !!code);
       const covered =
-        specificLanguages.length === 0 ||
-        specificLanguages.some((language) => {
-          const code = languageToCode(language)?.toLowerCase();
-          return code && expected.some((t) => t.language === code);
-        });
+        comparableLanguages.length === 0 ||
+        comparableLanguages.every((code) =>
+          expected.some((t) => t.language === code)
+        );
       if (!covered) {
         return undefined;
       }


### PR DESCRIPTION
`episodeTitleMatches` rejects a release whose parsed episode title does not match any known name for the requested episode. Because a release names its episode in one of the languages it carries — and which one is not recorded — that verdict is only meaningful when there was a name to compare against:

```ts
// A release names its episode in its own language, so a mismatch only
// means something when that language is among the known names.
const covered =
  specificLanguages.length === 0 ||
  specificLanguages.some((language) => {
    const code = languageToCode(language)?.toLowerCase();
    return code && expected.some((t) => t.language === code);
  });
if (!covered) return undefined;
return false;
```

`some` does not implement what the comment describes. A dual-language release is judged as soon as *one* of its languages has a known name, even when its title is written in the other. A release carrying both an unnamed language and a named one, titled in the unnamed one, is then rejected as the wrong episode.

Requiring `every` language to have a known name matches the stated rule: whichever language the title turned out to be in, there was something to compare it against.

### Effect

Releases that declare no specific language are unchanged — `specificLanguages.length === 0` still short-circuits — so a title that plainly names a different episode is still rejected. Only multi-language releases whose languages are not all covered stop being judged, and they return "cannot judge" rather than a false rejection.

Measured on a live instance for one episode request, episode-title rejections went from 3 to 1. The two that stopped being rejected were the requested episode under a non-English title, carrying both that language and English; the one still rejected genuinely names a different episode.

`tsc --noEmit` on `packages/core` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode title mismatch handling.
  * Mismatches are now flagged only when expected titles are available for every specific, code-resolvable language on a release.
  * Non-specific or unresolvable languages are excluded from coverage checks, reducing incorrect actionable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->