### PR TITLE
feat(templates): ask before a template update overwrites your changes

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -537,6 +537,11 @@ export const UserDataSchema = z.object({
         id: z.string(),
         version: z.string(),
         url: z.string().optional(),
+        // The template's config as it was applied, so an update can be merged
+        // against what the user started from rather than overwriting it. Never
+        // contains credentials: it is captured before the user's inputs are
+        // stamped in.
+        config: z.record(z.string(), z.unknown()).optional(),
         dismissedVersion: z.string().optional(), // dismissed update notification up to this version
         ignored: z.boolean().optional(), // permanently ignore all future update notifications
       })

--- a/packages/frontend/src/components/shared/templates/conflict-step.tsx
+++ b/packages/frontend/src/components/shared/templates/conflict-step.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { TemplateUpdateConflict } from '@/lib/templates/merge';
+
+interface Props {
+  conflicts: TemplateUpdateConflict[];
+  isLoading?: boolean;
+  onCancel: () => void;
+  onConfirm: (keepMine: string[]) => void;
+}
+
+/**
+ * Shown when a template update would change a setting the user has changed
+ * themselves. Only those settings appear: anything the user never touched is
+ * updated without asking.
+ */
+export function TemplateConflictStep({
+  conflicts,
+  isLoading,
+  onCancel,
+  onConfirm,
+}: Props) {
+  // Keeping the user's own values is the default. The update is what they asked
+  // for, but their changes are the thing they would notice losing.
+  const [keepMine, setKeepMine] = useState<Set<string>>(
+    () => new Set(conflicts.map((c) => String(c.field)))
+  );
+
+  const toggle = (field: string, keep: boolean) => {
+    setKeepMine((prev) => {
+      const next = new Set(prev);
+      if (keep) next.add(field);
+      else next.delete(field);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 overflow-y-auto">
+      <p className="text-sm text-[--muted]">
+        These settings differ from the template because you changed them. Tick
+        the ones to keep as they are; the rest will take the update. Everything
+        else in this template updates either way.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {conflicts.map((conflict) => {
+          const field = String(conflict.field);
+          return (
+            <label
+              key={field}
+              className="flex items-center gap-3 rounded-[--radius] border border-[--border] p-3"
+            >
+              <Checkbox
+                value={keepMine.has(field)}
+                onValueChange={(v) => toggle(field, Boolean(v))}
+                aria-label={`Keep my ${field}`}
+              />
+              <span className="text-sm font-mono">{field}</span>
+              <span className="ml-auto text-xs text-[--muted]">
+                {keepMine.has(field) ? 'keeping yours' : 'taking update'}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button
+          intent="primary"
+          className="flex-1"
+          loading={isLoading}
+          onClick={() => onConfirm([...keepMine])}
+        >
+          Apply Update
+        </Button>
+        <Button intent="gray-outline" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/shared/templates/index.tsx
+++ b/packages/frontend/src/components/shared/templates/index.tsx
@@ -21,6 +21,7 @@ import { TemplateValidationModal } from './validation-modal';
 import { TemplateImportModal } from './import-modal';
 
 import type { ConfigTemplatesModalProps } from '@/lib/templates/types';
+import { TemplateConflictStep } from './conflict-step';
 
 export function ConfigTemplatesModal({
   open,
@@ -270,6 +271,26 @@ export function ConfigTemplatesModal({
               onConfirm={wizard.confirmLoadTemplate}
             />
           )}
+        </div>
+      </Modal>
+
+      {/* Settings the update would change that the user has changed */}
+      <Modal
+        open={open && wizard.currentStep === 'resolveConflicts'}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) wizard.cancelConflicts();
+        }}
+        title="Keep your changes?"
+        description="This update changes settings you have since changed yourself"
+        contentClass="max-w-xl"
+      >
+        <div className="flex flex-col gap-4 overflow-hidden max-h-[calc(100svh-8rem)] md:max-h-[calc(100svh-10rem)]">
+          <TemplateConflictStep
+            conflicts={wizard.pendingConflicts}
+            isLoading={wizard.isLoading}
+            onCancel={wizard.cancelConflicts}
+            onConfirm={wizard.resolveConflicts}
+          />
         </div>
       </Modal>
 

--- a/packages/frontend/src/hooks/templates/wizard.ts
+++ b/packages/frontend/src/hooks/templates/wizard.ts
@@ -9,6 +9,10 @@ import {
 } from '@aiostreams/core';
 import { applyMigrations, useUserData } from '@/context/userData';
 import {
+  planTemplateUpdate,
+  type TemplateUpdateConflict,
+} from '@/lib/templates/merge';
+import {
   applyTemplateConditionals,
   resolveCredentialRefs,
 } from '@/lib/templates/processors/conditionals';
@@ -22,6 +26,7 @@ import {
 import {
   getLocalStorageTemplateInputs,
   saveLocalStorageTemplateInputs,
+  templateSnapshot,
 } from '@/lib/templates/storage';
 import {
   processTemplate,
@@ -47,6 +52,11 @@ export interface UseTemplateWizardParams {
 export interface UseTemplateWizard {
   // State
   currentStep: WizardStep;
+  /** Settings an update would change that the user has already changed. */
+  pendingConflicts: TemplateUpdateConflict[];
+  /** Applies the update, keeping the named fields as the user has them. */
+  resolveConflicts: (keepMine: string[]) => void;
+  cancelConflicts: () => void;
   processedTemplate: ProcessedTemplate | null;
   selectedServices: string[];
   inputValues: Record<string, string>;
@@ -92,6 +102,14 @@ export function useTemplateWizard({
   const [selectedServices, setSelectedServices] = useState<string[]>([]);
   const [inputValues, setInputValues] = useState<Record<string, string>>({});
   const [pendingTemplate, setPendingTemplate] = useState<Template | null>(null);
+  // An apply held at the conflict step, with everything needed to finish it once
+  // the user has said which settings to keep.
+  const [pendingConflicts, setPendingConflicts] = useState<
+    TemplateUpdateConflict[]
+  >([]);
+  const [pendingCommit, setPendingCommit] = useState<
+    ((keepMine: string[]) => void) | null
+  >(null);
   const [templateInputOptions, setTemplateInputOptions] = useState<Option[]>(
     []
   );
@@ -157,6 +175,34 @@ export function useTemplateWizard({
    * Migrates config, stamps in input values, filters services,
    * resolves credential refs, merges into userData, then resets wizard state.
    */
+  /**
+   * Finishes an apply that stopped at the conflict step. keepMine names the
+   * fields to leave as the user has them; everything else takes the update.
+   */
+  const resolveConflicts = (keepMine: string[]) => {
+    // The pending call writes the config and then runs the same completion the
+    // immediate path runs, so the notifications and the save-install switch
+    // happen here too rather than only when there was nothing to ask about.
+    pendingCommit?.(keepMine);
+  };
+
+  /**
+   * Abandons an apply held at the conflict step. Clears the same transient
+   * state a cancel does, or a later apply can reopen on a stale snapshot.
+   */
+  const cancelConflicts = () => {
+    setPendingConflicts([]);
+    setPendingCommit(null);
+    setProcessedTemplate(null);
+    setPendingTemplate(null);
+    setTemplateInputValues({});
+    setSelectedServices([]);
+    setInputValues({});
+    setWizardHistory([]);
+    setCurrentStep('browse');
+    setIsLoading(false);
+  };
+
   const applyTemplate = async ({
     config,
     inputs,
@@ -181,6 +227,11 @@ export function useTemplateWizard({
     setIsLoading(true);
     try {
       const migratedData = applyMigrations(JSON.parse(JSON.stringify(config)));
+
+      // The template as applied, kept so a later update can tell what the user
+      // changed from what the template set. Taken before the loop below stamps
+      // the user's inputs in, since those include service credentials.
+      const appliedConfig = templateSnapshot(migratedData);
 
       inputs.forEach((input) => {
         const value = resolvedValues[input.key];
@@ -234,48 +285,125 @@ export function useTemplateWizard({
       }
 
       resolveCredentialRefs(migratedData, resolvedValues);
-      setUserData((prev: any) => ({ ...prev, ...migratedData }));
 
-      if (templateId && templateVersion) {
-        setUserData((prev: any) => ({
-          ...prev,
-          appliedTemplates: [
-            ...((prev.appliedTemplates ?? []) as any[]).filter(
-              (t: any) => t.id !== templateId
-            ),
-            {
-              id: templateId,
-              version: templateVersion,
-              ...(templateSourceUrl ? { url: templateSourceUrl } : {}),
-            },
-          ],
-        }));
+      // Everything the user has changed since this template was applied, that
+      // the update would change back. Empty on a first apply, and empty on an
+      // update that touches nothing the user has an opinion about.
+      const applied = (userData?.appliedTemplates ?? []).find(
+        (t: any) => t.id === templateId
+      );
+      const plan = templateId
+        ? planTemplateUpdate(applied?.config, userData, migratedData)
+        : { changed: Object.keys(migratedData), conflicts: [] };
+      const conflicts = plan.conflicts;
+
+      // Writes the update, minus any field the user chose to keep, and records
+      // the template as applied. The base stored here is the template's own
+      // config either way, so a kept setting still reads as the user's change
+      // at the next update rather than becoming the new baseline.
+      const commit = (keepMine: string[] = []) => {
+        // Only what the update actually changes, minus anything the user chose
+        // to keep. Applying the whole config would reset customisations to
+        // settings this update never touched, which is the thing the prompt
+        // exists to prevent.
+        const incoming: any = {};
+        for (const field of plan.changed) {
+          if (keepMine.includes(field)) continue;
+          incoming[field] = (migratedData as any)[field];
+        }
+        setUserData((prev: any) => {
+          // Credentials are left out of the conflict comparison, since they are
+          // the user's rather than the template's. That means an update whose
+          // services carry empty credentials raises no conflict — so without
+          // this the keys would be replaced by nothing, unasked, by a step whose
+          // whole promise is to ask first.
+          //
+          // Computed into a new array rather than assigned back into `incoming`:
+          // an updater has to be safe to call twice, and `incoming` is from the
+          // enclosing scope.
+          if (!Array.isArray(incoming.services))
+            return { ...prev, ...incoming };
+          const services = incoming.services.map((service: any) => {
+            const existing = (prev.services ?? []).find(
+              (s: any) => s.id === service.id
+            );
+            const credentials = { ...(existing?.credentials ?? {}) };
+            for (const [key, value] of Object.entries(
+              service.credentials ?? {}
+            )) {
+              if (value !== '' && value !== undefined) credentials[key] = value;
+            }
+            return { ...service, credentials };
+          });
+          return { ...prev, ...incoming, services };
+        });
+
+        if (templateId && templateVersion) {
+          setUserData((prev: any) => ({
+            ...prev,
+            appliedTemplates: [
+              ...((prev.appliedTemplates ?? []) as any[]).filter(
+                (t: any) => t.id !== templateId
+              ),
+              {
+                id: templateId,
+                version: templateVersion,
+                config: appliedConfig,
+                ...(templateSourceUrl ? { url: templateSourceUrl } : {}),
+              },
+            ],
+          }));
+        }
+      };
+
+      // Everything that happens once a template has actually been applied. Held
+      // in one place because the conflict step applies it later, from a
+      // different call, and a second copy of this would drift.
+      const finish = () => {
+        const addonsNeedingSetup = (migratedData.presets || [])
+          .filter((preset: any) =>
+            ['gdrive'].some((type) => preset.type.toLowerCase().includes(type))
+          )
+          .map((preset: any) => preset.options?.name || preset.type);
+
+        toast.success(`Template "${templateName}" loaded successfully`);
+
+        if (addonsNeedingSetup.length > 0) {
+          setTimeout(() => {
+            toast.info(
+              `Note: ${addonsNeedingSetup.join(', ')} require additional setup. Please configure them in the Addons section.`,
+              { duration: 8000 }
+            );
+          }, 1000);
+        }
+
+        setProcessedTemplate(null);
+        setCurrentStep('browse');
+        setSelectedServices([]);
+        setInputValues({});
+        setWizardHistory([]);
+        setPendingTemplate(null);
+        setTemplateInputValues({});
+        setPendingConflicts([]);
+        setPendingCommit(null);
+        setIsLoading(false);
+        if (setToSaveInstallMenu) setSelectedMenu('save-install');
+        onOpenChange(false);
+      };
+
+      if (conflicts.length > 0) {
+        setPendingConflicts(conflicts);
+        setPendingCommit(() => (keepMine: string[]) => {
+          commit(keepMine);
+          finish();
+        });
+        setCurrentStep('resolveConflicts');
+        setIsLoading(false);
+        return;
       }
 
-      const addonsNeedingSetup = (migratedData.presets || [])
-        .filter((preset: any) =>
-          ['gdrive'].some((type) => preset.type.toLowerCase().includes(type))
-        )
-        .map((preset: any) => preset.options?.name || preset.type);
-
-      toast.success(`Template "${templateName}" loaded successfully`);
-
-      if (addonsNeedingSetup.length > 0) {
-        setTimeout(() => {
-          toast.info(
-            `Note: ${addonsNeedingSetup.join(', ')} require additional setup. Please configure them in the Addons section.`,
-            { duration: 8000 }
-          );
-        }, 1000);
-      }
-
-      setProcessedTemplate(null);
-      setCurrentStep('browse');
-      setSelectedServices([]);
-      setInputValues({});
-      setWizardHistory([]);
-      if (setToSaveInstallMenu) setSelectedMenu('save-install');
-      onOpenChange(false);
+      commit();
+      finish();
     } catch (err) {
       console.error('Error loading template:', err);
       toast.error('Failed to load template');
@@ -635,6 +763,9 @@ export function useTemplateWizard({
 
   return {
     currentStep,
+    pendingConflicts,
+    resolveConflicts,
+    cancelConflicts,
     processedTemplate,
     selectedServices,
     inputValues,

--- a/packages/frontend/src/lib/templates/merge.ts
+++ b/packages/frontend/src/lib/templates/merge.ts
@@ -1,0 +1,124 @@
+import type { UserData } from '@aiostreams/core';
+
+/**
+ * Fields that are not settings, so a template cannot meaningfully set them and
+ * an update must never offer a choice about them. Identity and server state:
+ * `trusted` is written server-side from the uuid, so prompting about it would
+ * offer a decision the user does not get to make. `appliedTemplates` and
+ * `variants` are this feature's own bookkeeping and the user's saved variants.
+ */
+const NOT_A_SETTING = new Set([
+  'uuid',
+  'encryptedPassword',
+  'ip',
+  'trusted',
+  'parentConfig',
+  'appliedTemplates',
+  'variants',
+]);
+
+/** A field both the user and a template update have changed. */
+export interface TemplateUpdateConflict {
+  field: string;
+  mine: unknown;
+  theirs: unknown;
+}
+
+/**
+ * Normalises a value for comparison. Presets carry an instanceId that identifies
+ * them, so they compare on that rather than on position. Credentials are
+ * dropped: they are the user's, never the template's, and must not be compared.
+ */
+function comparable(field: string, value: unknown): string {
+  if (field === 'presets' && Array.isArray(value)) {
+    const byInstance = [...value]
+      .map((preset: any) => ({ ...preset }))
+      .sort((a, b) =>
+        String(a?.instanceId).localeCompare(String(b?.instanceId))
+      );
+    return JSON.stringify(byInstance);
+  }
+  if (field === 'services' && Array.isArray(value)) {
+    return JSON.stringify(
+      value.map((service: any) => ({ ...service, credentials: undefined }))
+    );
+  }
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Works out which settings a template update would take away from the user.
+ *
+ * base is the template's config as it was applied. Comparing against it is what
+ * separates "the user chose this" from "the template set it", so no setting has
+ * to record where it came from.
+ *
+ * The fields considered are the ones the incoming template actually sets, which
+ * is by construction everything a template can affect — there is no list to keep
+ * in step with the schema, and a field added upstream is covered the day a
+ * template starts setting it.
+ *
+ * A field is a conflict only when both sides moved it and they disagree. A field
+ * the user never touched applies silently: an update that changes forty settings
+ * the user has no opinion about should ask about none of them.
+ *
+ * With no base — anyone who applied a template before it was stored — every
+ * field the update would change counts. Noisy once, and correct: assuming the
+ * user changed nothing is how their settings get overwritten.
+ */
+export interface TemplateUpdatePlan {
+  /** Fields the update itself changes. Everything else is left as it is. */
+  changed: string[];
+  /** Of those, the ones the user has also changed and would lose. */
+  conflicts: TemplateUpdateConflict[];
+}
+
+/**
+ * Works out what a template update actually changes, and which of those the
+ * user would lose.
+ *
+ * base is the template's config as it was applied, so comparing against it
+ * separates "the user chose this" from "the template set it" without any field
+ * having to record where it came from.
+ *
+ * Only fields the update moves are applied at all. A field the template still
+ * sets at the value it always set is not a change, so it neither prompts nor
+ * overwrites — without that, re-applying a template would quietly reset every
+ * customisation the user had made to settings the update never touched.
+ *
+ * With no base — a first apply, or a template applied before the snapshot
+ * existed — everything the template sets is treated as changed, which is the
+ * behaviour that has always applied.
+ */
+export function planTemplateUpdate(
+  base: Partial<UserData> | undefined,
+  mine: Partial<UserData>,
+  theirs: Partial<UserData>
+): TemplateUpdatePlan {
+  const changed: string[] = [];
+  const conflicts: TemplateUpdateConflict[] = [];
+
+  for (const field of Object.keys(theirs)) {
+    if (NOT_A_SETTING.has(field)) continue;
+    const ours = (mine as any)?.[field];
+    const incoming = (theirs as any)[field];
+
+    if (base) {
+      const original = (base as any)[field];
+      // The update leaves this field where it was, so it is not part of the
+      // update at all.
+      if (comparable(field, original) === comparable(field, incoming)) continue;
+      changed.push(field);
+      // The user never moved it, so the update simply applies.
+      if (comparable(field, original) === comparable(field, ours)) continue;
+    } else {
+      if (comparable(field, ours) === comparable(field, incoming)) continue;
+      changed.push(field);
+    }
+
+    if (comparable(field, ours) === comparable(field, incoming)) continue;
+    conflicts.push({ field, mine: ours, theirs: incoming });
+  }
+
+  return { changed, conflicts };
+}

--- a/packages/frontend/src/lib/templates/storage.ts
+++ b/packages/frontend/src/lib/templates/storage.ts
@@ -73,3 +73,26 @@ export const compareVersions = (v1: string, v2: string): number => {
 
   return 0;
 };
+
+/**
+ * The template's config as applied, stored so a later update can be merged
+ * against what the user started from instead of overwriting it.
+ *
+ * Takes only the template's own config. The user's inputs — which include
+ * service credentials — are stamped into the config after this point, so a
+ * snapshot that had access to them could write API keys into userData a second
+ * time. Keeping them out of this signature is what makes that impossible rather
+ * than merely avoided.
+ */
+export function templateSnapshot(config: unknown): Record<string, unknown> {
+  const snapshot = JSON.parse(JSON.stringify(config ?? {}));
+  // Emptied rather than trusted. The snapshot is taken before the user's inputs
+  // are stamped in, so there is nothing to strip today; doing it anyway means a
+  // future call moved a few lines later cannot write credentials into userData.
+  // A merge has no use for them either: they are the user's, and an update must
+  // never overwrite them.
+  for (const service of (snapshot?.services ?? []) as any[]) {
+    if (service && typeof service === 'object') service.credentials = {};
+  }
+  return snapshot;
+}

--- a/packages/frontend/src/lib/templates/types.ts
+++ b/packages/frontend/src/lib/templates/types.ts
@@ -86,7 +86,10 @@ export type WizardStep =
   | 'browse'
   | 'templateInputs'
   | 'selectService'
-  | 'inputs';
+  | 'inputs'
+  // Reached only when an update would change a setting the user has since
+  // changed themselves. A first-time apply never sees it.
+  | 'resolveConflicts';
 
 /** Snapshot of all wizard state saved before each forward navigation step. */
 export interface WizardSnapshot {


### PR DESCRIPTION
## The problem

Apply a template, then change your sort order to suit how you watch. When the
template publishes an update and you apply it, your sort order is silently
replaced by the template's, with no prompt and no sign that anything of yours was
overwritten.

This isn't a bug in how templates apply — the template legitimately sets
`sortCriteria`, and applying it does what it says. The problem is that applying an
update can't tell a setting the user deliberately changed from one they never
touched, so it replaces both. `debrid-starter.json` sets 51 top-level keys, so an
update potentially replaces 51 settings when the user had an opinion about one.

## What this does

Where an update and the user have both moved the same setting, the wizard asks
which to keep. Where only one of them moved it, nothing is asked and the update
applies as before.

```
user changed sorting, update changes sorting and resolutions
  -> asks about sortCriteria only

user changed nothing                -> asks nothing
update changes nothing they touched -> asks nothing
no stored base                      -> asks about every changed field, once
```

The middle two rows are what make it usable. An update touching forty settings the
user has no opinion about still goes through silently.

## How it works

`appliedTemplates[]` gains the template's config as it was applied. That is the
missing piece — with `id` and `version` alone there is nothing to compare against,
so a change of the user's and a change of the template's are indistinguishable.

With a base stored there are three things to compare, and no setting has to record
where it came from:

| | |
|---|---|
| base | the template's config as applied |
| mine | the user's config now |
| theirs | the template at the new version |

`base vs mine` is what the user changed. `base vs theirs` is what the update
changes. The overlap is the only thing worth asking about.

With no base — anyone who applied a template before this lands — every field the
update would change is treated as a conflict. Noisy once, and correct: assuming
the user changed nothing is how settings get overwritten.

The snapshot is taken before the wizard writes any service credentials into the
config, and `templateSnapshot` empties `services[].credentials` regardless, so
nothing of the user's ends up stored in `appliedTemplates[]`.


**Try it** — multi-arch image built from this branch:
```
ghcr.io/ibbylabs/aiostreams:pr1200-e615fc1d
```
Pinned to commit `e615fc1d`, so this tag keeps pointing at what was reviewed even if the branch moves. Unofficial build from an unmerged branch, published under `ibbylabs` rather than by the maintainer.

This branch adds a field to `UserDataSchema` but no database migration, so switching back to your usual image is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conflict detection when updating configuration templates.
  - Users can review differences between their current settings and incoming changes.
  - Added options to keep individual settings, apply updates, or cancel.
  - Template updates preserve user-modified values and existing credentials where appropriate.
  - Sensitive service credentials are excluded from saved template snapshots.
- **Bug Fixes**
  - Improved handling of template settings and service metadata during updates.
  - Preserved service metadata while protecting credentials in configuration snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
