### PR TITLE
feat(failover): detect debrid error videos and fail over to the next stream

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -901,6 +901,8 @@ export const UserDataSchema = z.object({
       precacheFailover: z.boolean().optional(),
       /** Include non-owned addon debrid URLs (resolved by probing) as failover targets. Default false. */
       includeExternalFailover: z.boolean().optional(),
+      /** Probe each resolved playback URL and fail over when the debrid service serves a short error video instead of the release. Costs one extra request per attempt. Default false. */
+      verifyPlayback: z.boolean().optional(),
       /** Max same-release variant attempts tried per release before moving on (0 disables). */
       sameReleaseLimit: z.number().min(0).optional(),
       /** Delay between launching same-release variant attempts (ms). Default 0. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,3 +69,15 @@ export type {
   RunPlayChainConfig,
   RunPlayChainResult,
 } from './main/failover.js';
+export {
+  classifyProbedBody,
+  createProbeSignal,
+  verifyPlaybackUrl,
+  MIN_PLAUSIBLE_FILE_SIZE,
+  DEFAULT_PROBE_TIMEOUT_MS,
+} from './main/playback-probe.js';
+export type {
+  ProbeVerdict,
+  ProbedBody,
+  VerifyPlaybackOptions,
+} from './main/playback-probe.js';

--- a/packages/core/src/main/failover.ts
+++ b/packages/core/src/main/failover.ts
@@ -17,6 +17,12 @@ import {
   PLAYBACK_PATH_PREFIX,
 } from '../debrid/utils.js';
 import { isFailoverRetryableError } from './play-chain.js';
+import {
+  classifyProbedBody,
+  createProbeSignal,
+  verifyPlaybackUrl,
+  DEFAULT_PROBE_TIMEOUT_MS,
+} from './playback-probe.js';
 
 const logger = createLogger('failover');
 
@@ -107,10 +113,19 @@ function buildPlaybackInfo(
  * Decode + resolve a single owned playback target to a servable URL (or
  * undefined if the source is still downloading). Used uniformly for the clicked
  * item and every failover target.
+ *
+ * With `ctx.verify`, the resolved URL is probed before it is handed back, so a
+ * debrid provider answering a dead link with its "content unavailable" clip
+ * fails the attempt and the chain advances to the next stream instead of
+ * playing the error video.
  */
 export async function resolvePlaybackTarget(
   target: PlaybackTarget,
-  ctx: { clientIp?: string },
+  ctx: {
+    clientIp?: string;
+    /** Probe the resolved URL and reject error videos. */
+    verify?: boolean;
+  },
   signal?: AbortSignal
 ): Promise<string | undefined> {
   const fileInfo = await decodeFileInfo(target.fileInfoRaw);
@@ -137,24 +152,19 @@ export async function resolvePlaybackTarget(
     storeAuth.credential,
     ctx.clientIp
   );
-  return service.resolve(
+  const url = await service.resolve(
     playbackInfo,
     target.filename,
     fileInfo.cacheAndPlay ?? false,
     fileInfo.autoRemoveDownloads,
     signal
   );
-}
 
-/**
- * Smallest body we will accept as a real release.
- */
-const MIN_PLAUSIBLE_FILE_SIZE = 16 * 1024 * 1024;
-
-/** Total size out of a `Content-Range: bytes 0-0/12345` header, when stated. */
-function parseContentRangeTotal(value: string | null): number | undefined {
-  const total = value?.match(/\/\s*(\d+)\s*$/)?.[1];
-  return total === undefined ? undefined : Number(total);
+  // undefined = still downloading; there is nothing to probe yet.
+  if (url && ctx.verify) {
+    await verifyPlaybackUrl(url, { clientIp: ctx.clientIp, signal });
+  }
+  return url;
 }
 
 /**
@@ -182,10 +192,12 @@ export async function resolveExternalTarget(
   })();
   logger.debug({ host }, 'probing external failover target');
   const res = await makeRequest(url, {
-    timeout: 10000,
+    timeout: DEFAULT_PROBE_TIMEOUT_MS,
     method: 'GET',
     forwardIp: ctx.clientIp,
-    signal,
+    // makeRequest ignores `timeout` whenever a signal is given, so combine the
+    // two or this probe would inherit the whole failover deadline.
+    signal: createProbeSignal(DEFAULT_PROBE_TIMEOUT_MS, signal),
     headers: { Range: 'bytes=0-0' },
     rawOptions: { redirect: 'manual' },
   });
@@ -211,52 +223,18 @@ export async function resolveExternalTarget(
       return location;
     }
 
-    if (res.status >= 200 && res.status < 300) {
-      const contentType = res.headers.get('content-type') ?? '';
-      if (
-        !contentType.startsWith('video/') &&
-        !contentType.startsWith('application/octet-stream')
-      ) {
-        throw new Error(
-          `external target returned non-video response (${contentType || res.status})`
-        );
-      }
-
-      if (res.status === 206) {
-        const total = parseContentRangeTotal(res.headers.get('content-range'));
-        if (total !== undefined && total < MIN_PLAUSIBLE_FILE_SIZE) {
-          throw new Error(
-            `external target served a ${total}-byte file, too small to be the release`
-          );
-        }
-        logger.debug(
-          { host, contentType, total },
-          'external target serves ranged bytes; using probe url'
-        );
-        return url;
-      }
-
-      // 200: the server ignored our Range. A link that cannot seek is unusable for
-      // playback anyway, so accept it only if it at least declares a real size.
-      const lengthHeader = res.headers.get('content-length');
-      const length = lengthHeader === null ? undefined : Number(lengthHeader);
-      if (
-        length !== undefined &&
-        Number.isFinite(length) &&
-        length >= MIN_PLAUSIBLE_FILE_SIZE
-      ) {
-        logger.debug(
-          { host, contentType, length },
-          'external target serves bytes directly without range support; using probe url'
-        );
-        return url;
-      }
-      throw new Error(
-        `external target ignored Range and returned ${lengthHeader ?? 'an unsized'} body (${contentType}); treating as an error video`
-      );
+    const verdict = classifyProbedBody({
+      status: res.status,
+      headers: res.headers,
+    });
+    if (!verdict.ok) {
+      throw new Error(`external target ${verdict.reason}`);
     }
-
-    throw new Error(`external target probe failed with status ${res.status}`);
+    logger.debug(
+      { host, status: res.status },
+      'external target serves the release; using probe url'
+    );
+    return url;
   } finally {
     // Never read the body. A server that ignores Range answers 200 with the whole
     // file, and we only ever needed the headers.

--- a/packages/core/src/main/play-chain.ts
+++ b/packages/core/src/main/play-chain.ts
@@ -82,6 +82,8 @@ export interface PlayChainRecord {
   sameReleaseLimit: number;
   /** Delay between launching same-release variant attempts (ms). */
   duplicateStaggerMs: number;
+  /** Probe resolved playback URLs and fail over off debrid error videos. */
+  verifyPlayback: boolean;
 }
 
 /** Build-time options derived from the user's `failover` config. */
@@ -102,6 +104,8 @@ export interface BuildPlayChainOptions {
   sameReleaseLimit: number;
   /** Delay between launching same-release variant attempts (ms). */
   duplicateStaggerMs: number;
+  /** Probe resolved playback URLs and fail over off debrid error videos. */
+  verifyPlayback?: boolean;
 }
 
 function chainCache() {
@@ -215,6 +219,7 @@ export async function buildPlayChain(
     proxyConfig: opts.proxyConfig?.enabled ? opts.proxyConfig : undefined,
     sameReleaseLimit: opts.sameReleaseLimit,
     duplicateStaggerMs: opts.duplicateStaggerMs,
+    verifyPlayback: opts.verifyPlayback ?? false,
   };
   await chainCache().set(
     listKey,
@@ -287,6 +292,8 @@ export interface ResolvedPlayChain {
   clickedProxied?: boolean;
   /** Delay between launching same-release variant attempts (ms). */
   duplicateStaggerMs: number;
+  /** Probe resolved playback URLs and fail over off debrid error videos. */
+  verifyPlayback: boolean;
 }
 
 /** Stable identity of a resolvable target, ignoring the display-only fallback-key
@@ -391,6 +398,8 @@ export async function getPlayChain(
     clicked: clickedItem,
     clickedProxied: clickedItem?.proxied,
     duplicateStaggerMs: record.duplicateStaggerMs,
+    // Chains cached before this field existed default to the old behaviour.
+    verifyPlayback: record.verifyPlayback ?? false,
   };
 }
 

--- a/packages/core/src/main/playback-probe.test.ts
+++ b/packages/core/src/main/playback-probe.test.ts
@@ -1,0 +1,242 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MIN_PLAUSIBLE_FILE_SIZE,
+  classifyProbedBody,
+  verifyPlaybackUrl,
+  type ProbeResponse,
+} from './playback-probe.js';
+
+const MiB = 1024 * 1024;
+const GiB = 1024 * MiB;
+
+function headers(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+function okResponse(): ProbeResponse {
+  return {
+    status: 206,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-range': `bytes 0-0/${20 * GiB}`,
+    }),
+  };
+}
+
+test('accepts a ranged response whose declared total is a plausible release', () => {
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-range': `bytes 0-0/${20 * GiB}`,
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('rejects a ranged response whose declared total is an error-video-sized file', () => {
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-range': 'bytes 0-0/1048576',
+    }),
+  });
+
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.ok === false ? verdict.reason : '', /1048576/);
+});
+
+test('accepts a file that is only just above the floor', () => {
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-range': `bytes 0-0/${MIN_PLAUSIBLE_FILE_SIZE}`,
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('accepts a ranged response that states no total', () => {
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({ 'content-type': 'video/mp4' }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('rejects a response that is not video or octet-stream', () => {
+  const verdict = classifyProbedBody({
+    status: 200,
+    headers: headers({
+      'content-type': 'text/html',
+      'content-length': String(20 * GiB),
+    }),
+  });
+
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.ok === false ? verdict.reason : '', /text\/html/);
+});
+
+test('accepts octet-stream, which debrid CDNs use for direct downloads', () => {
+  const verdict = classifyProbedBody({
+    status: 200,
+    headers: headers({
+      'content-type': 'application/octet-stream',
+      'content-length': String(20 * GiB),
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('rejects a response that ignored Range and declared a tiny body', () => {
+  const verdict = classifyProbedBody({
+    status: 200,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-length': String(2 * MiB),
+    }),
+  });
+
+  assert.equal(verdict.ok, false);
+});
+
+test('rejects a response that ignored Range and declared no size at all', () => {
+  const verdict = classifyProbedBody({
+    status: 200,
+    headers: headers({ 'content-type': 'video/mp4' }),
+  });
+
+  assert.equal(verdict.ok, false);
+});
+
+test('rejects a non-success status', () => {
+  const verdict = classifyProbedBody({
+    status: 404,
+    headers: headers({ 'content-type': 'video/mp4' }),
+  });
+
+  assert.equal(verdict.ok, false);
+  assert.match(verdict.ok === false ? verdict.reason : '', /404/);
+});
+
+test('verifyPlaybackUrl resolves for a healthy target and cancels the body', async () => {
+  let cancelled = false;
+  const response: ProbeResponse = {
+    ...okResponse(),
+    body: {
+      cancel: async () => {
+        cancelled = true;
+      },
+    },
+  };
+
+  await verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+    request: async () => response,
+  });
+
+  assert.equal(cancelled, true);
+});
+
+test('verifyPlaybackUrl throws a retryable error for an error video', async () => {
+  const response: ProbeResponse = {
+    status: 206,
+    headers: headers({
+      'content-type': 'video/mp4',
+      'content-range': 'bytes 0-0/524288',
+    }),
+  };
+
+  await assert.rejects(
+    () =>
+      verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+        request: async () => response,
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof Error);
+      // No `code`, so isFailoverRetryableError() lets the chain advance.
+      assert.equal((err as { code?: string }).code, undefined);
+      return true;
+    }
+  );
+});
+
+test('verifyPlaybackUrl sends a single-byte range request for the given url', async () => {
+  let seenUrl: string | undefined;
+  let seenInit: Record<string, any> | undefined;
+
+  await verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+    clientIp: '1.2.3.4',
+    request: async (url, init) => {
+      seenUrl = url;
+      seenInit = init as Record<string, any>;
+      return okResponse();
+    },
+  });
+
+  assert.equal(seenUrl, 'https://cdn.example.com/file.mkv');
+  assert.equal(seenInit?.headers?.Range, 'bytes=0-0');
+  assert.equal(seenInit?.forwardIp, '1.2.3.4');
+});
+
+test('verifyPlaybackUrl aborts the probe when the caller aborts', async () => {
+  const caller = new AbortController();
+  let probeSignal: AbortSignal | undefined;
+
+  await verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+    signal: caller.signal,
+    request: async (_url, init) => {
+      probeSignal = (init as { signal?: AbortSignal }).signal;
+      return okResponse();
+    },
+  });
+
+  assert.ok(probeSignal);
+  assert.equal(probeSignal!.aborted, false);
+  caller.abort();
+  assert.equal(probeSignal!.aborted, true);
+});
+
+test('verifyPlaybackUrl bounds the probe with its own timeout even when the caller passes a signal', async () => {
+  // makeRequest only applies `timeout` when no signal is given, so a probe that
+  // forwards the caller's signal verbatim would inherit the whole chain deadline
+  // instead of failing fast.
+  const caller = new AbortController();
+  let probeSignal: AbortSignal | undefined;
+
+  await verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+    signal: caller.signal,
+    timeout: 10,
+    request: async (_url, init) => {
+      probeSignal = (init as { signal?: AbortSignal }).signal;
+      return okResponse();
+    },
+  });
+
+  assert.notEqual(probeSignal, caller.signal);
+  await new Promise((r) => setTimeout(r, 40));
+  assert.equal(probeSignal!.aborted, true);
+});
+
+test('verifyPlaybackUrl still bounds the probe when no caller signal is given', async () => {
+  let probeSignal: AbortSignal | undefined;
+
+  await verifyPlaybackUrl('https://cdn.example.com/file.mkv', {
+    timeout: 10,
+    request: async (_url, init) => {
+      probeSignal = (init as { signal?: AbortSignal }).signal;
+      return okResponse();
+    },
+  });
+
+  assert.ok(probeSignal);
+  await new Promise((r) => setTimeout(r, 40));
+  assert.equal(probeSignal!.aborted, true);
+});

--- a/packages/core/src/main/playback-probe.test.ts
+++ b/packages/core/src/main/playback-probe.test.ts
@@ -96,6 +96,43 @@ test('accepts octet-stream, which debrid CDNs use for direct downloads', () => {
   assert.deepEqual(verdict, { ok: true });
 });
 
+test('accepts a video content type regardless of case', () => {
+  // RFC 9110 §8.3: media type and subtype are case-insensitive.
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({
+      'content-type': 'Video/MP4',
+      'content-range': `bytes 0-0/${20 * GiB}`,
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('accepts an octet-stream content type regardless of case', () => {
+  const verdict = classifyProbedBody({
+    status: 200,
+    headers: headers({
+      'content-type': 'Application/Octet-Stream',
+      'content-length': String(20 * GiB),
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
+test('accepts a video content type carrying parameters', () => {
+  const verdict = classifyProbedBody({
+    status: 206,
+    headers: headers({
+      'content-type': 'VIDEO/x-matroska; charset=binary',
+      'content-range': `bytes 0-0/${20 * GiB}`,
+    }),
+  });
+
+  assert.deepEqual(verdict, { ok: true });
+});
+
 test('rejects a response that ignored Range and declared a tiny body', () => {
   const verdict = classifyProbedBody({
     status: 200,

--- a/packages/core/src/main/playback-probe.ts
+++ b/packages/core/src/main/playback-probe.ts
@@ -52,9 +52,12 @@ export function classifyProbedBody({
   }
 
   const contentType = headers.get('content-type') ?? '';
+  // RFC 9110 §8.3: type and subtype are case-insensitive, so a CDN answering
+  // `Video/MP4` is serving a perfectly good file.
+  const mediaType = contentType.toLowerCase();
   if (
-    !contentType.startsWith('video/') &&
-    !contentType.startsWith('application/octet-stream')
+    !mediaType.startsWith('video/') &&
+    !mediaType.startsWith('application/octet-stream')
   ) {
     return {
       ok: false,

--- a/packages/core/src/main/playback-probe.ts
+++ b/packages/core/src/main/playback-probe.ts
@@ -1,0 +1,172 @@
+import {
+  createLogger,
+  makeRequest,
+  type RequestOptions,
+} from '../utils/index.js';
+
+const logger = createLogger('failover');
+
+/**
+ * Smallest body we will accept as a real release. Debrid providers answer a dead
+ * or unavailable link with a few-seconds "content unavailable" clip; those clips
+ * are orders of magnitude below this.
+ *
+ * Deliberately a blanket floor rather than a comparison against the size the
+ * source advertised: `ParsedStream.size` is only reliably per-file for our own
+ * builtins, and falls back to whatever an external addon put in `stream.size` or
+ * its description — often a season-pack total. Sizing the check off that would
+ * reject perfectly good single-episode files.
+ */
+export const MIN_PLAUSIBLE_FILE_SIZE = 16 * 1024 * 1024;
+
+/** How long a probe may take before it is abandoned. */
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+export type ProbeVerdict = { ok: true } | { ok: false; reason: string };
+
+/** The parts of a probe response the classifier reads. */
+export interface ProbedBody {
+  status: number;
+  headers: Headers;
+}
+
+/** Total size out of a `Content-Range: bytes 0-0/12345` header, when stated. */
+export function parseContentRangeTotal(
+  value: string | null | undefined
+): number | undefined {
+  const total = value?.match(/\/\s*(\d+)\s*$/)?.[1];
+  return total === undefined ? undefined : Number(total);
+}
+
+/**
+ * Decide whether a probed response is the real release or a stand-in error
+ * video, from status, content type and declared size alone. Pure — the body is
+ * never read.
+ */
+export function classifyProbedBody({
+  status,
+  headers,
+}: ProbedBody): ProbeVerdict {
+  if (status < 200 || status >= 300) {
+    return { ok: false, reason: `probe failed with status ${status}` };
+  }
+
+  const contentType = headers.get('content-type') ?? '';
+  if (
+    !contentType.startsWith('video/') &&
+    !contentType.startsWith('application/octet-stream')
+  ) {
+    return {
+      ok: false,
+      reason: `returned a non-video response (${contentType || status})`,
+    };
+  }
+
+  if (status === 206) {
+    const total = parseContentRangeTotal(headers.get('content-range'));
+    if (total !== undefined && total < MIN_PLAUSIBLE_FILE_SIZE) {
+      return {
+        ok: false,
+        reason: `served a ${total}-byte file, too small to be the release`,
+      };
+    }
+    return { ok: true };
+  }
+
+  // 200: the server ignored our Range. A link that cannot seek is unusable for
+  // playback anyway, so accept it only if it at least declares a real size.
+  const lengthHeader = headers.get('content-length');
+  const length = lengthHeader === null ? undefined : Number(lengthHeader);
+  if (
+    length !== undefined &&
+    Number.isFinite(length) &&
+    length >= MIN_PLAUSIBLE_FILE_SIZE
+  ) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: `ignored Range and returned ${lengthHeader ?? 'an unsized'} body (${contentType}); treating as an error video`,
+  };
+}
+
+/** The parts of a response {@link verifyPlaybackUrl} needs. */
+export interface ProbeResponse {
+  status: number;
+  headers: Headers;
+  body?: { cancel: () => Promise<unknown> } | null;
+}
+
+export type ProbeRequestFn = (
+  url: string,
+  options: RequestOptions
+) => Promise<ProbeResponse>;
+
+export interface VerifyPlaybackOptions {
+  clientIp?: string;
+  signal?: AbortSignal;
+  timeout?: number;
+  /** Injectable for tests; defaults to the shared request helper. */
+  request?: ProbeRequestFn;
+}
+
+const defaultRequest: ProbeRequestFn = makeRequest;
+
+/**
+ * A signal that trips when the caller aborts OR when the probe outstays its
+ * timeout. `makeRequest` only honours its `timeout` when no signal is supplied,
+ * so a probe that forwarded the caller's signal verbatim would inherit the whole
+ * failover deadline instead of failing fast.
+ */
+export function createProbeSignal(
+  timeout: number,
+  callerSignal: AbortSignal | undefined
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  return callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
+}
+
+/**
+ * Probe a resolved playback URL with a single-byte range request and throw when
+ * it looks like a debrid error video rather than the release. The thrown error
+ * carries no debrid error code, so the failover chain treats it as retryable and
+ * moves on to the next stream.
+ *
+ * `clientIp` is forwarded so IP-bound CDN links resolve for the client, not the
+ * server.
+ */
+export async function verifyPlaybackUrl(
+  url: string,
+  opts: VerifyPlaybackOptions = {}
+): Promise<void> {
+  const request = opts.request ?? defaultRequest;
+  const timeout = opts.timeout ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const res = await request(url, {
+    timeout,
+    method: 'GET',
+    forwardIp: opts.clientIp,
+    signal: createProbeSignal(timeout, opts.signal),
+    headers: { Range: 'bytes=0-0' },
+  });
+
+  try {
+    const verdict = classifyProbedBody({
+      status: res.status,
+      headers: res.headers,
+    });
+    if (!verdict.ok) {
+      throw new Error(`playback target ${verdict.reason}`);
+    }
+    logger.debug({ status: res.status }, 'playback target verified');
+  } finally {
+    // Never read the body. A server that ignores Range answers 200 with the
+    // whole file, and we only ever needed the headers.
+    try {
+      await res.body?.cancel();
+    } catch {
+      // already closed
+    }
+  }
+}

--- a/packages/core/src/main/resources.ts
+++ b/packages/core/src/main/resources.ts
@@ -248,6 +248,7 @@ export async function processStreams(
     includeExternalFailover?: boolean;
     sameReleaseLimit: number;
     duplicateStaggerMs: number;
+    verifyPlayback?: boolean;
   }
 ): Promise<{
   streams: ParsedStream[];
@@ -350,6 +351,7 @@ export async function processStreams(
         includeExternal: failoverOpts.includeExternalFailover,
         sameReleaseLimit: failoverOpts.sameReleaseLimit,
         duplicateStaggerMs: failoverOpts.duplicateStaggerMs,
+        verifyPlayback: failoverOpts.verifyPlayback,
       },
       userScopeKey(ctx.userData)
     ).catch((error) => {
@@ -385,6 +387,7 @@ export async function processStreams(
         includeExternal: failoverOpts.includeExternalFailover,
         sameReleaseLimit: failoverOpts.sameReleaseLimit,
         duplicateStaggerMs: failoverOpts.duplicateStaggerMs,
+        verifyPlayback: failoverOpts.verifyPlayback,
       },
       userScopeKey(ctx.userData)
     ).catch((error) => {
@@ -418,6 +421,7 @@ export async function processStreams(
           includeExternal: failoverOpts.includeExternalFailover,
           sameReleaseLimit: failoverOpts.sameReleaseLimit,
           duplicateStaggerMs: failoverOpts.duplicateStaggerMs,
+          verifyPlayback: failoverOpts.verifyPlayback,
         },
         userScopeKey(ctx.userData)
       ).catch((error) => {
@@ -780,6 +784,9 @@ export async function getStreams(
           duplicateStaggerMs:
             ctx.userData.failover.duplicateStaggerMs ??
             constants.DEFAULT_FAILOVER_DUPLICATE_STAGGER_MS,
+          verifyPlayback:
+            ctx.userData.failover.verifyPlayback ??
+            constants.DEFAULT_FAILOVER_VERIFY_PLAYBACK,
         }
       : undefined
   );

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -222,6 +222,9 @@ export const BUILTIN_PROXY_PATH_PREFIX = '/api/v1/proxy/';
 /** Whether external addon debrid URLs may be used as failover targets. */
 export const DEFAULT_FAILOVER_INCLUDE_EXTERNAL = false;
 
+/** Whether resolved playback URLs are probed for debrid error videos. */
+export const DEFAULT_FAILOVER_VERIFY_PLAYBACK = false;
+
 /** Max same-release variant attempts tried per release before moving on (0 = off). */
 export const DEFAULT_FAILOVER_SAME_RELEASE_LIMIT = 2;
 /** Delay between launching same-release variant attempts (ms). 0 = no delay. */

--- a/packages/docs/content/docs/guides/usenet.mdx
+++ b/packages/docs/content/docs/guides/usenet.mdx
@@ -453,6 +453,7 @@ Stremio NNTP results are excluded — playback happens entirely inside Stremio. 
 - **Failover Content Types** — whether Usenet and/or debrid results may be used as targets.
 - **Allow Cross-Type Failover** — let a failed Usenet result fall through to a debrid result (or vice versa) if that's what's next in the list. Off keeps failover within the clicked result's own kind.
 - **Include External Addon Targets** — see above.
+- **Verify Playback Before Serving** — check each resolved link before your player is redirected to it. Debrid services answer a dead link with a short "content unavailable" video rather than an HTTP error, which otherwise looks like a successful resolve and plays as a few seconds of nothing; when one is detected the link is rejected and failover moves on to the next result. Costs one extra request per attempt, so playback starts slightly slower. Off by default.
 - **Max Failover Attempts** — how many fallback results to try before giving up.
 - **Same-Release Failover Attempts** — see [below](#same-release-variants-deduplicator-merging).
 - **Parallel Attempts** and its timing knobs (backup delay, preferred-item grace, …) — advanced: race several attempts and take the first healthy one.

--- a/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
+++ b/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
@@ -198,6 +198,19 @@ export function BuiltinSettings() {
             }));
           }}
         />
+        <Switch
+          label="Verify Playback Before Serving"
+          side="right"
+          disabled={!userData.failover?.enabled}
+          help="Check each resolved link before handing it to your player. Debrid services answer a dead link with a short 'content unavailable' video instead of an error; when that is detected, the link is rejected and failover moves on to the next result. Costs one extra request per attempt, so playback starts slightly slower."
+          value={userData.failover?.verifyPlayback ?? false}
+          onValueChange={(value) => {
+            setUserData((prev) => ({
+              ...prev,
+              failover: { ...prev.failover, verifyPlayback: value },
+            }));
+          }}
+        />
         {/* --- How many to try (budget) --- */}
         <NumberInput
           label="Max Failover Attempts"

--- a/packages/server/src/routes/api/debrid.ts
+++ b/packages/server/src/routes/api/debrid.ts
@@ -93,6 +93,11 @@ router.get(
 
       const clientIp = req.userIp;
 
+      // Probe each resolved URL before serving it, so a debrid service answering
+      // a dead link with its short "content unavailable" clip fails the attempt
+      // and the chain moves on instead of playing the error video.
+      const verify = chain?.verifyPlayback ?? false;
+
       const arrivedViaOurProxy = !!req.query[constants.INTERNAL_PROXY_MARKER];
       const proxyConfig = chain?.proxyConfig;
 
@@ -139,8 +144,8 @@ router.get(
           }
           const target = parsePlaybackUrl(item.url);
           return target
-            ? resolvePlaybackTarget(target, { clientIp }, signal).then((url) =>
-                maybeProxy(url, item.proxied)
+            ? resolvePlaybackTarget(target, { clientIp, verify }, signal).then(
+                (url) => maybeProxy(url, item.proxied)
               )
             : Promise.reject(new Error('unparseable fallback url'));
         };
@@ -154,7 +159,13 @@ router.get(
           resolve: (signal) =>
             resolvePlaybackTarget(
               { encryptedStoreAuth, fileInfoRaw, metadataId, filename },
-              { clientIp },
+              {
+                clientIp,
+                // With nothing to fail over to, rejecting the clicked item only
+                // trades an error video for an error page — so don't risk a
+                // false positive.
+                verify: verify && hasFailover,
+              },
               signal
             ).then((url) => maybeProxy(url, chain?.clickedProxied)),
         },


### PR DESCRIPTION
## Problem

When a debrid link is dead or unavailable, providers don't return an HTTP error — they return a short "content unavailable" video. `service.resolve()` hands that link back without complaint, so `resolvePlaybackTarget` treats it as a success, it wins the play chain, and the user gets a few seconds of error video with no failover.

The heuristics for spotting one already exist in this repo, but only for *external* addon URLs, inline in `resolveExternalTarget` (16 MiB floor, content-type gate, same-host-redirect rule). The owned debrid path — the main one — never probed anything.

## Change

Extract those heuristics into `classifyProbedBody` (pure, unit-tested) in a new `packages/core/src/main/playback-probe.ts`, and reuse them on the owned path behind a new opt-in `failover.verifyPlayback` option.

When enabled, the resolved URL is probed with a `Range: bytes=0-0` GET before being served. If it looks like an error video, the attempt throws a plain `Error` — no debrid `code`, so `isFailoverRetryableError` treats it as retryable and the chain advances to the next stream.

`resolveExternalTarget` is refactored onto the same classifier. Its redirect handling is untouched and it keeps its existing semantics.

### On sizing the check

I initially compared the served size against the size the source advertised, which would catch error clips above the 16 MiB floor. I dropped it: `ParsedStream.size` is only reliably per-file for the builtins — `getSize()` otherwise falls back to whatever an external addon put in `stream.size` or parsed out of its description, which is frequently a season-pack total. A 2 GiB episode from a release advertised at 20 GiB would have been rejected as an error video. The blanket floor is enough in practice, since provider error clips are ~1–10 MB.

### Drive-by fix

The probe timeout never applied. `makeRequest` does `options.signal ?? AbortSignal.timeout(options.timeout)`, and failover always passes a per-attempt signal, so both probes were bounded only by the whole chain deadline (60s default) rather than 10s. They now race the caller's signal against their own timeout via `AbortSignal.any`, so a hanging CDN fails fast instead of stalling an attempt for a minute.

## Behaviour

- **Off by default** (`DEFAULT_FAILOVER_VERIFY_PLAYBACK = false`). No change for anyone who doesn't enable it.
- Costs one extra request per attempt, so playback starts slightly slower. Called out in the UI help text and the docs.
- The clicked item is only verified when fallbacks exist — with nothing to advance to, rejecting it just trades an error video for an error page, so there's no upside to risking a false positive.
- Play chains cached before this change default `verifyPlayback` to `false`, so nothing breaks across a deploy.
- The schema addition is a plain optional boolean; no migration needed on either driver.

## Testing

15 unit tests in `packages/core/src/main/playback-probe.test.ts` covering the classifier (206 vs 200, missing `content-range`, content-type gate, floor boundary, non-success status) and `verifyPlaybackUrl` (body cancellation, retryable error shape, request shape, signal/timeout composition).

`pnpm -F core test` 15/15, `core` + `server` build, `frontend` typecheck and lint clean.

## Files

- **new** `packages/core/src/main/playback-probe.ts`, `packages/core/src/main/playback-probe.test.ts`
- `packages/core/src/main/failover.ts` — shared classifier, `ctx.verify` on `resolvePlaybackTarget`, timeout fix
- `packages/core/src/main/play-chain.ts`, `resources.ts`, `db/schemas.ts`, `utils/constants.ts`, `index.ts` — flag plumbing
- `packages/server/src/routes/api/debrid.ts` — wiring
- `packages/frontend/src/components/menu/services/_components/builtin-settings.tsx` — toggle
- `packages/docs/content/docs/guides/usenet.mdx` — documented under Failover → Key Settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Verify Playback Before Serving** failover setting.
  * Resolved playback links can be checked for unavailable-content responses before redirection.
  * Invalid links are rejected so failover can continue to the next available result.
  * Added playback verification across playback resolution and failover processing, disabled by default.
* **Documentation**
  * Documented the setting, including its additional verification request per attempt.
* **Tests**
  * Added coverage for response validation, timeouts, cancellation, retries and range requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->