### PR TITLE
feat(usenet): harden nzb grab caching against invalid payloads

### DIFF
--- a/packages/core/src/usenet/integration/dashboard/providers.ts
+++ b/packages/core/src/usenet/integration/dashboard/providers.ts
@@ -13,6 +13,7 @@ import { NntpConnection } from '../../nntp/connection.js';
 import { NntpError } from '../../nntp/errors.js';
 import { getSpeedTestEngineConfig, usenetEngineRegistry } from '../engine.js';
 import { fetchNzb } from '../library.js';
+import { parseWithNzbGrabInvalidation } from '../nzb-grab-invalidation.js';
 
 const logger = createLogger('usenet/dashboard');
 
@@ -216,7 +217,9 @@ async function resolveSpeedTestSource(
   }
   try {
     const xml = await fetchNzb(SPEEDTEST_NZB_URL, signal);
-    const nzb = await parseNzb(xml);
+    const nzb = await parseWithNzbGrabInvalidation(SPEEDTEST_NZB_URL, () =>
+      parseNzb(xml)
+    );
     const fileIndexes = dataFileIndexes(nzb);
     if (fileIndexes.length === 0) return null;
     const source: SpeedTestSource = { nzb, fileIndexes };

--- a/packages/core/src/usenet/integration/library-grab-invalidation.test.ts
+++ b/packages/core/src/usenet/integration/library-grab-invalidation.test.ts
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { before, describe, it } from 'node:test';
+import { settingsStore } from '../../config/index.js';
+import { UsenetIndexerMetricsRepository } from '../../db/index.js';
+import { downloadManager } from '../../utils/download-manager.js';
+import { addUsenetNzb, resolveFileList } from './library.js';
+import { parseWithNzbGrabInvalidation } from './nzb-grab-invalidation.js';
+import { openNativeUsenetStream } from './stream-session.js';
+import { encodeUsenetStreamToken } from './tokens.js';
+
+const STRICT_INVALID_NZB = Buffer.from(
+  '<?xml version="1.0" encoding="UTF-8"?><nzb></nzb>',
+  'utf8'
+);
+
+function isStrictParseError(error: unknown): boolean {
+  assert.ok(error instanceof Error);
+  assert.equal(error.message, 'Invalid NZB: no files with segments found');
+  return true;
+}
+
+before(async () => {
+  await settingsStore.set('usenet.providers', [
+    {
+      id: 'test-provider',
+      host: '127.0.0.1',
+      port: 119,
+      tls: false,
+      maxConnections: 1,
+      priority: 0,
+    },
+  ]);
+});
+
+describe('parseWithNzbGrabInvalidation', () => {
+  it('invalidates the exact remote URL and rethrows the original parse error', async (t) => {
+    const url =
+      'https://indexer.test/api?apikey=secret&t=get&id=1&ordered=true';
+    const calls: string[] = [];
+    t.mock.method(downloadManager, 'invalidateNzb', async (key: string) => {
+      calls.push(key);
+      return true;
+    });
+    const parseError = new Error('strict parse failed');
+
+    await assert.rejects(
+      parseWithNzbGrabInvalidation(url, async () => {
+        throw parseError;
+      }),
+      (err) => err === parseError
+    );
+    assert.deepEqual(calls, [url]);
+  });
+
+  it('does not let an invalidation failure mask the parse error', async (t) => {
+    t.mock.method(downloadManager, 'invalidateNzb', async () => {
+      throw new Error('disk delete failed');
+    });
+    const parseError = new Error('original parse failure');
+
+    await assert.rejects(
+      parseWithNzbGrabInvalidation('https://indexer.test/grab', async () => {
+        throw parseError;
+      }),
+      (err) => err === parseError
+    );
+  });
+
+  it('does not invalidate direct XML or local-nzb content', async (t) => {
+    const invalidate = t.mock.method(
+      downloadManager,
+      'invalidateNzb',
+      async () => true
+    );
+    const directError = new Error('direct XML parse failed');
+    const localError = new Error('local NZB parse failed');
+
+    await assert.rejects(
+      parseWithNzbGrabInvalidation(undefined, async () => {
+        throw directError;
+      }),
+      (err) => err === directError
+    );
+    await assert.rejects(
+      parseWithNzbGrabInvalidation('local-nzb://content-hash', async () => {
+        throw localError;
+      }),
+      (err) => err === localError
+    );
+    assert.equal(invalidate.mock.callCount(), 0);
+  });
+
+  it('does not invalidate when parsing succeeds', async (t) => {
+    const invalidate = t.mock.method(
+      downloadManager,
+      'invalidateNzb',
+      async () => true
+    );
+    const parsed = { hash: 'parsed' };
+
+    assert.strictEqual(
+      await parseWithNzbGrabInvalidation(
+        'https://indexer.test/grab',
+        async () => parsed
+      ),
+      parsed
+    );
+    assert.equal(invalidate.mock.callCount(), 0);
+  });
+});
+
+describe('productive NZB parse-failure wiring', () => {
+  it('invalidates once from resolveFileList without retrying or double-counting', async (t) => {
+    const url = `https://indexer.test/grab/${randomUUID()}?apikey=secret`;
+    const searchHash = `search-${randomUUID()}`;
+    const fetch = t.mock.method(
+      downloadManager,
+      'fetchNzb',
+      async () => STRICT_INVALID_NZB
+    );
+    const invalidated: string[] = [];
+    t.mock.method(downloadManager, 'invalidateNzb', async (key: string) => {
+      invalidated.push(key);
+      throw new Error('disk delete failed');
+    });
+    const record = t.mock.method(
+      UsenetIndexerMetricsRepository,
+      'record',
+      async () => undefined
+    );
+
+    await assert.rejects(
+      resolveFileList(
+        {
+          type: 'usenet',
+          hash: searchHash,
+          nzb: url,
+          indexer: 'Wiring Test',
+        },
+        searchHash,
+        [],
+        {},
+        undefined
+      ),
+      isStrictParseError
+    );
+
+    assert.equal(fetch.mock.callCount(), 1);
+    assert.deepEqual(invalidated, [url]);
+    assert.equal(record.mock.callCount(), 1);
+    const delta = record.mock.calls[0].arguments[0];
+    assert.equal(delta.indexer, 'Wiring Test');
+    assert.equal(delta.failed, 1);
+    assert.equal(delta.failedFetch, 0);
+  });
+
+  it('invalidates the exact URL from addUsenetNzb and preserves the parse error', async (t) => {
+    const url = `https://manual-indexer.test/grab/${randomUUID()}`;
+    const fetch = t.mock.method(
+      downloadManager,
+      'fetchNzb',
+      async () => STRICT_INVALID_NZB
+    );
+    const invalidated: string[] = [];
+    t.mock.method(downloadManager, 'invalidateNzb', async (key: string) => {
+      invalidated.push(key);
+      throw new Error('disk delete failed');
+    });
+    const record = t.mock.method(
+      UsenetIndexerMetricsRepository,
+      'record',
+      async () => undefined
+    );
+
+    await assert.rejects(addUsenetNzb({ url }), isStrictParseError);
+
+    assert.equal(fetch.mock.callCount(), 1);
+    assert.deepEqual(invalidated, [url]);
+    assert.equal(record.mock.callCount(), 1);
+  });
+
+  it('does not invalidate or fetch when addUsenetNzb receives direct XML', async (t) => {
+    const fetch = t.mock.method(
+      downloadManager,
+      'fetchNzb',
+      async () => STRICT_INVALID_NZB
+    );
+    const invalidate = t.mock.method(
+      downloadManager,
+      'invalidateNzb',
+      async () => true
+    );
+    const record = t.mock.method(
+      UsenetIndexerMetricsRepository,
+      'record',
+      async () => undefined
+    );
+
+    await assert.rejects(
+      addUsenetNzb({ xml: STRICT_INVALID_NZB }),
+      isStrictParseError
+    );
+
+    assert.equal(fetch.mock.callCount(), 0);
+    assert.equal(invalidate.mock.callCount(), 0);
+    assert.equal(record.mock.callCount(), 1);
+  });
+
+  it('invalidates once on a real cold stream open and preserves the parse error', async (t) => {
+    const url = `https://stream-indexer.test/grab/${randomUUID()}`;
+    const fetch = t.mock.method(
+      downloadManager,
+      'fetchNzb',
+      async () => STRICT_INVALID_NZB
+    );
+    const invalidated: string[] = [];
+    t.mock.method(downloadManager, 'invalidateNzb', async (key: string) => {
+      invalidated.push(key);
+      throw new Error('disk delete failed');
+    });
+    const token = encodeUsenetStreamToken({
+      nzb: url,
+      hash: `cold-${randomUUID()}`,
+      filename: 'cold-open.mkv',
+    });
+
+    await assert.rejects(openNativeUsenetStream({ token }), isStrictParseError);
+
+    assert.equal(fetch.mock.callCount(), 1);
+    assert.deepEqual(invalidated, [url]);
+  });
+
+  it('does not expose the invalidation helpers through the public core API', async () => {
+    const publicApi = await import('../../index.js');
+
+    assert.equal('invalidateRemoteNzb' in publicApi, false);
+    assert.equal('parseWithNzbGrabInvalidation' in publicApi, false);
+  });
+});

--- a/packages/core/src/usenet/integration/library.ts
+++ b/packages/core/src/usenet/integration/library.ts
@@ -66,14 +66,10 @@ import {
   grabHttpStatus,
   grabErrorMessage,
 } from './grab-metrics.js';
+import { LOCAL_NZB_SCHEME } from './nzb-source.js';
+import { parseWithNzbGrabInvalidation } from './nzb-grab-invalidation.js';
 
 const logger = createLogger('usenet/library');
-
-/**
- * Synthetic URL scheme for NZBs uploaded directly (no indexer URL). The
- * contents are persisted on disk so the entry stays streamable after upload.
- */
-const LOCAL_NZB_SCHEME = 'local-nzb://';
 
 /** Directory holding the raw XML of directly-uploaded NZBs. */
 function localNzbDir(): string {
@@ -644,7 +640,9 @@ export async function resolveFileList(
   const grabbedAt = Date.now();
   let nzb: Nzb;
   try {
-    nzb = await parseNzbCached(nzbHash, xml);
+    nzb = await parseWithNzbGrabInvalidation(playbackInfo.nzb, () =>
+      parseNzbCached(nzbHash, xml)
+    );
   } catch (err) {
     recordGrabOutcome({
       indexer: indexerLabelFor(playbackInfo.indexer, playbackInfo.nzb),
@@ -911,11 +909,13 @@ export async function addUsenetNzb(opts: {
   const startedAt = Date.now();
   let xml: string | Buffer;
   let grabMs: number | undefined;
+  let grabbedUrl: string | undefined;
   if (opts.xml != null) {
     xml = opts.xml;
   } else {
+    grabbedUrl = opts.url!;
     try {
-      xml = await fetchNzb(opts.url!);
+      xml = await fetchNzb(grabbedUrl);
     } catch (err) {
       recordGrabOutcome({
         indexer: indexerLabelFor(undefined, opts.url),
@@ -930,7 +930,7 @@ export async function addUsenetNzb(opts: {
   }
   let nzb: Nzb;
   try {
-    nzb = await parseNzb(xml);
+    nzb = await parseWithNzbGrabInvalidation(grabbedUrl, () => parseNzb(xml));
   } catch (err) {
     recordGrabOutcome({
       indexer: indexerLabelFor(undefined, opts.url),
@@ -1090,7 +1090,7 @@ async function requeueEntry(
   const grabMs = Date.now() - fetchStart;
   let nzb: Nzb;
   try {
-    nzb = await parseNzb(xml);
+    nzb = await parseWithNzbGrabInvalidation(nzbUrl, () => parseNzb(xml));
   } catch (err) {
     recordGrabOutcome({
       indexer: indexerLabelFor(undefined, nzbUrl),

--- a/packages/core/src/usenet/integration/nzb-grab-invalidation.ts
+++ b/packages/core/src/usenet/integration/nzb-grab-invalidation.ts
@@ -1,0 +1,23 @@
+import { downloadManager } from '../../utils/download-manager.js';
+import { LOCAL_NZB_SCHEME } from './nzb-source.js';
+
+/** Best-effort invalidation for URLs that actually use the remote grab cache. */
+export async function invalidateRemoteNzb(
+  url: string | undefined
+): Promise<boolean> {
+  if (!url || url.startsWith(LOCAL_NZB_SCHEME)) return false;
+  return downloadManager.invalidateNzb(url).catch(() => false);
+}
+
+/** Parse once and evict only the corresponding remote grab on failure. */
+export async function parseWithNzbGrabInvalidation<T>(
+  url: string | undefined,
+  parse: () => Promise<T>
+): Promise<T> {
+  try {
+    return await parse();
+  } catch (err) {
+    await invalidateRemoteNzb(url);
+    throw err;
+  }
+}

--- a/packages/core/src/usenet/integration/nzb-source.ts
+++ b/packages/core/src/usenet/integration/nzb-source.ts
@@ -1,0 +1,2 @@
+/** Synthetic source scheme for directly uploaded NZB contents. */
+export const LOCAL_NZB_SCHEME = 'local-nzb://';

--- a/packages/core/src/usenet/integration/stream-session.ts
+++ b/packages/core/src/usenet/integration/stream-session.ts
@@ -23,6 +23,7 @@ import {
   type HoleHooks,
   type HoleInfo,
   type HoleDecision,
+  type Nzb,
   type ArchiveStreamLayout,
   type LazyResolveHooks,
   type DataFragment,
@@ -49,6 +50,7 @@ import {
 } from '../../stream-sessions/index.js';
 import { usenetEngineRegistry, getUsenetEngineConfig } from './engine.js';
 import { fetchNzb, parseNzbCached, canonicaliseNzbHash } from './library.js';
+import { parseWithNzbGrabInvalidation } from './nzb-grab-invalidation.js';
 import { noteStreamActivity, pruneStreamActivity } from './damage-policy.js';
 
 const logger = createLogger('usenet/stream');
@@ -447,7 +449,9 @@ async function getStreamSession(
     const grabbedAt = Date.now();
     // Reuses the model the resolve just parsed (same hash); parsing the same
     // multi-MB NZB twice per playback is pure waste.
-    const nzb = await parseNzbCached(decoded.hash, xml);
+    const nzb: Nzb = await parseWithNzbGrabInvalidation(decoded.nzb, () =>
+      parseNzbCached(decoded.hash, xml)
+    );
     const parsedAt = Date.now();
     // tokens minted before the content-hash rekey carry a search-time
     // hash. Every library read/write below

--- a/packages/core/src/utils/disk-backed-cache.test.ts
+++ b/packages/core/src/utils/disk-backed-cache.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { it, type TestContext } from 'node:test';
+import { DiskBackedCache } from './disk-backed-cache.js';
+
+const codec = {
+  serialize: (value: Buffer): Buffer => value,
+  deserialize: (value: Buffer): Buffer => value,
+  sizeOf: (value: Buffer): number => value.length,
+};
+
+async function tempDir(t: TestContext): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aiostreams-disk-test-'));
+  t.after(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+  return dir;
+}
+
+function makeCache(dir: string, name = 'disk-test'): DiskBackedCache<Buffer> {
+  return new DiskBackedCache<Buffer>({
+    name,
+    dir,
+    maxMemBytes: 0,
+    maxDiskBytes: 16 * 1024 * 1024,
+    ...codec,
+  });
+}
+
+it('persists unaffected keys and keeps a targeted deletion across reloads', async (t) => {
+  const dir = await tempDir(t);
+  const first = makeCache(dir);
+  await first.whenReady();
+  first.set('target', Buffer.from('target'));
+  first.set('other', Buffer.from('other'));
+  await first.flush();
+  assert.equal(await first.delete('target'), true);
+  assert.equal(await first.delete('target'), false);
+  await first.close();
+
+  const reopened = makeCache(dir);
+  await reopened.whenReady();
+  assert.equal(await reopened.getAsync('target'), undefined);
+  assert.deepEqual(await reopened.getAsync('other'), Buffer.from('other'));
+  await reopened.close();
+});
+
+it('drains a pending write before deletion and cannot overwrite a fresh rewrite', async (t) => {
+  const dir = await tempDir(t);
+  const name = 'pending-write';
+  const key = 'https://indexer.test/api?t=get&id=pending';
+  const fileKey = createHash('sha1').update(key).digest('hex');
+  const filePath = path.join(dir, name, fileKey);
+  const cache = makeCache(dir, name);
+  await cache.whenReady();
+
+  cache.set(key, Buffer.alloc(4 * 1024 * 1024, 0x61));
+  assert.equal(await cache.delete(key), true);
+  await assert.rejects(() => fs.stat(filePath), { code: 'ENOENT' });
+
+  const fresh = Buffer.from('fresh valid NZB body');
+  cache.set(key, fresh);
+  await cache.flush();
+  assert.deepEqual(await fs.readFile(filePath), fresh);
+  await cache.close();
+
+  const reopened = makeCache(dir, name);
+  await reopened.whenReady();
+  assert.deepEqual(await reopened.getAsync(key), fresh);
+  await reopened.close();
+});

--- a/packages/core/src/utils/disk-backed-cache.test.ts
+++ b/packages/core/src/utils/disk-backed-cache.test.ts
@@ -30,6 +30,17 @@ function makeCache(dir: string, name = 'disk-test'): DiskBackedCache<Buffer> {
   });
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 it('persists unaffected keys and keeps a targeted deletion across reloads', async (t) => {
   const dir = await tempDir(t);
   const first = makeCache(dir);
@@ -71,4 +82,49 @@ it('drains a pending write before deletion and cannot overwrite a fresh rewrite'
   await reopened.whenReady();
   assert.deepEqual(await reopened.getAsync(key), fresh);
   await reopened.close();
+});
+
+it('drains overlapping writes that settle in reverse order before deletion', async (t) => {
+  const dir = await tempDir(t);
+  const name = 'overlapping-writes';
+  const key = 'https://indexer.test/api?t=get&id=overlapping';
+  const fileKey = createHash('sha1').update(key).digest('hex');
+  const filePath = path.join(dir, name, fileKey);
+  const cache = makeCache(dir, name);
+  await cache.whenReady();
+
+  const originalWriteFile = fs.writeFile.bind(fs);
+  const releases = [deferred<void>(), deferred<void>()];
+  const completed = [deferred<void>(), deferred<void>()];
+  let dataWrites = 0;
+  t.mock.method(fs, 'writeFile', async (target, data, options) => {
+    if (String(target) !== filePath) {
+      return originalWriteFile(target, data, options);
+    }
+    const index = dataWrites++;
+    assert.ok(index < releases.length);
+    await releases[index].promise;
+    await originalWriteFile(target, data, options);
+    completed[index].resolve();
+  });
+
+  cache.set(key, Buffer.from('older'));
+  cache.set(key, Buffer.from('newer'));
+  assert.equal(dataWrites, 2);
+
+  let deletionSettled = false;
+  const deleting = cache.delete(key).then((removed) => {
+    deletionSettled = true;
+    return removed;
+  });
+
+  releases[1].resolve();
+  await completed[1].promise;
+  assert.equal(deletionSettled, false);
+
+  releases[0].resolve();
+  await completed[0].promise;
+  assert.equal(await deleting, true);
+  await assert.rejects(() => fs.stat(filePath), { code: 'ENOENT' });
+  await cache.close();
 });

--- a/packages/core/src/utils/disk-backed-cache.ts
+++ b/packages/core/src/utils/disk-backed-cache.ts
@@ -122,8 +122,10 @@ export class DiskBackedCache<V> {
   private readonly indexPath: string;
   private readonly opts: DiskBackedCacheOptions<V>;
 
-  /** In-flight disk writes keyed by file key, so reads can await consistency. */
-  private pendingWrites = new Map<string, Promise<void>>();
+  /** Every in-flight disk write keyed by file key, so reads/deletes can drain all. */
+  private pendingWrites = new Map<string, Set<Promise<void>>>();
+  /** Total in-flight writes across all keys (the map itself counts keys). */
+  private pendingWriteCount = 0;
   /** Approximate bytes held by in-flight disk writes (serialized payloads). */
   private pendingWriteBytes = 0;
   /** Serialises index persistence. */
@@ -258,7 +260,7 @@ export class DiskBackedCache<V> {
     }
     // Ensure any in-flight write for this key has settled before reading.
     const pending = this.pendingWrites.get(fileKey);
-    if (pending) await pending.catch(() => {});
+    if (pending) await Promise.allSettled([...pending]);
     try {
       const buf = await fs.readFile(this.filePath(fileKey));
       const value = this.opts.deserialize(buf);
@@ -350,7 +352,7 @@ export class DiskBackedCache<V> {
   /** Update the disk index synchronously; write the file in the background. */
   private persistToDisk(key: string, value: V, size: number): void {
     if (
-      this.pendingWrites.size >= DiskBackedCache.MAX_PENDING_WRITES ||
+      this.pendingWriteCount >= DiskBackedCache.MAX_PENDING_WRITES ||
       this.pendingWriteBytes >= DiskBackedCache.MAX_PENDING_WRITE_BYTES
     ) {
       return; // saturated — skip this persist rather than queue it
@@ -382,7 +384,14 @@ export class DiskBackedCache<V> {
       payload = this.opts.serialize(value);
     }
 
+    let pendingForKey = this.pendingWrites.get(fileKey);
+    if (!pendingForKey) {
+      pendingForKey = new Set();
+      this.pendingWrites.set(fileKey, pendingForKey);
+    }
+
     let write: Promise<void>;
+    this.pendingWriteCount++;
     this.pendingWriteBytes += size;
     const run = async (): Promise<void> => {
       try {
@@ -396,14 +405,19 @@ export class DiskBackedCache<V> {
         );
       } finally {
         if (slot) this.releaseWriteBuf(slot);
+        this.pendingWriteCount--;
         this.pendingWriteBytes -= size;
-        if (this.pendingWrites.get(fileKey) === write) {
+        pendingForKey.delete(write);
+        if (
+          pendingForKey.size === 0 &&
+          this.pendingWrites.get(fileKey) === pendingForKey
+        ) {
           this.pendingWrites.delete(fileKey);
         }
       }
     };
     write = run();
-    this.pendingWrites.set(fileKey, write);
+    pendingForKey.add(write);
   }
 
   /** Evict least-recently-used disk entries until within budget. */
@@ -451,15 +465,16 @@ export class DiskBackedCache<V> {
     }
     const fileKey = this.fileKey(key);
     const pending = this.pendingWrites.get(fileKey);
+    const earlierWrites = pending ? [...pending] : [];
     if (this.disk.has(fileKey)) {
       this.dropDisk(fileKey);
       removed = true;
     }
 
     // dropDisk() removes eagerly, but a write that was already in progress can
-    // recreate the file afterwards. Wait for that exact write and remove once
-    // more before allowing GrabCache's per-key lock to admit a new producer.
-    if (pending) await pending.catch(() => {});
+    // recreate the file afterwards. Wait for every write that started before
+    // this deletion and remove once more before GrabCache admits a new producer.
+    if (earlierWrites.length > 0) await Promise.allSettled(earlierWrites);
     if (this.diskEnabled()) {
       await fs.rm(this.filePath(fileKey), { force: true }).catch(() => {});
     }
@@ -537,7 +552,10 @@ export class DiskBackedCache<V> {
    */
   async flush(): Promise<void> {
     await this.ready.catch(() => {});
-    await Promise.allSettled([...this.pendingWrites.values()]);
+    const writes = [...this.pendingWrites.values()].flatMap((pending) => [
+      ...pending,
+    ]);
+    await Promise.allSettled(writes);
     await this.flushIndex();
   }
 

--- a/packages/core/src/utils/disk-backed-cache.ts
+++ b/packages/core/src/utils/disk-backed-cache.ts
@@ -440,6 +440,8 @@ export class DiskBackedCache<V> {
   }
 
   async delete(key: string): Promise<boolean> {
+    await this.ready.catch(() => {});
+
     let removed = false;
     const memEntry = this.mem.get(key);
     if (memEntry) {
@@ -448,9 +450,18 @@ export class DiskBackedCache<V> {
       removed = true;
     }
     const fileKey = this.fileKey(key);
+    const pending = this.pendingWrites.get(fileKey);
     if (this.disk.has(fileKey)) {
       this.dropDisk(fileKey);
       removed = true;
+    }
+
+    // dropDisk() removes eagerly, but a write that was already in progress can
+    // recreate the file afterwards. Wait for that exact write and remove once
+    // more before allowing GrabCache's per-key lock to admit a new producer.
+    if (pending) await pending.catch(() => {});
+    if (this.diskEnabled()) {
+      await fs.rm(this.filePath(fileKey), { force: true }).catch(() => {});
     }
     return removed;
   }

--- a/packages/core/src/utils/download-manager.test.ts
+++ b/packages/core/src/utils/download-manager.test.ts
@@ -43,6 +43,13 @@ describe('assertLikelyNzbPayload', () => {
     assert.doesNotThrow(() => assertLikelyNzbPayload('application/xml', body));
   });
 
+  it('accepts comments and an NZB doctype before the document root', () => {
+    const body = Buffer.from(
+      '<?xml version="1.0"?><!-- generated --><!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd"><nzb></nzb>'
+    );
+    assert.doesNotThrow(() => assertLikelyNzbPayload('application/xml', body));
+  });
+
   it('rejects an empty body with the typed payload error', () => {
     assert.throws(
       () => assertLikelyNzbPayload('application/x-nzb', Buffer.alloc(0)),
@@ -99,6 +106,17 @@ describe('assertLikelyNzbPayload', () => {
     });
   }
 
+  it('rejects an NZB element nested under a non-NZB document root', () => {
+    assert.throws(
+      () =>
+        assertLikelyNzbPayload(
+          'application/xml',
+          Buffer.from('<?xml version="1.0"?><error><nzb></nzb></error>')
+        ),
+      InvalidNzbPayloadError
+    );
+  });
+
   it('only sniffs the first 64 KiB for the NZB root', () => {
     const body = Buffer.concat([
       Buffer.alloc(64 * 1024, 0x20),
@@ -115,6 +133,7 @@ describe('DownloadManager NZB cache admission', () => {
   it('does not cache a 200 HTML response and does cache a valid NZB', async () => {
     const nonce = randomUUID();
     const htmlPath = `/html-${nonce}`;
+    const nestedPath = `/nested-${nonce}`;
     const validPath = `/valid-${nonce}`;
     const requests = new Map<string, number>();
     const server = createServer((req, res) => {
@@ -123,6 +142,11 @@ describe('DownloadManager NZB cache admission', () => {
       if (pathname === htmlPath) {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end('<!doctype html><html><body>Login required</body></html>');
+        return;
+      }
+      if (pathname === nestedPath) {
+        res.writeHead(200, { 'Content-Type': 'application/xml' });
+        res.end('<error><nzb></nzb></error>');
         return;
       }
       if (pathname === validPath) {
@@ -141,6 +165,7 @@ describe('DownloadManager NZB cache admission', () => {
     assert.ok(address && typeof address === 'object');
     const baseUrl = `http://127.0.0.1:${address.port}`;
     const htmlUrl = `${baseUrl}${htmlPath}`;
+    const nestedUrl = `${baseUrl}${nestedPath}`;
     const validUrl = `${baseUrl}${validPath}`;
 
     try {
@@ -154,11 +179,22 @@ describe('DownloadManager NZB cache admission', () => {
       );
       assert.equal(requests.get(htmlPath), 2);
 
+      await assert.rejects(
+        downloadManager.fetchNzb(nestedUrl),
+        InvalidNzbPayloadError
+      );
+      await assert.rejects(
+        downloadManager.fetchNzb(nestedUrl),
+        InvalidNzbPayloadError
+      );
+      assert.equal(requests.get(nestedPath), 2);
+
       assert.deepEqual(await downloadManager.fetchNzb(validUrl), VALID_NZB);
       assert.deepEqual(await downloadManager.fetchNzb(validUrl), VALID_NZB);
       assert.equal(requests.get(validPath), 1);
     } finally {
       await downloadManager.invalidateNzb(htmlUrl);
+      await downloadManager.invalidateNzb(nestedUrl);
       await downloadManager.invalidateNzb(validUrl);
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/packages/core/src/utils/download-manager.test.ts
+++ b/packages/core/src/utils/download-manager.test.ts
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import { describe, it } from 'node:test';
+import {
+  downloadManager,
+  InvalidNzbPayloadError,
+  assertLikelyNzbPayload,
+} from './download-manager.js';
+
+const SIMPLE_NZB = Buffer.from(
+  '<?xml version="1.0" encoding="UTF-8"?><nzb></nzb>',
+  'utf8'
+);
+
+const VALID_NZB = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+  <file poster="poster" date="1" subject="&quot;video.mkv&quot; yEnc (1/1)">
+    <groups><group>alt.binaries.test</group></groups>
+    <segments><segment bytes="10" number="1">part@example.test</segment></segments>
+  </file>
+</nzb>`);
+
+describe('assertLikelyNzbPayload', () => {
+  for (const contentType of [
+    'application/x-nzb',
+    'application/octet-stream',
+    'text/plain',
+    '',
+  ]) {
+    it(`accepts an NZB served as ${contentType || 'no content type'}`, () => {
+      assert.doesNotThrow(() =>
+        assertLikelyNzbPayload(contentType, SIMPLE_NZB)
+      );
+    });
+  }
+
+  it('accepts a BOM, whitespace, XML declaration, and namespaced root', () => {
+    const body = Buffer.from(
+      '\uFEFF  \n\t<?xml version="1.0"?>\n<NZB xmlns="http://www.newzbin.com/DTD/2003/nzb"><head /></NZB>',
+      'utf8'
+    );
+    assert.doesNotThrow(() => assertLikelyNzbPayload('application/xml', body));
+  });
+
+  it('rejects an empty body with the typed payload error', () => {
+    assert.throws(
+      () => assertLikelyNzbPayload('application/x-nzb', Buffer.alloc(0)),
+      (error: unknown) => {
+        assert.ok(error instanceof InvalidNzbPayloadError);
+        assert.equal(error.name, 'InvalidNzbPayloadError');
+        assert.equal(error.message, 'grab response is not an NZB document');
+        assert.equal(error.contentType, 'application/x-nzb');
+        assert.equal(error.bytes, 0);
+        return true;
+      }
+    );
+  });
+
+  it('rejects text/html even when the body contains an NZB tag', () => {
+    assert.throws(
+      () => assertLikelyNzbPayload('text/html; charset=utf-8', SIMPLE_NZB),
+      InvalidNzbPayloadError
+    );
+  });
+
+  it('rejects an HTML doctype served with a generic content type', () => {
+    assert.throws(
+      () =>
+        assertLikelyNzbPayload(
+          'application/octet-stream',
+          Buffer.from('<!DOCTYPE html><html><body>Login</body></html>')
+        ),
+      InvalidNzbPayloadError
+    );
+  });
+
+  it('rejects an HTML root without a content type', () => {
+    assert.throws(
+      () =>
+        assertLikelyNzbPayload(
+          '',
+          Buffer.from('  <HtMl lang="en"><body>Challenge</body></HtMl>')
+        ),
+      InvalidNzbPayloadError
+    );
+  });
+
+  for (const root of ['error', 'rss']) {
+    it(`rejects XML with a non-NZB ${root} root`, () => {
+      assert.throws(
+        () =>
+          assertLikelyNzbPayload(
+            'application/xml',
+            Buffer.from(`<?xml version="1.0"?><${root}></${root}>`)
+          ),
+        InvalidNzbPayloadError
+      );
+    });
+  }
+
+  it('only sniffs the first 64 KiB for the NZB root', () => {
+    const body = Buffer.concat([
+      Buffer.alloc(64 * 1024, 0x20),
+      Buffer.from('<nzb></nzb>'),
+    ]);
+    assert.throws(
+      () => assertLikelyNzbPayload('application/octet-stream', body),
+      InvalidNzbPayloadError
+    );
+  });
+});
+
+describe('DownloadManager NZB cache admission', () => {
+  it('does not cache a 200 HTML response and does cache a valid NZB', async () => {
+    const nonce = randomUUID();
+    const htmlPath = `/html-${nonce}`;
+    const validPath = `/valid-${nonce}`;
+    const requests = new Map<string, number>();
+    const server = createServer((req, res) => {
+      const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+      requests.set(pathname, (requests.get(pathname) ?? 0) + 1);
+      if (pathname === htmlPath) {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end('<!doctype html><html><body>Login required</body></html>');
+        return;
+      }
+      if (pathname === validPath) {
+        res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+        res.end(VALID_NZB);
+        return;
+      }
+      res.writeHead(404).end();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const htmlUrl = `${baseUrl}${htmlPath}`;
+    const validUrl = `${baseUrl}${validPath}`;
+
+    try {
+      await assert.rejects(
+        downloadManager.fetchNzb(htmlUrl),
+        InvalidNzbPayloadError
+      );
+      await assert.rejects(
+        downloadManager.fetchNzb(htmlUrl),
+        InvalidNzbPayloadError
+      );
+      assert.equal(requests.get(htmlPath), 2);
+
+      assert.deepEqual(await downloadManager.fetchNzb(validUrl), VALID_NZB);
+      assert.deepEqual(await downloadManager.fetchNzb(validUrl), VALID_NZB);
+      assert.equal(requests.get(validPath), 1);
+    } finally {
+      await downloadManager.invalidateNzb(htmlUrl);
+      await downloadManager.invalidateNzb(validUrl);
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/packages/core/src/utils/download-manager.ts
+++ b/packages/core/src/utils/download-manager.ts
@@ -45,6 +45,36 @@ export class NzbTooLargeError extends Error {
   }
 }
 
+/** A successful grab response did not contain a plausible NZB document. */
+export class InvalidNzbPayloadError extends Error {
+  constructor(
+    readonly contentType: string,
+    readonly bytes: number
+  ) {
+    super('grab response is not an NZB document');
+    this.name = 'InvalidNzbPayloadError';
+  }
+}
+
+/** Reject obvious non-NZB responses before they can enter the grab cache. */
+export function assertLikelyNzbPayload(contentType: string, buf: Buffer): void {
+  const head = buf
+    .subarray(0, Math.min(buf.length, 64 * 1024))
+    .toString('utf8')
+    .replace(/^\uFEFF/, '')
+    .trimStart();
+
+  const looksLikeHtml =
+    contentType.toLowerCase().includes('text/html') ||
+    /<!doctype\s+html|<html(?:\s|>)/i.test(head);
+
+  const containsNzbRoot = /<nzb(?:\s|>)/i.test(head);
+
+  if (buf.length === 0 || looksLikeHtml || !containsNzbRoot) {
+    throw new InvalidNzbPayloadError(contentType, buf.length);
+  }
+}
+
 /**
  * Process-wide download manager for grabbed `.nzb` files: a disk-backed,
  * restart-surviving, single-flighted grab layer (so a player resuming a stream
@@ -87,6 +117,11 @@ class DownloadManager {
     );
   }
 
+  /** Remove exactly one grabbed NZB, keyed by its original URL string. */
+  invalidateNzb(url: string): Promise<boolean> {
+    return this.nzbCache().delete(url);
+  }
+
   private async download(url: string, opts: GrabOptions): Promise<Buffer> {
     const startedAt = Date.now();
     const maxBytes = appConfig.usenet.maxNzbSize;
@@ -111,6 +146,7 @@ class DownloadManager {
     if (buf.length > maxBytes) {
       throw new NzbTooLargeError(buf.length, maxBytes);
     }
+    assertLikelyNzbPayload(response.headers.get('content-type') ?? '', buf);
     logger.debug(
       { bytes: buf.length, latencyMs: Date.now() - startedAt },
       'grabbed nzb'

--- a/packages/core/src/utils/download-manager.ts
+++ b/packages/core/src/utils/download-manager.ts
@@ -56,6 +56,58 @@ export class InvalidNzbPayloadError extends Error {
   }
 }
 
+/** Offset of the first XML element after legal prolog constructs. */
+function xmlRootOffset(xml: string): number | undefined {
+  let offset = 0;
+  let sawDoctype = false;
+  for (;;) {
+    while (/[ \t\r\n]/.test(xml[offset] ?? '')) offset++;
+
+    if (xml.startsWith('<!--', offset)) {
+      const end = xml.indexOf('-->', offset + 4);
+      if (end < 0) return undefined;
+      offset = end + 3;
+      continue;
+    }
+    if (xml.startsWith('<?', offset)) {
+      const end = xml.indexOf('?>', offset + 2);
+      if (end < 0) return undefined;
+      offset = end + 2;
+      continue;
+    }
+
+    const rest = xml.slice(offset);
+    const doctype = /^<!doctype\s+([A-Za-z_:][A-Za-z0-9_.:-]*)/i.exec(rest);
+    if (doctype) {
+      if (sawDoctype || doctype[1].toLowerCase() !== 'nzb') return undefined;
+      sawDoctype = true;
+      let quote: '"' | "'" | undefined;
+      let subsetDepth = 0;
+      let end: number | undefined;
+      for (let i = offset + doctype[0].length; i < xml.length; i++) {
+        const char = xml[i];
+        if (quote) {
+          if (char === quote) quote = undefined;
+        } else if (char === '"' || char === "'") {
+          quote = char;
+        } else if (char === '[') {
+          subsetDepth++;
+        } else if (char === ']' && subsetDepth > 0) {
+          subsetDepth--;
+        } else if (char === '>' && subsetDepth === 0) {
+          end = i + 1;
+          break;
+        }
+      }
+      if (end === undefined) return undefined;
+      offset = end;
+      continue;
+    }
+
+    return offset;
+  }
+}
+
 /** Reject obvious non-NZB responses before they can enter the grab cache. */
 export function assertLikelyNzbPayload(contentType: string, buf: Buffer): void {
   const head = buf
@@ -68,9 +120,11 @@ export function assertLikelyNzbPayload(contentType: string, buf: Buffer): void {
     contentType.toLowerCase().includes('text/html') ||
     /<!doctype\s+html|<html(?:\s|>)/i.test(head);
 
-  const containsNzbRoot = /<nzb(?:\s|>)/i.test(head);
+  const rootOffset = xmlRootOffset(head);
+  const hasNzbRoot =
+    rootOffset !== undefined && /^<nzb(?:\s|>)/i.test(head.slice(rootOffset));
 
-  if (buf.length === 0 || looksLikeHtml || !containsNzbRoot) {
+  if (buf.length === 0 || looksLikeHtml || !hasNzbRoot) {
     throw new InvalidNzbPayloadError(contentType, buf.length);
   }
 }

--- a/packages/core/src/utils/grab-cache.test.ts
+++ b/packages/core/src/utils/grab-cache.test.ts
@@ -9,6 +9,7 @@ import {
   NzbTooLargeError,
   assertLikelyNzbPayload,
 } from './download-manager.js';
+import { DiskBackedCache } from './disk-backed-cache.js';
 import { GrabCache } from './grab-cache.js';
 
 const bufferCodec = {
@@ -191,6 +192,52 @@ describe('GrabCache.delete', () => {
       await cache.fetch('target', async () => Buffer.from('fresh')),
       Buffer.from('fresh')
     );
+  });
+
+  it('waits for a pending cached L2 read before deletion', async (t) => {
+    const cache = await testCache(t, {
+      maxMemBytes: 0,
+      maxDiskBytes: 1024,
+    });
+    const key = 'https://indexer.test/api?t=get&id=pending-read';
+    const stale = Buffer.from('stale');
+    await cache.fetch(key, async () => stale);
+
+    const backing = (cache as unknown as { cache: DiskBackedCache<Buffer> })
+      .cache;
+    await backing.flush();
+    backing.resize(1024);
+
+    const readStarted = deferred<void>();
+    const releaseRead = deferred<void>();
+    const originalGetAsync = backing.getAsync.bind(backing);
+    let firstRead = true;
+    t.mock.method(backing, 'getAsync', async (readKey: string) => {
+      if (!firstRead) return originalGetAsync(readKey);
+      firstRead = false;
+      readStarted.resolve();
+      await releaseRead.promise;
+      // Model getAsync's completed L2-read promotion after invalidation began.
+      backing.set(readKey, stale, { skipDisk: true });
+      return stale;
+    });
+    const originalDelete = backing.delete.bind(backing);
+    const deleteBacking = t.mock.method(
+      backing,
+      'delete',
+      (deleteKey: string) => originalDelete(deleteKey)
+    );
+
+    const reading = cache.cached(key);
+    await readStarted.promise;
+    const deleting = cache.delete(key);
+    assert.equal(deleteBacking.mock.callCount(), 0);
+
+    releaseRead.resolve();
+    assert.deepEqual(await reading, stale);
+    assert.equal(await deleting, true);
+    assert.equal(deleteBacking.mock.callCount(), 1);
+    assert.equal(await originalGetAsync(key), undefined);
   });
 });
 

--- a/packages/core/src/utils/grab-cache.test.ts
+++ b/packages/core/src/utils/grab-cache.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, type TestContext } from 'node:test';
+import { parseNzb } from '../usenet/nzb/parse.js';
+import {
+  GrabHttpError,
+  NzbTooLargeError,
+  assertLikelyNzbPayload,
+} from './download-manager.js';
+import { GrabCache } from './grab-cache.js';
+
+const bufferCodec = {
+  serialize: (value: Buffer): Buffer => value,
+  deserialize: (value: Buffer): Buffer => value,
+  sizeOf: (value: Buffer): number => value.length,
+};
+
+const VALID_NZB = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+  <file poster="poster" date="1" subject="&quot;video.mkv&quot; yEnc (1/1)">
+    <groups><group>alt.binaries.test</group></groups>
+    <segments><segment bytes="10" number="1">part@example.test</segment></segments>
+  </file>
+</nzb>`);
+
+async function testCache(
+  t: TestContext,
+  opts: { maxMemBytes?: number; maxDiskBytes?: number } = {}
+): Promise<GrabCache<Buffer>> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aiostreams-grab-test-'));
+  t.after(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+  return new GrabCache<Buffer>({
+    name: 'grab-test',
+    dir,
+    maxMemBytes: opts.maxMemBytes ?? 1024 * 1024,
+    maxDiskBytes: opts.maxDiskBytes ?? 0,
+    ...bufferCodec,
+  });
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('GrabCache producer validation', () => {
+  it('does not cache a successful HTTP-shaped HTML payload', async (t) => {
+    const cache = await testCache(t);
+    const url = 'https://indexer.test/api?t=get&id=poisoned';
+    let requests = 0;
+    const produce = async (): Promise<Buffer> => {
+      requests++;
+      const body = Buffer.from('<!doctype html><html>Login</html>');
+      assertLikelyNzbPayload('text/html', body);
+      return body;
+    };
+
+    await assert.rejects(() => cache.fetch(url, produce));
+    assert.equal(await cache.cached(url), undefined);
+    await assert.rejects(() => cache.fetch(url, produce));
+    assert.equal(requests, 2);
+  });
+
+  it('caches a valid NZB after validation and preserves single-flight', async (t) => {
+    const cache = await testCache(t);
+    const url = 'https://indexer.test/api?t=get&id=valid';
+    const release = deferred<Buffer>();
+    let requests = 0;
+    const produce = async (): Promise<Buffer> => {
+      requests++;
+      const body = await release.promise;
+      assertLikelyNzbPayload('application/octet-stream', body);
+      return body;
+    };
+
+    const first = cache.fetch(url, produce);
+    const second = cache.fetch(url, produce);
+    release.resolve(VALID_NZB);
+    assert.deepEqual(await first, VALID_NZB);
+    assert.deepEqual(await second, VALID_NZB);
+    assert.deepEqual(await cache.fetch(url, produce), VALID_NZB);
+    assert.equal(requests, 1);
+  });
+
+  it('does not cache HTTP or size failures', async (t) => {
+    const cache = await testCache(t);
+    const cases = [
+      {
+        key: 'http',
+        error: new GrabHttpError(503, 'Service Unavailable'),
+      },
+      { key: 'size', error: new NzbTooLargeError(101, 100) },
+    ];
+
+    for (const { key, error } of cases) {
+      let attempts = 0;
+      const produce = async (): Promise<Buffer> => {
+        attempts++;
+        throw error;
+      };
+      await assert.rejects(() => cache.fetch(key, produce), error.constructor);
+      assert.equal(await cache.cached(key), undefined);
+      await assert.rejects(() => cache.fetch(key, produce), error.constructor);
+      assert.equal(attempts, 2);
+    }
+  });
+});
+
+describe('GrabCache.delete', () => {
+  for (const tier of [
+    { name: 'L1', maxMemBytes: 1024, maxDiskBytes: 0 },
+    { name: 'L2', maxMemBytes: 0, maxDiskBytes: 1024 },
+  ]) {
+    it(`removes only the requested key from ${tier.name}`, async (t) => {
+      const cache = await testCache(t, tier);
+      await cache.fetch('target', async () => Buffer.from('target'));
+      await cache.fetch('other', async () => Buffer.from('other'));
+      assert.deepEqual(await cache.cached('target'), Buffer.from('target'));
+      assert.deepEqual(await cache.cached('other'), Buffer.from('other'));
+
+      assert.equal(await cache.delete('target'), true);
+      assert.equal(await cache.cached('target'), undefined);
+      assert.deepEqual(await cache.cached('other'), Buffer.from('other'));
+      assert.equal(await cache.delete('target'), false);
+      assert.equal(await cache.delete('unknown'), false);
+    });
+  }
+
+  it('coalesces deletes, waits an earlier producer, and gates a new fetch', async (t) => {
+    const cache = await testCache(t);
+    const started = deferred<void>();
+    const release = deferred<Buffer>();
+    let replacementRuns = 0;
+
+    const first = cache.fetch('target', async () => {
+      started.resolve();
+      return release.promise;
+    });
+    await started.promise;
+
+    const deleting = cache.delete('target');
+    const coalesced = cache.delete('target');
+    assert.strictEqual(coalesced, deleting);
+
+    const replacement = cache.fetch('target', async () => {
+      replacementRuns++;
+      return Buffer.from('fresh');
+    });
+    const unrelated = cache.fetch('other', async () => Buffer.from('other'));
+    assert.deepEqual(await unrelated, Buffer.from('other'));
+    assert.equal(replacementRuns, 0);
+
+    release.resolve(Buffer.from('stale'));
+    assert.deepEqual(await first, Buffer.from('stale'));
+    assert.equal(await deleting, true);
+    assert.equal(await coalesced, true);
+    assert.deepEqual(await replacement, Buffer.from('fresh'));
+    assert.equal(replacementRuns, 1);
+    assert.deepEqual(await cache.cached('target'), Buffer.from('fresh'));
+  });
+
+  it('still invalidates after an earlier producer rejects', async (t) => {
+    const cache = await testCache(t);
+    const started = deferred<void>();
+    const release = deferred<Buffer>();
+    const original = new Error('producer failed');
+    const first = cache.fetch('target', async () => {
+      started.resolve();
+      return release.promise;
+    });
+    await started.promise;
+    const deleting = cache.delete('target');
+    release.reject(original);
+
+    await assert.rejects(first, (err) => err === original);
+    assert.equal(await deleting, false);
+    assert.deepEqual(
+      await cache.fetch('target', async () => Buffer.from('fresh')),
+      Buffer.from('fresh')
+    );
+  });
+});
+
+describe('poisoned NZB self-healing', () => {
+  it('evicts a pre-existing poisoned URL after parsing and fetches fresh next time', async (t) => {
+    const cache = await testCache(t);
+    const url = 'https://indexer.test/api?t=get&id=self-heal';
+    const otherUrl = 'https://indexer.test/api?t=get&id=other';
+    const poisoned = Buffer.from('<html><body>Rules</body></html>');
+    await cache.fetch(url, async () => poisoned);
+    await cache.fetch(otherUrl, async () => VALID_NZB);
+
+    const cached = await cache.fetch(url, async () => {
+      throw new Error('poisoned entry should have been a cache hit');
+    });
+    let parseError: unknown;
+    try {
+      await parseNzb(cached);
+    } catch (err) {
+      parseError = err;
+      await cache.delete(url);
+    }
+    assert.ok(parseError instanceof Error);
+    assert.equal(await cache.cached(url), undefined);
+    assert.deepEqual(await cache.cached(otherUrl), VALID_NZB);
+
+    let remoteRequests = 0;
+    const fresh = await cache.fetch(url, async () => {
+      remoteRequests++;
+      return VALID_NZB;
+    });
+    const parsed = await parseNzb(fresh);
+    assert.equal(parsed.files.length, 1);
+    assert.deepEqual(await cache.fetch(url, async () => poisoned), VALID_NZB);
+    assert.equal(remoteRequests, 1);
+  });
+});

--- a/packages/core/src/utils/grab-cache.ts
+++ b/packages/core/src/utils/grab-cache.ts
@@ -40,6 +40,10 @@ export interface GrabCacheOptions<V> {
 export class GrabCache<V> {
   private readonly cache: DiskBackedCache<V>;
   private readonly inflight = new Map<string, Promise<V>>();
+  /** Full fetch lifecycle, including the async L2 lookup before production. */
+  private readonly fetches = new Map<string, Promise<V>>();
+  /** Per-key invalidations; unrelated grab URLs never block one another. */
+  private readonly deletions = new Map<string, Promise<boolean>>();
 
   constructor(opts: GrabCacheOptions<V>) {
     this.cache = new DiskBackedCache<V>({
@@ -54,7 +58,12 @@ export class GrabCache<V> {
   }
 
   /** Cached value for `key` (L1→L2), or `undefined` on a miss. */
-  cached(key: string): Promise<V | undefined> {
+  async cached(key: string): Promise<V | undefined> {
+    for (;;) {
+      const deleting = this.deletions.get(key);
+      if (!deleting) break;
+      await deleting.catch(() => false);
+    }
     return this.cache.getAsync(key);
   }
 
@@ -69,17 +78,62 @@ export class GrabCache<V> {
    * to the cache; failures reject and are not cached.
    */
   async fetch(key: string, produce: () => Promise<V>): Promise<V> {
-    const hit = await this.cached(key);
-    if (hit !== undefined) return hit;
-    const existing = this.inflight.get(key);
+    // A fetch that arrives during invalidation must observe the post-delete
+    // state. Loop because another coalesced invalidation may start as the
+    // previous one settles.
+    for (;;) {
+      const deleting = this.deletions.get(key);
+      if (!deleting) break;
+      await deleting.catch(() => false);
+    }
+
+    // Register before the first async cache lookup. This closes the window in
+    // which delete() could otherwise miss a fetch that has begun reading L2
+    // but has not started its producer yet.
+    const active = this.fetches.get(key);
+    if (active) return active;
+
+    let fetch!: Promise<V>;
+    fetch = (async () => {
+      const hit = await this.cache.getAsync(key);
+      if (hit !== undefined) return hit;
+
+      const existing = this.inflight.get(key);
+      if (existing) return existing;
+
+      const producer = produce()
+        .then((value) => {
+          this.cache.set(key, value);
+          return value;
+        })
+        .finally(() => {
+          if (this.inflight.get(key) === producer) {
+            this.inflight.delete(key);
+          }
+        });
+      this.inflight.set(key, producer);
+      return producer;
+    })().finally(() => {
+      if (this.fetches.get(key) === fetch) this.fetches.delete(key);
+    });
+    this.fetches.set(key, fetch);
+    return fetch;
+  }
+
+  /** Remove one key after any earlier fetch for it has completely settled. */
+  delete(key: string): Promise<boolean> {
+    const existing = this.deletions.get(key);
     if (existing) return existing;
-    const p = produce()
-      .then((value) => {
-        this.cache.set(key, value);
-        return value;
-      })
-      .finally(() => this.inflight.delete(key));
-    this.inflight.set(key, p);
-    return p;
+
+    let deletion!: Promise<boolean>;
+    deletion = (async () => {
+      const running = this.fetches.get(key);
+      if (running) await running.catch(() => undefined);
+      return this.cache.delete(key);
+    })().finally(() => {
+      if (this.deletions.get(key) === deletion) this.deletions.delete(key);
+    });
+    this.deletions.set(key, deletion);
+    return deletion;
   }
 }

--- a/packages/core/src/utils/grab-cache.ts
+++ b/packages/core/src/utils/grab-cache.ts
@@ -42,6 +42,8 @@ export class GrabCache<V> {
   private readonly inflight = new Map<string, Promise<V>>();
   /** Full fetch lifecycle, including the async L2 lookup before production. */
   private readonly fetches = new Map<string, Promise<V>>();
+  /** Standalone cached() reads that may promote an L2 hit back into L1. */
+  private readonly reads = new Map<string, Set<Promise<V | undefined>>>();
   /** Per-key invalidations; unrelated grab URLs never block one another. */
   private readonly deletions = new Map<string, Promise<boolean>>();
 
@@ -64,7 +66,21 @@ export class GrabCache<V> {
       if (!deleting) break;
       await deleting.catch(() => false);
     }
-    return this.cache.getAsync(key);
+
+    let readsForKey = this.reads.get(key);
+    if (!readsForKey) {
+      readsForKey = new Set();
+      this.reads.set(key, readsForKey);
+    }
+    let read!: Promise<V | undefined>;
+    read = this.cache.getAsync(key).finally(() => {
+      readsForKey.delete(read);
+      if (readsForKey.size === 0 && this.reads.get(key) === readsForKey) {
+        this.reads.delete(key);
+      }
+    });
+    readsForKey.add(read);
+    return read;
   }
 
   /** The in-flight producer for `key`, if one is running. */
@@ -129,6 +145,8 @@ export class GrabCache<V> {
     deletion = (async () => {
       const running = this.fetches.get(key);
       if (running) await running.catch(() => undefined);
+      const reads = this.reads.get(key);
+      if (reads) await Promise.allSettled([...reads]);
       return this.cache.delete(key);
     })().finally(() => {
       if (this.deletions.get(key) === deletion) this.deletions.delete(key);

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -1,5 +1,31 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after } from 'node:test';
+
 const env = process.env as Record<string, string | undefined>;
 env.NODE_ENV ??= 'test';
 env.SECRET_KEY ??= '0'.repeat(64); // 64-char hex required by the validator
 env.BASE_URL ??= 'http://localhost:3000'; // Vite-injected '/' would fail it
 env.LOG_LEVEL ??= 'error'; // keep test output clean; override to debug locally
+
+const testRoot = await fs.mkdtemp(
+  path.join(os.tmpdir(), 'aiostreams-core-test-')
+);
+env.DATABASE_URI = `sqlite://${path.join(testRoot, 'test.sqlite')}`;
+env.DISK_CACHE_DIR = path.join(testRoot, 'cache');
+delete env.USENET_PROVIDERS;
+
+// Initialise the config-led import graph before isolated test modules import
+// logger-backed utilities directly. The production entry point establishes the
+// same order; without it, ESM can enter logger -> redact -> config via a cycle.
+const { config, settingsStore } = await import('../src/config/index.js');
+const { closeDb, initDb } = await import('../src/db/db.js');
+
+await initDb(config.bootstrap.databaseUri);
+await settingsStore.initialise();
+
+after(async () => {
+  await closeDb();
+  await fs.rm(testRoot, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem

NZB grab endpoints can return HTTP 200 with an HTML login, rules, or error page instead of an NZB. They can also return XML that looks like an NZB but fails strict parsing. These responses could enter the persistent grab cache, causing later resolve and playback requests to reuse a poisoned entry until it expired.

Cache deletion also needed to account for in-flight producers and pending disk writes so stale data could not be restored after invalidation.

## Fix

- Validate downloaded NZB payloads after the size check and before cache admission, rejecting empty, HTML, and non-NZB responses.
- Invalidate only the exact cached URL when strict parsing fails in resolve, manual URL import, dashboard speed test, and cold stream-open paths. The original parse error is preserved and the same request is not retried.
- Coordinate per-key fetches and deletions, and wait for pending disk writes before targeted removal.
- Keep the shared invalidation helpers internal instead of exporting them through the public Core API.

Direct XML uploads remain local and never trigger remote cache invalidation.

## Verification

- `pnpm -F core test` — 32 tests passed
- `pnpm -F core build`
- `pnpm run build`
- Targeted Prettier check for the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed or invalid NZB downloads are detected earlier, including empty, HTML, malformed, or non-NZB responses.
  - Failed remote NZB grabs are automatically invalidated for clean retries, while preserving the original parsing error.
  - Directly uploaded NZB content is excluded from remote grab invalidation.
- **Reliability**
  - Improved cache handling prevents deleted or invalid entries from reappearing.
  - Concurrent downloads, cache reads, writes, and deletions now complete more reliably.
  - Invalid responses are prevented from entering the download cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->