### PR TITLE
feat: skip an addon, service or usenet server while it is down

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -17,6 +17,7 @@ import {
   fromUrlSafeBase64,
   getSimpleTextHash,
   getTimeTakenSincePoint,
+  resolveHealthyNntp,
   SERVICE_DETAILS,
 } from '../../utils/index.js';
 import { config as appConfig } from '../../config/index.js';
@@ -372,8 +373,12 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
             Buffer.from(encodedNntpServers, 'base64').toString('utf-8')
           )
         );
+        // A server that will not accept a connection cannot serve articles, so
+        // it is left out rather than handed over to fail later. All of them
+        // failing leaves no servers, and the addons that need one are not built.
+        const reachable = await resolveHealthyNntp(nntpServers);
         // servers - array, a list of strings that each represent a connection to a NNTP (usenet) server (for nzbUrl) in the form of nntp(s)://{user}:{pass}@{nntpDomain}:{nntpPort}/{nntpConnections} (nntps = SSL; nntp = no encryption) (example: nntps://myuser:mypass@news.example.com/4)
-        servers = nntpServers.map(
+        servers = reachable.map(
           (s) =>
             `${s.ssl ? 'nntps' : 'nntp'}://${encodeURIComponent(
               s.username

--- a/packages/core/src/config/schema/rate-limits.ts
+++ b/packages/core/src/config/schema/rate-limits.ts
@@ -70,6 +70,12 @@ export const rateLimitsSchema = {
     envPrefix: 'STATIC',
     label: 'static file',
   }),
+  healthCheckApi: rateLimit({
+    windowDefault: 60,
+    maxDefault: 10,
+    envPrefix: 'HEALTH_CHECK_API',
+    label: 'health check test',
+  }),
   userApi: rateLimit({
     windowDefault: 5,
     maxDefault: 5,

--- a/packages/core/src/db/schemas.test.ts
+++ b/packages/core/src/db/schemas.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { UserDataSchema } from './schemas.js';
+
+// Services and addons share one healthCheckUrl definition, so exercising it
+// through the service list covers both.
+const services = UserDataSchema.shape.services;
+
+function parse(healthCheckUrl?: string) {
+  return services.safeParse([
+    {
+      id: 'realdebrid',
+      credentials: { apiKey: 'x' },
+      ...(healthCheckUrl === undefined ? {} : { healthCheckUrl }),
+    },
+  ]);
+}
+
+describe('healthCheckUrl', () => {
+  it('accepts a public https address', () => {
+    assert.equal(parse('https://api.example.com/health').success, true);
+  });
+
+  it('accepts a service with no health check at all', () => {
+    assert.equal(parse().success, true);
+  });
+
+  it('rejects a private address, which the gate treats as healthy and never skips', () => {
+    assert.equal(parse('http://192.168.1.50:8080/health').success, false);
+    assert.equal(parse('http://10.0.0.5/health').success, false);
+  });
+
+  it('rejects loopback', () => {
+    assert.equal(parse('http://127.0.0.1:8080/health').success, false);
+    assert.equal(parse('http://localhost:8080/health').success, false);
+  });
+
+  it('rejects a non-http scheme', () => {
+    assert.equal(parse('ftp://example.com/health').success, false);
+  });
+});

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import * as constants from '../utils/constants.js';
 import { config } from '../config/index.js';
 import { WD1_KEY_REGEX } from '../release-blocklist/keys.js';
+import { isUnsafeRemoteUrl } from '../utils/url-safety.js';
 
 /**
  * Stream Expression Language string with a runtime-configurable maximum length
@@ -166,10 +167,24 @@ const BitrateFilterOptions = z.object({
   resolution: z.partialRecord(Resolutions, SizeFilter).optional(),
 });
 
+// Refused rather than accepted-and-ignored: the gate treats an address it cannot
+// probe as healthy, so a private one would save and never skip anything. The
+// literal-host check only; the gate applies the DNS-resolving one before it
+// fetches.
+const HealthCheckUrl = z
+  .string()
+  .url()
+  .refine((url) => !isUnsafeRemoteUrl(url), {
+    message:
+      'Must be a public http(s) address. Loopback, private and link-local addresses are refused.',
+  });
+
 const ServiceSchema = z.object({
   id: ServiceIds,
   enabled: z.boolean().optional(),
   credentials: z.record(z.string().min(1), z.string()),
+  // Skipped while this URL answers 5xx. Absent means never skipped.
+  healthCheckUrl: HealthCheckUrl.optional(),
 });
 
 export type Service = z.infer<typeof ServiceSchema>;
@@ -203,6 +218,9 @@ const AddonSchema = z.object({
   // forceToTop: z.boolean().optional(),
   pinPosition: z.enum(['top', 'bottom']).optional(),
   serviceWrapped: z.boolean().optional(),
+  // For an addon whose dependency cannot be inferred, such as a custom manifest
+  // carrying a provider's key. Skipped while this URL answers 5xx.
+  healthCheckUrl: HealthCheckUrl.optional(),
   headers: z.record(z.string().min(1), z.string().min(1)).optional(),
   ip: z.string().optional(),
 });
@@ -299,6 +317,7 @@ const OptionDefinition = z.looseObject({
     'subsection',
     'custom-nntp-servers',
     'nab-endpoint',
+    'health-check-url',
   ]),
   nab: z
     .object({
@@ -1470,6 +1489,9 @@ const PresetMinimalMetadataSchema = z.object({
   OPTIONS: z.array(OptionDefinition),
   BUILTIN: z.boolean().optional(),
   CATEGORY: z.enum(constants.PRESET_CATEGORIES).optional(),
+  // Absent means the preset gets a health check option. Only false withholds
+  // it, for a preset whose health is decided per server rather than per addon.
+  SUPPORTS_HEALTH_CHECK: z.boolean().optional(),
 });
 
 const PresetMetadataSchema = PresetMinimalMetadataSchema.extend({
@@ -1572,6 +1594,9 @@ const StatusResponseSchema = z.object({
         knownNames: z.array(z.string()),
         signUpText: z.string(),
         credentials: z.array(OptionDefinition),
+        // Not optional: the default lives in the projection, so a missing value
+        // here fails validation loudly rather than hiding every control.
+        supportsHealthCheck: z.boolean(),
       })
     ),
     limits: z.object({

--- a/packages/core/src/main/serviceWrapper.ts
+++ b/packages/core/src/main/serviceWrapper.ts
@@ -18,6 +18,7 @@ import {
   FileInfo,
 } from '../debrid/index.js';
 import { processTorrents } from '../builtins/utils/debrid.js';
+import { resolveHealthy } from '../utils/health-gate.js';
 import { StreamContext } from '../streams/context.js';
 import { isServiceWrapEligibleP2PStream } from '../streams/utils.js';
 import { parseTorrentTitleCached } from '../parser/title.js';
@@ -138,7 +139,7 @@ export async function resolveServiceWrappedStreams(
   );
 
   // Build BuiltinDebridServices from user's service configuration
-  const debridServices = buildDebridServices(userData);
+  const debridServices = await buildDebridServices(userData);
 
   if (debridServices.length === 0) {
     errors.push({
@@ -255,9 +256,21 @@ export async function resolveServiceWrappedStreams(
 // Helper functions
 // ---------------------------------------------------------------------------
 
-function buildDebridServices(userData: UserData): BuiltinDebridServices {
-  const enabledServices =
+async function buildDebridServices(
+  userData: UserData
+): Promise<BuiltinDebridServices> {
+  const candidates =
     userData.services?.filter((s) => s.enabled !== false) ?? [];
+  const healthy = await resolveHealthy(candidates, (s) => s.id);
+  const enabledServices = candidates.filter((s) => {
+    if (healthy.has(s.id)) return true;
+    // At warn rather than debug: see the note in fetcher.ts.
+    logger.warn(
+      { service: s.id },
+      'skipping service: its health check says it is down'
+    );
+    return false;
+  });
   const serviceWrapFilter = userData.serviceWrap?.services;
   const builtinServiceIds = new Set(constants.BUILTIN_SUPPORTED_SERVICES);
   const debridServices: BuiltinDebridServices = [];

--- a/packages/core/src/main/setup.ts
+++ b/packages/core/src/main/setup.ts
@@ -100,6 +100,10 @@ export async function applyPresets(ctx: AIOStreamsContext): Promise<void> {
             // if no identifier is present, we can assume that the preset can only generate one addon at a time and so no
             // unique identifier is needed as the preset instance id is enough to identify the addon
             instanceId: `${preset.instanceId}${getSimpleTextHash(`${a.identifier ?? ''}`).slice(0, 4)}`,
+            // Stamped here rather than in each preset's transformer: it has no
+            // per-preset default to honour, so one place owns it and every
+            // preset gets it without eighty-four copies.
+            healthCheckUrl: preset.options.healthCheckUrl || undefined,
           })
         )
       );
@@ -140,6 +144,7 @@ export async function applyPresets(ctx: AIOStreamsContext): Promise<void> {
                 },
                 instanceId: `${preset.instanceId}${getSimpleTextHash(`servicewrap-${a.identifier ?? ''}`).slice(0, 4)}`,
                 serviceWrapped: true,
+                healthCheckUrl: preset.options.healthCheckUrl || undefined,
               })
             )
           );

--- a/packages/core/src/presets/builtin.ts
+++ b/packages/core/src/presets/builtin.ts
@@ -203,9 +203,7 @@ export class BuiltinStreamParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    return stream.description?.match(
-      getRegexForTextAfterEmojis(['🏷️'])
-    )?.[1];
+    return stream.description?.match(getRegexForTextAfterEmojis(['🏷️']))?.[1];
   }
 }
 

--- a/packages/core/src/presets/preset.ts
+++ b/packages/core/src/presets/preset.ts
@@ -30,6 +30,25 @@ import { config as appConfig } from '../config/index.js';
 // timeout: z.number().min(1).optional(),
 // resources: ResourceList.optional(),
 
+// Opt-in rather than part of baseOptions: the option and the transformer line
+// that assigns it have to move together, and baseOptions supplies only the
+// definition. A preset that shows this without assigning it would offer a
+// control that gates nothing.
+export const healthCheckUrlOption: Option = {
+  id: 'healthCheckUrl',
+  name: 'Health Check URL',
+  description:
+    "Skips this addon while the given URL answers a 5xx. Any other response, including a timeout, leaves it enabled. Must be a public http(s) address; private and local addresses are refused. Use this for the addon's own backend. To skip a single provider when it goes down, set the health check on that service instead, under Services, so the addon keeps running on the others.",
+  // Its own type rather than 'url': this control is an input and a Test button,
+  // and the manifest override is a plain input. Sharing a type would leave the
+  // dispatch branching on an id inside a case that claims to handle both.
+  type: 'health-check-url',
+  required: false,
+  showInSimpleMode: false,
+  default: undefined,
+  emptyIsUndefined: true,
+};
+
 export const baseOptions = (
   name: string,
   resources: Resource[],

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -1,4 +1,5 @@
-﻿import { PresetMetadata, PresetMinimalMetadata } from '../db/index.js';
+﻿import { Option, PresetMetadata, PresetMinimalMetadata } from '../db/index.js';
+import { healthCheckUrlOption } from './preset.js';
 import { CometPreset } from './comet.js';
 import { MeteorPreset } from './meteor.js';
 import { CustomPreset } from './custom.js';
@@ -165,6 +166,20 @@ let PRESET_LIST: string[] = [
 ].filter(Boolean);
 
 export class PresetManager {
+  /**
+   * A preset's options plus the ones every preset carries. The health check is
+   * offered on all of them rather than declared eighty-four times, and it is
+   * applied centrally in main/setup.ts, so both halves stay in one place.
+   */
+  static optionsFor(metadata: PresetMetadata): Option[] {
+    // Compared against false rather than read as a boolean: absent means the
+    // option is offered, so an undefined read as falsy would withhold it from
+    // every preset that never mentions it.
+    return metadata.SUPPORTS_HEALTH_CHECK === false
+      ? [...metadata.OPTIONS]
+      : [...metadata.OPTIONS, healthCheckUrlOption];
+  }
+
   static getPresetList(): PresetMinimalMetadata[] {
     return PRESET_LIST.map((presetId) => this.fromId(presetId).METADATA).map(
       (metadata: PresetMetadata) => ({
@@ -175,7 +190,7 @@ export class PresetManager {
         SUPPORTED_RESOURCES: metadata.SUPPORTED_RESOURCES,
         SUPPORTED_STREAM_TYPES: metadata.SUPPORTED_STREAM_TYPES,
         SUPPORTED_SERVICES: metadata.SUPPORTED_SERVICES,
-        OPTIONS: metadata.OPTIONS,
+        OPTIONS: this.optionsFor(metadata),
         BUILTIN: metadata.BUILTIN,
         DISABLED: metadata.DISABLED,
         CATEGORY: metadata.CATEGORY,

--- a/packages/core/src/presets/usenetStreamer.ts
+++ b/packages/core/src/presets/usenetStreamer.ts
@@ -149,6 +149,9 @@ export class UsenetStreamerPreset extends Preset {
       SUPPORTED_SERVICES: supportedServices,
       SUPPORTED_RESOURCES: supportedResources,
       SUPPORTED_STREAM_TYPES: [constants.USENET_STREAM_TYPE],
+      // Its servers are reachability-checked one by one, so an addon-wide URL
+      // would answer a question that is already answered per server.
+      SUPPORTS_HEALTH_CHECK: false,
       OPTIONS: options,
     };
   }

--- a/packages/core/src/streams/fetcher.ts
+++ b/packages/core/src/streams/fetcher.ts
@@ -5,6 +5,7 @@ import {
   getAddonName,
   getTimeTakenSincePoint,
 } from '../utils/index.js';
+import { resolveHealthy } from '../utils/health-gate.js';
 import { Wrapper } from '../main/wrapper.js';
 import {
   ExitConditionEvaluator,
@@ -105,7 +106,20 @@ class StreamFetcher {
       });
     }
 
+    // A custom manifest can carry a provider's key, and nothing in the config
+    // says which provider that is. The user declares it; we skip while it is down.
+    const healthy = await resolveHealthy(addons, (a) => a);
     addons = addons.filter((addon) => {
+      if (!healthy.has(addon)) {
+        // At warn rather than debug: results are missing a provider, which is
+        // the one thing an operator has to be able to see without turning on a
+        // level that logs credential-bearing request paths.
+        logger.warn(
+          { addon: getAddonName(addon) },
+          'skipping addon: its health check says the service it depends on is down'
+        );
+        return false;
+      }
       if (
         addon.mediaTypes &&
         addon.mediaTypes.length > 0 &&

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -66,7 +66,19 @@ function getServiceCredentialForced(
   return appConfig.services.forcedCredentials[serviceId]?.[credentialId];
 }
 
-export function getEnvironmentServiceDetails(): typeof constants.SERVICE_DETAILS {
+/**
+ * The service catalogue as the UI sees it. `supportsHealthCheck` is optional on
+ * the definition and materialised here, so the type says definitely-boolean and
+ * a consumer cannot read a missing value as false.
+ */
+export type EnvironmentServiceDetails = {
+  [K in constants.ServiceId]: Omit<
+    (typeof constants.SERVICE_DETAILS)[K],
+    'supportsHealthCheck'
+  > & { supportsHealthCheck: boolean };
+};
+
+export function getEnvironmentServiceDetails(): EnvironmentServiceDetails {
   return Object.fromEntries(
     Object.entries(constants.SERVICE_DETAILS)
       .filter(([id, _]) => !FeatureControl.disabledServices.has(id))
@@ -78,6 +90,10 @@ export function getEnvironmentServiceDetails(): typeof constants.SERVICE_DETAILS
           shortName: service.shortName,
           knownNames: service.knownNames,
           signUpText: service.signUpText,
+          // Materialised here rather than passed through: the field is optional
+          // on the definition and undefined is falsy, so a straight copy would
+          // hide the control on every service that never declared it.
+          supportsHealthCheck: service.supportsHealthCheck ?? true,
           credentials: service.credentials.map((cred) => ({
             id: cred.id,
             name: cred.name,
@@ -101,7 +117,7 @@ export function getEnvironmentServiceDetails(): typeof constants.SERVICE_DETAILS
           })),
         },
       ])
-  ) as typeof constants.SERVICE_DETAILS;
+  ) as EnvironmentServiceDetails;
 }
 
 export interface ValidateConfigOptions {
@@ -1139,7 +1155,7 @@ function validatePreset(preset: PresetObject) {
   const presetMeta = PresetManager.fromId(preset.type)
     .METADATA as PresetMetadata;
 
-  const optionMetas = presetMeta.OPTIONS;
+  const optionMetas = PresetManager.optionsFor(presetMeta);
 
   if (presetMeta.DISABLED) {
     throw new Error(

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -467,6 +467,14 @@ const SERVICE_DETAILS: Record<
     knownNames: string[];
     signUpText: string;
     credentials: Option[];
+    /**
+     * Whether a health check URL can be set on this service. Defaults to true:
+     * a service is a remote thing with an address, so asking whether it answers
+     * is meaningful. Set false where the service is a local engine over servers
+     * the user supplies — those are checked per server instead, and one URL for
+     * the whole set would drop every provider when one of them is down.
+     */
+    supportsHealthCheck?: boolean;
   }
 > = {
   [REALDEBRID_SERVICE]: {
@@ -561,6 +569,8 @@ const SERVICE_DETAILS: Record<
   },
   [STREMIO_NNTP_SERVICE]: {
     id: STREMIO_NNTP_SERVICE,
+    // The servers live in this service's own config and are checked one by one.
+    supportsHealthCheck: false,
     name: 'Stremio NNTP',
     shortName: 'SN',
     knownNames: ['SN', 'Stremio NNTP', 'StremioNntp', 'Stremio-NNTP'],
@@ -650,6 +660,9 @@ const SERVICE_DETAILS: Record<
   },
   [AIOSTREAMS_SERVICE]: {
     id: AIOSTREAMS_SERVICE,
+    // Its NNTP providers are set globally rather than on this service, so there
+    // is nothing here for a URL to report on.
+    supportsHealthCheck: false,
     name: 'AIOStreams',
     shortName: 'AIO',
     knownNames: ['AIO', 'AIO Usenet', 'NZB', 'Usenet', 'Native Usenet'],

--- a/packages/core/src/utils/health-gate.ts
+++ b/packages/core/src/utils/health-gate.ts
@@ -1,0 +1,323 @@
+import { Cache } from './cache.js';
+import { isUnsafeRemoteUrlResolved } from './url-safety.js';
+import { createLogger } from '../logging/logger.js';
+
+const logger = createLogger('health-gate');
+
+const TTL_SECONDS = 30;
+// One budget for the whole probe, lookups and fetches together. Per-hop caps
+// would each be honoured and still leave a redirect chain multiplying them,
+// and a user waits on the total rather than on a hop.
+// Sized for a cold lookup, a TLS handshake and a redirect rather than for one
+// warm fetch. Overrunning leaves the item enabled, so the cost is that this
+// stops gating.
+const TIMEOUT_MS = 4_000;
+const MAX_REDIRECTS = 3;
+
+// Resolved on first use rather than at module load: Cache reaches appConfig,
+// which imports this module's neighbours, and taking the instance up front
+// makes that a cycle.
+let store: Cache<string, boolean> | undefined;
+const cache = () =>
+  (store ??= Cache.getInstance<string, boolean>('health-check', 500));
+
+const inFlight = new Map<string, Promise<boolean>>();
+
+// The resolver call carries no timeout of its own, so an unresolvable host would
+// otherwise wait on the system resolver while a user waits on the stream. A
+// lookup that overruns its share of the budget is treated as unsafe, which
+// leaves the item enabled.
+async function unsafeWithinBudget(
+  url: string,
+  ms: number
+): Promise<'safe' | 'unsafe' | 'timed-out'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      isUnsafeRemoteUrlResolved(url).then((unsafe) =>
+        unsafe ? ('unsafe' as const) : ('safe' as const)
+      ),
+      new Promise<'timed-out'>((resolve) => {
+        timer = setTimeout(() => resolve('timed-out'), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * What a health check concluded, and why. Returned rather than logged so the
+ * gate and the Test button read the same value: a button that explained itself
+ * from its own logic could reassure about something the gate does not do.
+ */
+export type HealthCause =
+  | 'server-error'
+  | 'answered'
+  | 'unsafe-address'
+  | 'no-time'
+  | 'unresolvable'
+  | 'bad-redirect'
+  | 'too-many-redirects'
+  | 'unreachable';
+
+export interface HealthVerdict {
+  ok: boolean;
+  outcome: 'skipped' | 'enabled';
+  cause: HealthCause;
+  reason: string;
+  status?: number;
+}
+
+const enabled = (
+  cause: HealthCause,
+  reason: string,
+  status?: number
+): HealthVerdict => ({ ok: true, outcome: 'enabled', cause, reason, status });
+
+/**
+ * Probe a URL and say what the gate would do with it. Does no logging: a user
+ * pressing Test is not an event worth a warning.
+ */
+export async function probeVerdict(url: string): Promise<HealthVerdict> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  const remaining = () => deadline - Date.now();
+  try {
+    let current = url;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      if (remaining() <= 0) {
+        return enabled(
+          'no-time',
+          'The check ran out of time, so nothing is skipped.'
+        );
+      }
+      // The URL comes from an end user, so the DNS-resolving guard applies: a
+      // literal-host check passes a name that resolves to a private address.
+      // Every hop is re-checked, so a redirect cannot reach one the first
+      // refused.
+      const safety = await unsafeWithinBudget(current, remaining());
+      if (safety === 'unsafe') {
+        return enabled(
+          'unsafe-address',
+          'That address is not reachable from the public internet, so it is ignored. Use a public http(s) address.'
+        );
+      }
+      if (safety === 'timed-out') {
+        return enabled(
+          'unresolvable',
+          'The host did not resolve in time, so nothing is skipped.'
+        );
+      }
+
+      const res = await fetch(current, {
+        method: 'HEAD',
+        redirect: 'manual',
+        signal: AbortSignal.timeout(Math.max(remaining(), 1)),
+      });
+      await res.body?.cancel().catch(() => {});
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location');
+        if (!location) {
+          return enabled(
+            'bad-redirect',
+            'The URL redirected without saying where, so nothing is skipped.',
+            res.status
+          );
+        }
+        current = new URL(location, current).toString();
+        continue;
+      }
+
+      // Only a definite refusal skips a provider. A monitor that does not know
+      // the id has told us nothing about the service, and a mistyped URL is a
+      // configuration error rather than an outage.
+      if (res.status >= 500) {
+        return {
+          ok: true,
+          outcome: 'skipped',
+          cause: 'server-error',
+          reason: 'The check answered with a server error, so this is skipped.',
+          status: res.status,
+        };
+      }
+      return enabled(
+        'answered',
+        'The check answered, so this stays enabled.',
+        res.status
+      );
+    }
+    return enabled(
+      'too-many-redirects',
+      'The URL redirected too many times, so nothing is skipped.'
+    );
+  } catch {
+    // Nor can a monitor we failed to reach disable something that is working.
+    return {
+      ok: false,
+      outcome: 'enabled',
+      cause: 'unreachable',
+      reason: 'The check could not be reached, so nothing is skipped.',
+    };
+  }
+}
+
+/**
+ * Whether a usenet server accepts a connection. It opens the socket, completes
+ * the TLS handshake where the row asks for it, and closes — it never signs in,
+ * so a wrong password is not reported as an outage.
+ */
+export async function probeNntpVerdict(
+  host: string,
+  port: number,
+  ssl: boolean
+): Promise<HealthVerdict> {
+  const { connect: netConnect } = await import('node:net');
+  const { connect: tlsConnect } = await import('node:tls');
+  return new Promise<HealthVerdict>((resolve) => {
+    let settled = false;
+    const finish = (verdict: HealthVerdict) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(verdict);
+    };
+    const socket = ssl
+      ? tlsConnect({ host, port, servername: host })
+      : netConnect({ host, port });
+    socket.setTimeout(TIMEOUT_MS);
+    socket.once(ssl ? 'secureConnect' : 'connect', () =>
+      finish(
+        enabled(
+          'answered',
+          'The server accepted a connection. It was not signed in to, so the username and password are not tested.'
+        )
+      )
+    );
+    socket.once('timeout', () =>
+      finish({
+        ok: false,
+        outcome: 'skipped',
+        cause: 'no-time',
+        reason: 'The server did not answer in time, so it is skipped.',
+      })
+    );
+    socket.once('error', () =>
+      finish({
+        ok: false,
+        outcome: 'skipped',
+        cause: 'unreachable',
+        reason: 'The server could not be reached, so it is skipped.',
+      })
+    );
+  });
+}
+
+async function probe(url: string): Promise<boolean> {
+  const verdict = await probeVerdict(url);
+  if (verdict.outcome === 'skipped') return false;
+  // Only the states a human has to act on reach the log at warn; the transient
+  // ones would be noisy at every probe.
+  const actionable: HealthCause[] = [
+    'unsafe-address',
+    'bad-redirect',
+    'too-many-redirects',
+  ];
+  if (actionable.includes(verdict.cause)) {
+    logger.warn(`${verdict.reason} Health check: ${url}`);
+  } else if (verdict.cause !== 'answered') {
+    logger.debug(`${verdict.reason} Health check: ${url}`);
+  }
+  return true;
+}
+
+async function usable(url: string): Promise<boolean> {
+  const cached = await cache().get(url);
+  if (cached !== undefined) return cached;
+
+  let pending = inFlight.get(url);
+  if (!pending) {
+    pending = probe(url)
+      .then(async (result) => {
+        await cache().set(url, result, TTL_SECONDS);
+        return result;
+      })
+      .finally(() => inFlight.delete(url));
+    inFlight.set(url, pending);
+  }
+  return pending;
+}
+
+/**
+ * The usenet servers that accept a connection right now.
+ *
+ * Unlike a URL check this fails closed: a server that will not accept a
+ * connection cannot serve articles, so the reading is the thing itself rather
+ * than a signal about it. Verdicts are cached and shared for the same reason
+ * and for the same window as the URL checks.
+ */
+async function nntpUsable(server: {
+  host: string;
+  port: number;
+  ssl: boolean;
+}): Promise<boolean> {
+  const key = `nntp://${server.host}:${server.port}/${server.ssl ? 1 : 0}`;
+  const cached = await cache().get(key);
+  if (cached !== undefined) return cached;
+
+  let pending = inFlight.get(key);
+  if (!pending) {
+    pending = probeNntpVerdict(server.host, server.port, server.ssl)
+      .then(async (verdict) => {
+        const ok = verdict.outcome === 'enabled';
+        if (!ok) {
+          logger.warn(
+            `${verdict.reason} Usenet server: ${server.host}:${server.port}`
+          );
+        }
+        await cache().set(key, ok, TTL_SECONDS);
+        return ok;
+      })
+      .finally(() => inFlight.delete(key));
+    inFlight.set(key, pending);
+  }
+  return pending;
+}
+
+/**
+ * The usenet servers that accept a connection right now.
+ *
+ * Unlike a URL check this fails closed: a server that will not accept a
+ * connection cannot serve articles, so the reading is the thing itself rather
+ * than a signal about it. Verdicts are cached and shared for the same reason
+ * and for the same window as the URL checks.
+ */
+export async function resolveHealthyNntp<
+  T extends { host: string; port: number; ssl: boolean },
+>(servers: readonly T[]): Promise<T[]> {
+  const usable = await Promise.all(servers.map((server) => nntpUsable(server)));
+  return servers.filter((_, index) => usable[index]);
+}
+
+/**
+ * The keys of `items` that may be used right now.
+ *
+ * An item with no `healthCheckUrl` is always included, so an untouched config
+ * behaves as it does today. The first request for a URL waits for an answer;
+ * the verdict is cached and shared after that, so a restart does not wait
+ * again. Checks run in parallel, so the wait is one check rather than one per
+ * item.
+ */
+export async function resolveHealthy<T, K>(
+  items: readonly T[],
+  keyOf: (item: T) => K
+): Promise<Set<K>> {
+  const allowed = new Set<K>();
+  await Promise.all(
+    items.map(async (item) => {
+      const url = (item as { healthCheckUrl?: string })?.healthCheckUrl;
+      if (!url || (await usable(url))) allowed.add(keyOf(item));
+    })
+  );
+  return allowed;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cache.js';
+export * from './health-gate.js';
 export * from './constants.js';
 export * from './env.js';
 export * from '../logging/logger.js';

--- a/packages/frontend/src/components/menu/services/_components/stream-services.tsx
+++ b/packages/frontend/src/components/menu/services/_components/stream-services.tsx
@@ -19,6 +19,7 @@ import {
   TouchSensor,
   useSensor,
 } from '@dnd-kit/core';
+import { toast } from 'sonner';
 import { Button, IconButton } from '../../../ui/button';
 import { FiSettings, FiSearch } from 'react-icons/fi';
 import { TextInput } from '../../../ui/text-input';
@@ -26,7 +27,11 @@ import { cn } from '../../../ui/core/styling';
 import { Switch } from '../../../ui/switch';
 import { Modal } from '../../../ui/modal';
 import { Alert } from '../../../ui/alert';
-import TemplateOption from '../../../shared/template-option';
+import TemplateOption, {
+  HEALTH_CHECK_TEST_ENDPOINT,
+  verdictNeedsAttention,
+  type HealthCheckTestResult,
+} from '../../../shared/template-option';
 import MarkdownLite from '../../../shared/markdown-lite';
 import { StatusResponse, UserData } from '@aiostreams/core';
 
@@ -37,6 +42,9 @@ export function StreamServices() {
   const [modalOpen, setModalOpen] = useState(false);
   const [modalService, setModalService] = useState<ServiceId | null>(null);
   const [modalValues, setModalValues] = useState<Record<string, any>>({});
+  const [modalHealthCheckUrl, setModalHealthCheckUrl] = useState<
+    string | undefined
+  >(undefined);
   const [isDragging, setIsDragging] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<
@@ -66,6 +74,7 @@ export function StreamServices() {
     setModalService(service);
     const svc = userData.services?.find((s) => s.id === service);
     setModalValues(svc?.credentials || {});
+    setModalHealthCheckUrl(svc?.healthCheckUrl);
     setModalOpen(true);
   };
 
@@ -73,14 +82,23 @@ export function StreamServices() {
     setModalOpen(false);
     setModalService(null);
     setModalValues({});
+    setModalHealthCheckUrl(undefined);
   };
 
-  const handleModalSubmit = (values: Record<string, any>) => {
+  const handleModalSubmit = (
+    values: Record<string, any>,
+    healthCheckUrl: string | undefined
+  ) => {
     setUserData((prev) => {
       const newUserData = { ...prev };
       newUserData.services = (newUserData.services ?? []).map((service) => {
         if (service.id === modalService) {
-          return { ...service, enabled: true, credentials: values };
+          return {
+            ...service,
+            enabled: true,
+            credentials: values,
+            healthCheckUrl: healthCheckUrl || undefined,
+          };
         }
         return service;
       });
@@ -351,6 +369,7 @@ export function StreamServices() {
         onOpenChange={setModalOpen}
         serviceId={modalService}
         values={modalValues}
+        healthCheckUrl={modalHealthCheckUrl}
         onSubmit={handleModalSubmit}
         onClose={handleModalClose}
       />
@@ -492,6 +511,7 @@ function ServiceModal({
   onOpenChange,
   serviceId,
   values,
+  healthCheckUrl,
   onSubmit,
   onClose,
 }: {
@@ -499,15 +519,59 @@ function ServiceModal({
   onOpenChange: (v: boolean) => void;
   serviceId: ServiceId | null;
   values: Record<string, any>;
-  onSubmit: (v: Record<string, any>) => void;
+  healthCheckUrl: string | undefined;
+  onSubmit: (
+    v: Record<string, any>,
+    healthCheckUrl: string | undefined
+  ) => void;
   onClose: () => void;
 }) {
   const { status } = useStatus();
   const [localValues, setLocalValues] = useState<Record<string, any>>({});
+  const [localHealthCheckUrl, setLocalHealthCheckUrl] = useState<
+    string | undefined
+  >(undefined);
+  const [verdict, setVerdict] = useState<HealthCheckTestResult | null>(null);
+  const [testing, setTesting] = useState(false);
 
   useEffect(() => {
-    if (open) setLocalValues(values);
-  }, [open, values]);
+    if (open) {
+      setLocalValues(values);
+      setLocalHealthCheckUrl(healthCheckUrl);
+      setVerdict(null);
+      setTesting(false);
+    }
+  }, [open, values, healthCheckUrl]);
+
+  const runHealthCheckTest = async () => {
+    if (!localHealthCheckUrl?.trim()) {
+      toast.error('Enter a URL before testing');
+      return;
+    }
+    setTesting(true);
+    setVerdict(null);
+    try {
+      const response = await fetch(HEALTH_CHECK_TEST_ENDPOINT, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: localHealthCheckUrl }),
+      });
+      const json = await response.json();
+      if (!json.success) {
+        throw new Error(
+          json.detail || json.error?.message || 'Could not run the test'
+        );
+      }
+      setVerdict(json.data as HealthCheckTestResult);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Could not run the test'
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
 
   if (!status || !serviceId) return null;
   const meta = status.settings.services[serviceId]!;
@@ -523,7 +587,7 @@ function ServiceModal({
         className="space-y-4"
         onSubmit={(e) => {
           e.preventDefault();
-          onSubmit(localValues);
+          onSubmit(localValues, localHealthCheckUrl);
         }}
       >
         {credentials.map((opt) => (
@@ -536,6 +600,52 @@ function ServiceModal({
             }
           />
         ))}
+        {meta.supportsHealthCheck && (
+          <div className="space-y-2">
+            <TemplateOption
+              option={{
+                id: 'healthCheckUrl',
+                name: 'Health Check URL',
+                description:
+                  'Skips this service while the given URL answers a 5xx. Any other response, a timeout or an unreachable host leaves it enabled. Must be a public http(s) address.',
+                type: 'url',
+                required: false,
+                emptyIsUndefined: true,
+              }}
+              value={localHealthCheckUrl}
+              onChange={(v) => {
+                // Any edit invalidates the previous verdict.
+                setVerdict(null);
+                setLocalHealthCheckUrl(v || undefined);
+              }}
+            />
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                size="sm"
+                intent="primary-outline"
+                loading={testing}
+                disabled={testing || !localHealthCheckUrl?.trim()}
+                onClick={runHealthCheckTest}
+              >
+                Test
+              </Button>
+              {verdict && (
+                <p
+                  className={
+                    verdictNeedsAttention(verdict)
+                      ? 'text-sm text-[--alert]'
+                      : 'text-sm text-[--muted]'
+                  }
+                >
+                  {verdict.status
+                    ? `${verdict.status} — ${verdict.reason}`
+                    : verdict.reason}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
         <div className="flex gap-2">
           <Button
             type="button"

--- a/packages/frontend/src/components/shared/template-option.tsx
+++ b/packages/frontend/src/components/shared/template-option.tsx
@@ -481,6 +481,16 @@ const TemplateOption: React.FC<TemplateOptionProps> = ({
           )}
         </div>
       );
+    case 'health-check-url':
+      return (
+        <HealthCheckUrlInput
+          name={name}
+          description={description}
+          value={forcedValue ?? value ?? defaultValue}
+          onChange={onChange}
+          disabled={isDisabled}
+        />
+      );
     case 'url':
       return (
         <div>
@@ -682,6 +692,36 @@ interface NabEndpointValue {
   url?: string;
   apiKey?: string;
 }
+
+// The connection check opens a socket and, when the row asks for SSL, completes
+// the handshake. It does not log in, so a pass says the server is reachable and
+// says nothing about the username and password.
+export type HealthCause =
+  | 'server-error'
+  | 'answered'
+  | 'unsafe-address'
+  | 'no-time'
+  | 'unresolvable'
+  | 'bad-redirect'
+  | 'too-many-redirects'
+  | 'unreachable';
+
+export interface HealthCheckTestResult {
+  ok: boolean;
+  outcome: 'skipped' | 'enabled';
+  cause: HealthCause;
+  reason: string;
+  // The HTTP code when the check made a request. A connection check has none.
+  status?: number;
+}
+
+// An address that can never be probed is the user's to fix; so is an addon
+// being skipped right now. Everything else describes someone else's server.
+export function verdictNeedsAttention(verdict: HealthCheckTestResult): boolean {
+  return verdict.cause === 'unsafe-address' || verdict.outcome === 'skipped';
+}
+
+export const HEALTH_CHECK_TEST_ENDPOINT = '/api/v1/health-check/test';
 
 interface NabTestResult {
   ok: boolean;
@@ -933,6 +973,101 @@ export interface NNTPServersInputProps {
   disabled?: boolean;
 }
 
+// Modal is a Radix Dialog with no forceMount, so closing it unmounts this and
+// discards the verdict. Adding forceMount carries a verdict to the next addon.
+function HealthCheckUrlInput({
+  name,
+  description,
+  value,
+  onChange,
+  disabled,
+}: {
+  name: string;
+  description?: string;
+  value: string | undefined;
+  onChange: (value: string | undefined) => void;
+  disabled?: boolean;
+}) {
+  const [verdict, setVerdict] = useState<HealthCheckTestResult | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  const runTest = async () => {
+    if (!value?.trim()) {
+      toast.error('Enter a URL before testing');
+      return;
+    }
+    setTesting(true);
+    setVerdict(null);
+    try {
+      const response = await fetch(HEALTH_CHECK_TEST_ENDPOINT, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: value }),
+      });
+      const json = await response.json();
+      if (!json.success) {
+        throw new Error(
+          json.detail || json.error?.message || 'Could not run the test'
+        );
+      }
+      setVerdict(json.data as HealthCheckTestResult);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Could not run the test'
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div>
+      <TextInput
+        label={name}
+        value={value ?? ''}
+        onValueChange={(next: string) => {
+          // Any edit invalidates the previous verdict.
+          setVerdict(null);
+          onChange(next || undefined);
+        }}
+        type="url"
+        disabled={disabled}
+      />
+      {description && (
+        <div className="text-xs text-[--muted] mt-1">
+          <MarkdownLite>{description}</MarkdownLite>
+        </div>
+      )}
+      <div className="flex items-center gap-3 mt-2">
+        <Button
+          type="button"
+          size="sm"
+          intent="primary-outline"
+          loading={testing}
+          disabled={disabled || testing || !value?.trim()}
+          onClick={runTest}
+        >
+          Test
+        </Button>
+        {verdict && (
+          <p
+            className={
+              verdictNeedsAttention(verdict)
+                ? 'text-sm text-[--alert]'
+                : 'text-sm text-[--muted]'
+            }
+          >
+            {verdict.status
+              ? `${verdict.status} — ${verdict.reason}`
+              : verdict.reason}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function NNTPServersInput({
   name,
   description,
@@ -942,11 +1077,21 @@ export function NNTPServersInput({
 }: NNTPServersInputProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [servers, setServers] = useState<NNTPServers>([]);
+  // Held beside the rows rather than on them: a verdict is not part of the
+  // saved config. Every handler that reorders or removes a row does the same to
+  // this, so a verdict cannot end up beside a server it was not taken from.
+  const [verdicts, setVerdicts] = useState<(HealthCheckTestResult | null)[]>(
+    []
+  );
+  const [testingIndex, setTestingIndex] = useState<number | null>(null);
 
   // Sync servers state when modal opens
   useEffect(() => {
     if (modalOpen) {
-      setServers(decodeServers(value));
+      const decoded = decodeServers(value);
+      setServers(decoded);
+      setVerdicts(decoded.map(() => null));
+      setTestingIndex(null);
     }
   }, [modalOpen, value]);
 
@@ -954,23 +1099,26 @@ export function NNTPServersInput({
 
   const handleAddServer = () => {
     setServers((prev) => [...prev, createEmptyServer()]);
+    setVerdicts((prev) => [...prev, null]);
   };
 
   const handleRemoveServer = (index: number) => {
     setServers((prev) => prev.filter((_, i) => i !== index));
+    setVerdicts((prev) => prev.filter((_, i) => i !== index));
+    setTestingIndex(null);
   };
 
   const handleMoveServer = (index: number, direction: 'up' | 'down') => {
-    setServers((prev) => {
-      const newServers = [...prev];
-      const targetIndex = direction === 'up' ? index - 1 : index + 1;
-      if (targetIndex < 0 || targetIndex >= newServers.length) return prev;
-      [newServers[index], newServers[targetIndex]] = [
-        newServers[targetIndex],
-        newServers[index],
-      ];
-      return newServers;
-    });
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= servers.length) return;
+    const swap = <T,>(list: T[]): T[] => {
+      const next = [...list];
+      [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+      return next;
+    };
+    setServers(swap);
+    setVerdicts(swap);
+    setTestingIndex(null);
   };
 
   const handleServerChange = (
@@ -983,6 +1131,9 @@ export function NNTPServersInput({
         i === index ? { ...server, [field]: fieldValue } : server
       )
     );
+    // Any edit invalidates the previous verdict: a pass beside a changed host
+    // reports on a server that was never tested.
+    setVerdicts((prev) => prev.map((v, i) => (i === index ? null : v)));
   };
 
   const handleSave = () => {
@@ -994,6 +1145,42 @@ export function NNTPServersInput({
 
   const handleCancel = () => {
     setModalOpen(false);
+  };
+
+  const runConnectionTest = async (index: number) => {
+    const server = servers[index];
+    if (!server?.host?.trim()) {
+      toast.error('Enter a host before testing');
+      return;
+    }
+    setTestingIndex(index);
+    setVerdicts((prev) => prev.map((v, i) => (i === index ? null : v)));
+    try {
+      const response = await fetch(HEALTH_CHECK_TEST_ENDPOINT, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          host: server.host,
+          port: server.port,
+          ssl: server.ssl,
+        }),
+      });
+      const json = await response.json();
+      if (!json.success) {
+        throw new Error(
+          json.detail || json.error?.message || 'Could not run the test'
+        );
+      }
+      const verdict = json.data as HealthCheckTestResult;
+      setVerdicts((prev) => prev.map((v, i) => (i === index ? verdict : v)));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Could not run the test'
+      );
+    } finally {
+      setTestingIndex(null);
+    }
   };
 
   return (
@@ -1123,6 +1310,36 @@ export function NNTPServersInput({
                     />
                   </div>
                 </div>
+
+                <div className="mt-3 flex items-center gap-3">
+                  <Button
+                    type="button"
+                    size="sm"
+                    intent="primary-outline"
+                    loading={testingIndex === index}
+                    disabled={disabled || testingIndex !== null}
+                    onClick={() => runConnectionTest(index)}
+                  >
+                    Test connection
+                  </Button>
+                  {verdicts[index] && (
+                    <p
+                      className={
+                        verdictNeedsAttention(verdicts[index]!)
+                          ? 'text-sm text-[--alert]'
+                          : 'text-sm text-[--muted]'
+                      }
+                    >
+                      {verdicts[index]!.status
+                        ? `${verdicts[index]!.status} — ${verdicts[index]!.reason}`
+                        : verdicts[index]!.reason}
+                    </p>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-[--muted]">
+                  Checks that the server accepts a connection. It does not sign
+                  in, so the username and password are not tested.
+                </p>
               </div>
             ))
           )}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,6 +3,7 @@ import {
   userApi,
   profilesApi,
   healthApi,
+  healthCheckApi,
   statusApi,
   formatApi,
   catalogApi,
@@ -167,6 +168,7 @@ const apiRouter = express.Router();
 apiRouter.use('/user', userApi);
 apiRouter.use('/profiles', profilesApi);
 apiRouter.use('/health', healthApi);
+apiRouter.use('/health-check', healthCheckApi);
 apiRouter.use('/status', statusApi);
 apiRouter.use('/format', formatApi);
 apiRouter.use('/catalogs', catalogApi);

--- a/packages/server/src/middlewares/ratelimit.ts
+++ b/packages/server/src/middlewares/ratelimit.ts
@@ -82,6 +82,14 @@ const lazyLimiter = (
   };
 };
 
+// The test endpoint fetches a URL the caller supplies, on demand and
+// uncached — unlike the gate, which only re-probes a saved value every thirty
+// seconds. Refusing private targets bounds where it can reach, not how often.
+const healthCheckApiRateLimiter = lazyLimiter(
+  () => appConfig.rateLimits.healthCheckApi,
+  'health-check-api'
+);
+
 const userApiRateLimiter = lazyLimiter(
   () => appConfig.rateLimits.userApi,
   'user-api'
@@ -163,6 +171,7 @@ const communityApiRateLimiter = lazyLimiter(
 );
 
 export {
+  healthCheckApiRateLimiter,
   userApiRateLimiter,
   userCreateRateLimiter,
   linkedAccountsRateLimiter,

--- a/packages/server/src/routes/api/health-check.ts
+++ b/packages/server/src/routes/api/health-check.ts
@@ -1,0 +1,67 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { createResponse } from '../../utils/responses.js';
+import {
+  APIError,
+  constants,
+  createLogger,
+  probeVerdict,
+  probeNntpVerdict,
+} from '@aiostreams/core';
+import { healthCheckApiRateLimiter } from '../../middlewares/ratelimit.js';
+
+const router: Router = Router();
+const logger = createLogger('server');
+
+router.use(healthCheckApiRateLimiter);
+
+const UrlTest = z.object({ url: z.string().url() });
+const NntpTest = z.object({
+  host: z.string().min(1),
+  port: z.number().int().positive(),
+  ssl: z.boolean(),
+});
+
+router.post(
+  '/test',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const nntp = NntpTest.safeParse(req.body);
+      if (nntp.success) {
+        const verdict = await probeNntpVerdict(
+          nntp.data.host,
+          nntp.data.port,
+          nntp.data.ssl
+        );
+        res.status(200).json(createResponse({ success: true, data: verdict }));
+        return;
+      }
+
+      const url = UrlTest.safeParse(req.body);
+      if (!url.success) {
+        throw new APIError(
+          constants.ErrorCode.BAD_REQUEST,
+          undefined,
+          'Provide either a health check URL, or a host, port and ssl flag.'
+        );
+      }
+
+      // The same call the gate makes, so the answer here is the answer there. A
+      // private or unresolvable address comes back as its own verdict rather than
+      // an error, because it is a thing to tell the user rather than a fault.
+      const verdict = await probeVerdict(url.data.url);
+      res.status(200).json(createResponse({ success: true, data: verdict }));
+    } catch (error: any) {
+      if (error instanceof APIError) {
+        next(error);
+        return;
+      }
+      logger.error(`Health check test failed: ${error.message}`);
+      next(
+        new APIError(constants.ErrorCode.INTERNAL_SERVER_ERROR, error.message)
+      );
+    }
+  }
+);
+
+export default router;

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -1,6 +1,7 @@
 export { default as userApi } from './user.js';
 export { default as profilesApi } from './profiles.js';
 export { default as healthApi } from './health.js';
+export { default as healthCheckApi } from './health-check.js';
 export { default as statusApi } from './status.js';
 export { default as formatApi } from './format.js';
 export { default as catalogApi } from './catalog.js';


### PR DESCRIPTION
Closes #1221.

## Image to try
`ghcr.io/ibbylabs/aiostreams:health_gate`

Back up your database first. The image is built from `main`, which carries migrations that are not in the last release, and the migration runner is up-only. This PR adds no migration of its own.

## What it does

A service, an addon or a usenet server can be skipped while it is known to be down, so a result you cannot play does not take a slot from one you can.

- **Addons and services** carry an optional `healthCheckUrl`. While that URL answers 5xx the item is left out; anything else, or no URL, and nothing changes.
- **Usenet servers** are checked by connecting to them. No URL to supply — the check opens the socket, completes the TLS handshake where the row asks for it, and closes. It never signs in, so a wrong password is not reported as an outage.
- Verdicts are cached for 30 seconds and concurrent lookups for one target share a single probe, so a chain of addons behind one provider costs one check rather than one each.

## Two different failure rules, on purpose

- A **URL** check fails **open**. A probe that times out, errors, or answers 4xx leaves the item enabled: a monitor being unreachable says nothing about the provider behind it, and a mistyped URL is a configuration mistake rather than an outage.
- A **usenet server** check fails **closed**. A server that will not accept a connection cannot serve articles, so that reading is the thing itself rather than a signal about it.

## Configuring it

- **Addons** — a Health Check URL on every preset, in the advanced section.
- **Services** — the same, on services that are a remote provider. Hidden where the service is a local engine over servers you supply; those are checked per server instead, because one URL for a whole set would drop every provider when one of them is down.
- **Usenet servers** — a Test connection button per row in the dashboard.

Each surface has a **Test** button that reports what the gate would do with the value in front of you, from the same code the gate runs. A verdict is cleared whenever the value it described is edited.

## URLs it refuses

The URL is fetched by the server, so it is treated as end-user input.

- The schema refuses a literal private, loopback or link-local address at save time. Accepting one would store a control that can never gate anything, since the gate treats an address it cannot probe as healthy.
- Before each fetch, and on every redirect hop, `isUnsafeRemoteUrlResolved` refuses a hostname that *resolves* to one. `url-safety.ts` names that as the guard for URLs that come from an end user, and a literal check alone would pass a name pointing at a private address.
- The Test endpoint is rate limited (`HEALTH_CHECK_API`, 10 per 60s by default). It probes an arbitrary URL on demand rather than a saved one every 30 seconds, so refusing private targets bounds where it can reach but not how often.

## Considered and not done

Two things were built as far as a design and then dropped, both for the same reason. Recording them so they are not proposed again.

- **Skipping the probe for a server that already has a live connection.** A live connection is proof of reachability, so probing one is redundant. It cannot be done here: the usenet servers this gate probes come from the `stremio_nntp` credential and are handed to a downstream addon as connection strings. AIOStreams never dials them, so there is no connection state of its own to consult.
- **Making the existing usenet Test button report the gate's verdict.** That button tests the usenet engine's own providers, which this gate never touches. Reporting a gate verdict there would describe a relationship that does not exist.

The line under both: this can only gate what AIOStreams is the one calling. A custom addon that resolves a stream through its own provider is invisible to it, and the addon-level URL is the only control that reaches that case.

## Known gaps, rather than surprises

- **Two of the three surfaces have been exercised, not all of them.** The service Configure modal and the addon option were driven against a built image, and two faults came out of it: the usenet preset was still offering an addon-wide health check, and the addon field said nothing about which URL belongs in it. Both are fixed here. The usenet server rows were not driven, so the socket probe is covered by its unit path and by reading rather than by use. No sweep across every preset and service has been done either.
- **The preset carve-out is read and typechecked, not executed.** `SUPPORTS_HEALTH_CHECK: false` withholding the option is covered by neither a test nor a click. Preset metadata reads config and then the database at import time, so a test cannot reach `optionsFor` without standing up a database before its own first line — which is also why no preset in this repo has a test today. Stated rather than implied.
- **`packages/core` must be built before typechecking the frontend.** It compiles against `core/dist`, so a source-only change produces errors that have nothing to do with the diff — twenty of them in one case, and a phantom missing field in another. `npm run build` in `packages/core` first.
- **Hiding the service field does not clear a stored value.** A service that no longer offers the control keeps any `healthCheckUrl` set before, which then cannot be edited from the UI. Hiding a control and deleting the data behind it are different acts and the second is not ours to do silently.
- **The addon surface clears its verdict by being unmounted.** The modal is a Radix `Dialog` without `forceMount`, so closing it destroys the component and the verdict with it. The other two surfaces clear explicitly. Adding `forceMount` — for a close animation, say — would start showing a verdict from the previously opened addon, with nothing failing.
- **A self-hosted instance still cannot use a private address for a URL check**, even with `linkedAccounts.allowPrivateUrls` set. Honouring that setting means reading config inside a zod refine, which the codebase guards against — schemas are built before `initialiseConfig()` resolves. Doing it properly means validating at the API boundary the way `assertReachableUrl` does, which is a separate change and your call.

— Milo #5574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional health-check endpoints for services and add-ons.
  - Services and add-ons are checked before stream retrieval and selection.
  - Health-check results are briefly cached and checked in parallel.

- **Bug Fixes**
  - Unavailable services and add-ons are automatically excluded.
  - Health checks use timeouts and safely follow redirects.
  - Skipped add-ons are reported in scrape summaries with a `SKIPPED` status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


