### PR TITLE
fix: coalesce concurrent addon resource requests via distributed lock

### DIFF
--- a/packages/core/src/main/wrapper.ts
+++ b/packages/core/src/main/wrapper.ts
@@ -40,6 +40,7 @@ import {
   appConfig,
   getTimeTakenSincePoint,
   RequestOptions,
+  DistributedLock,
 } from '../utils/index.js';
 import { Preset, PresetManager } from '../presets/index.js';
 import {
@@ -606,7 +607,16 @@ export class Wrapper {
       return result;
     };
 
-    const requestPromise = processRequest();
+    const maxRequestDuration = doBackground
+      ? (appConfig.resources.background.timeout ??
+        appConfig.userLimits.timeouts.maxTimeout)
+      : timeout;
+    const requestPromise = DistributedLock.getInstance()
+      .withLock(cacheKey, processRequest, {
+        timeout,
+        ttl: maxRequestDuration + 1000,
+      })
+      .then(({ result }) => result);
 
     if (!doBackground) {
       return await requestPromise;

--- a/packages/core/src/presets/debridioTmdb.ts
+++ b/packages/core/src/presets/debridioTmdb.ts
@@ -1,6 +1,6 @@
 import { Addon, Option, UserData } from '../db/index.js';
 import { CacheKeyRequestOptions, Preset, baseOptions } from './preset.js';
-import { constants } from '../utils/index.js';
+import { constants, getSimpleTextHash } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import {
   debridioSocialOption,
@@ -367,7 +367,7 @@ export class DebridioTmdbPreset extends Preset {
       cacheKey += `-${presetOptions.language}`;
     }
     if (resource === 'manifest') {
-      cacheKey += `-${presetOptions.debridioApiKey}`;
+      cacheKey += `-${getSimpleTextHash(presetOptions.debridioApiKey ?? '')}`;
     }
     return cacheKey;
   }

--- a/packages/core/src/presets/debridioTv.ts
+++ b/packages/core/src/presets/debridioTv.ts
@@ -7,7 +7,7 @@ import {
   UserData,
 } from '../db/index.js';
 import { CacheKeyRequestOptions, Preset, baseOptions } from './preset.js';
-import { constants } from '../utils/index.js';
+import { constants, getSimpleTextHash } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import {
   debridioSocialOption,
@@ -207,7 +207,7 @@ export class DebridioTvPreset extends Preset {
     } catch {}
     let cacheKey = `${this.METADATA.ID}-${resource}-${type}-${id}-${extras}`;
     if (resource === 'manifest') {
-      cacheKey += `-${presetOptions.debridioApiKey}-${presetOptions.channels}`;
+      cacheKey += `-${getSimpleTextHash(presetOptions.debridioApiKey ?? '')}-${presetOptions.channels}`;
     }
     return cacheKey;
   }

--- a/packages/core/src/presets/debridioTvdb.ts
+++ b/packages/core/src/presets/debridioTvdb.ts
@@ -1,6 +1,6 @@
 import { Addon, Option, UserData } from '../db/index.js';
 import { CacheKeyRequestOptions, Preset, baseOptions } from './preset.js';
-import { constants } from '../utils/index.js';
+import { constants, getSimpleTextHash } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
 import {
   debridioSocialOption,
@@ -111,7 +111,7 @@ export class DebridioTvdbPreset extends Preset {
     // allows cache key to be shared across different debridio users.
     let cacheKey = `${this.METADATA.ID}-${resource}-${type}-${id}-${extras}`;
     if (resource === 'manifest') {
-      cacheKey += `-${presetOptions.debridioApiKey}`;
+      cacheKey += `-${getSimpleTextHash(presetOptions.debridioApiKey ?? '')}`;
     }
     return cacheKey;
   }


### PR DESCRIPTION
Prevents parallel calls (e.g. multiple config variants) from racing the cache and each hitting the upstream addon independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent resource requests by ensuring requests for the same cached resource are processed in sequence.
  - Reduced duplicate or conflicting processing while preserving existing caching, timeout and stale-data behaviour.
  - Improved cache-key security by preventing Debridio API keys from being included directly in cache identifiers.
  - Adjusted lock expiry handling to better reflect the effective request duration, reducing premature lock expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->