### PR TITLE
chore: reuse chrome header preset for torrent-galaxy and knaben

### DIFF
--- a/packages/core/src/builtins/knaben/api.ts
+++ b/packages/core/src/builtins/knaben/api.ts
@@ -4,6 +4,7 @@ import {
   formatZodError,
   makeRequest,
   DistributedLock,
+  HEADER_PRESETS,
 } from '../../utils/index.js';
 import { createLogger } from '../../utils/index.js';
 import { searchWithBackgroundRefresh } from '../utils/general.js';
@@ -115,8 +116,7 @@ class KnabenAPI {
   constructor() {
     this.headers = {
       'Content-Type': 'application/json',
-      'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HEADER_PRESETS.chrome['User-Agent'],
       Accept: 'application/json',
     };
   }

--- a/packages/core/src/builtins/torrent-galaxy/api.ts
+++ b/packages/core/src/builtins/torrent-galaxy/api.ts
@@ -4,6 +4,7 @@ import {
   formatZodError,
   makeRequest,
   DistributedLock,
+  HEADER_PRESETS,
 } from '../../utils/index.js';
 import { createLogger } from '../../utils/index.js';
 import { searchWithBackgroundRefresh } from '../utils/general.js';
@@ -88,8 +89,7 @@ class TorrentGalaxyAPI {
   constructor() {
     this.headers = {
       'Content-Type': 'application/json',
-      'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'User-Agent': HEADER_PRESETS.chrome['User-Agent'],
       Accept: 'application/json',
     };
   }


### PR DESCRIPTION
missing and not touched on purpose: easynews is using this semi-weird custom `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36` and I have no clue if we can switch this over to e.g. chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardised browser identification for Knaben and Torrent Galaxy connections.
  * No user-visible behaviour changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->