### PR TITLE
chore(presets/newznab): add Treasure Maps api key url

### DIFF
--- a/packages/core/src/presets/newznab.ts
+++ b/packages/core/src/presets/newznab.ts
@@ -90,6 +90,7 @@ const NEWZNAB_INDEXERS: {
   {
     label: 'Treasure Maps (formerly SceneNZBs)',
     value: 'https://treasure-maps.com/api',
+    apiKeyUrl: 'https://treasure-maps.com/account',
   },
   {
     label: 'Tabula Rasa',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a direct account URL for configuring the Treasure Maps Newznab indexer API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->