### PR TITLE
feat(configure): add AIOManager sync to the install page

### DIFF
--- a/packages/frontend/src/components/menu/aiomanager-sync-modal.tsx
+++ b/packages/frontend/src/components/menu/aiomanager-sync-modal.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { TextInput } from '@/components/ui/text-input';
+import { PasswordInput } from '@/components/ui/password-input';
+import { Select } from '@/components/ui/select';
+import { Modal } from '@/components/ui/modal';
+import { toast } from 'sonner';
+import { checkAIOManagerStatus, syncToAIOManager } from '@/lib/api';
+
+const CUSTOM_INSTANCE = 'custom';
+
+/** Instances whose operators publish them for open use. */
+const PUBLIC_INSTANCES: { name: string; url: string }[] = [
+  { name: 'Elfhosted', url: 'https://aiomanager.elfhosted.com' },
+  { name: 'IbbyLabs', url: 'https://aiomanager.ibbylabs.dev' },
+  { name: 'Kuu', url: 'https://aiomanager.stremio.ru' },
+  { name: 'Midnight', url: 'https://aiomanagerfortheweebs.midnightignite.me' },
+  { name: 'Yeb', url: 'https://aiomanager.fortheweak.cloud' },
+  { name: 'Kuu (beta)', url: 'https://aiomanager-beta.stremio.ru' },
+  { name: 'Yeb (beta)', url: 'https://aiomanager-beta.fortheweak.cloud' },
+];
+
+/** The last instance used, so only the key has to be retyped. Never the key. */
+const INSTANCE_STORAGE_KEY = 'aiostreams-aiomanager-instance';
+
+type Support = 'unknown' | 'checking' | 'yes' | 'no';
+
+interface AIOManagerSyncModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  manifestUrl: string;
+}
+
+export function AIOManagerSyncModal({
+  open,
+  onOpenChange,
+  manifestUrl,
+}: AIOManagerSyncModalProps) {
+  const [selectedInstance, setSelectedInstance] =
+    React.useState<string>(CUSTOM_INSTANCE);
+  const [customUrl, setCustomUrl] = React.useState('');
+  const [apiKey, setApiKey] = React.useState('');
+  const [isSyncing, setIsSyncing] = React.useState(false);
+  const [support, setSupport] = React.useState<Support>('unknown');
+  const [instanceSupport, setInstanceSupport] = React.useState<
+    Record<string, boolean>
+  >({});
+
+  React.useEffect(() => {
+    if (!open) return;
+    let remembered: string | null = null;
+    try {
+      remembered = window.localStorage.getItem(INSTANCE_STORAGE_KEY);
+    } catch {
+      // Storage can be unavailable; the form simply starts empty.
+    }
+    if (!remembered) return;
+    const listed = PUBLIC_INSTANCES.find((i) => i.url === remembered);
+    setSelectedInstance(listed ? listed.url : CUSTOM_INSTANCE);
+    if (!listed) setCustomUrl(remembered);
+  }, [open]);
+
+  // Which listed instances have updated far enough to accept a sync. There is
+  // no registry of that, so each one is asked directly.
+  React.useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    Promise.all(
+      PUBLIC_INSTANCES.map(async (instance) => {
+        try {
+          const status = await checkAIOManagerStatus(instance.url);
+          return [instance.url, status.supported] as const;
+        } catch {
+          return [instance.url, false] as const;
+        }
+      })
+    ).then((pairs) => {
+      if (!cancelled) setInstanceSupport(Object.fromEntries(pairs));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const effectiveUrl = (
+    selectedInstance === CUSTOM_INSTANCE ? customUrl : selectedInstance
+  )
+    .trim()
+    .replace(/\/+$/, '');
+
+  React.useEffect(() => {
+    if (!open || !effectiveUrl) {
+      setSupport('unknown');
+      return;
+    }
+    let cancelled = false;
+    setSupport('checking');
+    const timer = setTimeout(() => {
+      checkAIOManagerStatus(effectiveUrl)
+        .then((status) => {
+          if (!cancelled) setSupport(status.supported ? 'yes' : 'no');
+        })
+        .catch(() => {
+          if (!cancelled) setSupport('unknown');
+        });
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [open, effectiveUrl]);
+
+  const handleSync = async () => {
+    const key = apiKey.trim();
+    if (!effectiveUrl || !key) {
+      toast.error('Enter your AIOManager instance URL and API key.');
+      return;
+    }
+    setIsSyncing(true);
+    try {
+      await syncToAIOManager({
+        instanceUrl: effectiveUrl,
+        apiKey: key,
+        addonUrl: manifestUrl,
+      });
+      try {
+        window.localStorage.setItem(INSTANCE_STORAGE_KEY, effectiveUrl);
+      } catch {
+        // Not remembering the instance is not worth failing the sync over.
+      }
+      toast.success('Addon synced to AIOManager');
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to sync to AIOManager'
+      );
+    } finally {
+      setIsSyncing(false);
+    }
+  };
+
+  const instanceOptions = [
+    ...PUBLIC_INSTANCES.map((instance) => ({
+      value: instance.url,
+      label:
+        instanceSupport[instance.url] === false
+          ? `${instance.name} — no Hydra API`
+          : instance.name,
+    })),
+    { value: CUSTOM_INSTANCE, label: 'Custom instance' },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Sync to AIOManager"
+      description="Install or update this addon in your AIOManager account and propagate it to your connected platforms."
+    >
+      <div className="flex flex-col gap-4">
+        <Select
+          label="Instance"
+          value={selectedInstance}
+          onValueChange={setSelectedInstance}
+          options={instanceOptions}
+        />
+
+        {selectedInstance === CUSTOM_INSTANCE && (
+          <TextInput
+            label="Instance URL"
+            placeholder="https://aio.example.com"
+            value={customUrl}
+            onValueChange={setCustomUrl}
+          />
+        )}
+
+        <PasswordInput
+          label="API key"
+          help="AIOManager: Accounts → Connections → API key"
+          value={apiKey}
+          onValueChange={setApiKey}
+        />
+
+        {support === 'no' && (
+          <p className="text-xs text-amber-300">
+            This instance does not serve the Hydra API, so it cannot accept a
+            sync. It needs a newer AIOManager release.
+          </p>
+        )}
+        {support === 'checking' && (
+          <p className="text-xs text-gray-400">Checking this instance…</p>
+        )}
+
+        <Button
+          onClick={handleSync}
+          intent="primary"
+          loading={isSyncing}
+          disabled={support === 'no' || !effectiveUrl || !apiKey.trim()}
+        >
+          Sync
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/frontend/src/components/menu/save-install.tsx
+++ b/packages/frontend/src/components/menu/save-install.tsx
@@ -18,6 +18,7 @@ import {
   CopyIcon,
   DownloadIcon,
   PlusIcon,
+  RefreshCw,
   Rss,
   SearchIcon,
   UploadIcon,
@@ -47,6 +48,7 @@ import { redactPresetOptions } from '@/lib/preset-credentials';
 import { useSave } from '@/context/save';
 import { FiExternalLink } from 'react-icons/fi';
 import { ProfileCard } from './profile-card';
+import { AIOManagerSyncModal } from './aiomanager-sync-modal';
 import { useSession } from '@/context/session';
 import { useQuery } from '@tanstack/react-query';
 import { configProfilesQuery } from '@/lib/queries';
@@ -445,6 +447,7 @@ interface InstallCardProps {
   usingAlias: boolean;
   onCopyManifestUrl: () => void;
   onOpenChillio: () => void;
+  onOpenAIOManager: () => void;
   onOpenSeanime: () => void;
   onOpenJellyfin: () => void;
   onOpenAniyomi: () => void;
@@ -466,6 +469,7 @@ function InstallCard({
   variantSelector,
   onCopyManifestUrl,
   onOpenChillio,
+  onOpenAIOManager,
   onOpenSeanime,
   onOpenJellyfin,
   onOpenAniyomi,
@@ -600,6 +604,12 @@ function InstallCard({
               unofficial
               author="worldInColors"
               onClick={onOpenAniyomi}
+            />
+            <AppCard
+              icon={<RefreshCw className="h-5 w-5" />}
+              name="AIOManager"
+              description="Sync into your Stremio account"
+              onClick={onOpenAIOManager}
             />
           </div>
         </div>
@@ -1426,6 +1436,7 @@ function Content() {
   const aniyomiModal = useDisclosure(false);
   const nabIndexerModal = useDisclosure(false);
   const searchApiModal = useDisclosure(false);
+  const aioManagerModal = useDisclosure(false);
   const { handleSave: handleSaveContext, loading: saveLoading } = useSave();
   const confirmResetProps = useConfirmationDialog({
     title: 'Confirm Reset',
@@ -1840,6 +1851,7 @@ function Content() {
               }
               onCopyManifestUrl={copyManifestUrl}
               onOpenChillio={chillLinkModal.open}
+              onOpenAIOManager={aioManagerModal.open}
               onOpenSeanime={seanimeModal.open}
               onOpenJellyfin={jellyfinModal.open}
               onOpenAniyomi={aniyomiModal.open}
@@ -2061,6 +2073,13 @@ function Content() {
             </div>
           </div>
         </Modal>
+
+        {/* AIOManager sync modal */}
+        <AIOManagerSyncModal
+          open={aioManagerModal.isOpen}
+          onOpenChange={aioManagerModal.toggle}
+          manifestUrl={manifestUrl}
+        />
 
         {/* Seanime modal */}
         <Modal

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -559,6 +559,35 @@ export async function fetchManifest(url: string): Promise<any> {
   return response.json();
 }
 
+export interface AIOManagerStatus {
+  supported: boolean;
+  capabilities?: Record<string, unknown>;
+}
+
+/**
+ * Ask whether an AIOManager instance serves the Hydra API. Instances that
+ * predate it report unsupported rather than failing.
+ */
+export async function checkAIOManagerStatus(instanceUrl: string) {
+  return api<AIOManagerStatus>(
+    `GET /aiomanager/status?instanceUrl=${encodeURIComponent(instanceUrl)}`
+  );
+}
+
+/**
+ * Install or update this addon in the user's AIOManager account. The key is
+ * relayed by the server, so it never leaves this origin.
+ */
+export async function syncToAIOManager(options: {
+  instanceUrl: string;
+  apiKey: string;
+  addonUrl: string;
+}) {
+  return api<Record<string, unknown>>('POST /aiomanager/reinstall', {
+    body: options,
+  });
+}
+
 export type {
   ParsedStream,
   LoadUserResponse,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -14,6 +14,7 @@ import {
   proxyApi,
   templatesApi,
   syncApi,
+  aiomanagerApi,
   authApi,
   dashboardApi,
   usenetApi,
@@ -176,6 +177,7 @@ apiRouter.use('/anime', animeApi);
 apiRouter.use('/proxy', proxyApi);
 apiRouter.use('/templates', templatesApi);
 apiRouter.use('/sync', syncApi);
+apiRouter.use('/aiomanager', aiomanagerApi);
 apiRouter.use('/auth', authApi);
 apiRouter.use('/dashboard', dashboardApi);
 apiRouter.use('/usenet', usenetApi);

--- a/packages/server/src/routes/api/aiomanager.ts
+++ b/packages/server/src/routes/api/aiomanager.ts
@@ -1,0 +1,223 @@
+import { Router } from 'express';
+import {
+  APIError,
+  constants,
+  createLogger,
+  Env,
+  isUnsafeRemoteUrl,
+  makeRequest,
+} from '@aiostreams/core';
+import { z } from 'zod';
+import { createResponse } from '../../utils/responses.js';
+
+const router: Router = Router();
+const logger = createLogger('server');
+
+const STATUS_TIMEOUT = 10000;
+const REINSTALL_TIMEOUT = 15000;
+
+const StatusQuerySchema = z.object({
+  instanceUrl: z.string().url(),
+});
+
+const ReinstallSchema = z.object({
+  instanceUrl: z.string().url(),
+  apiKey: z.string().min(1),
+  addonUrl: z.string().url(),
+});
+
+/**
+ * A manager URL comes from the browser and is fetched by this server, so it
+ * gets the same guard as any other user-supplied remote: http(s) only, and no
+ * loopback, private, link-local or CGNAT target.
+ *
+ * It is also a base that endpoint paths are appended to, so a query or fragment
+ * on it would move the request: `https://host/?x=1` + `/hydra/reinstall` asks
+ * for `/` and carries the API key there. A path is fine — instances behind one
+ * are supported — but anything after it is refused rather than trimmed, so a
+ * mistyped URL is reported instead of silently meaning something else.
+ */
+function managerUrlOrNull(value: string): URL | null {
+  if (isUnsafeRemoteUrl(value)) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  return parsed.search || parsed.hash ? null : parsed;
+}
+
+function parseUrlOrNull(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * GET /status — report whether a manager instance serves the Hydra API.
+ *
+ * Instances predating Hydra answer the route with their SPA, so a string body
+ * or a payload without capabilities means unsupported rather than broken.
+ */
+router.get('/status', async (req, res, next) => {
+  const parsed = StatusQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    next(
+      new APIError(
+        constants.ErrorCode.MISSING_REQUIRED_FIELDS,
+        undefined,
+        'instanceUrl must be a valid URL'
+      )
+    );
+    return;
+  }
+
+  const instance = managerUrlOrNull(parsed.data.instanceUrl);
+  if (!instance) {
+    next(
+      new APIError(
+        constants.ErrorCode.BAD_REQUEST,
+        undefined,
+        'instanceUrl must be a public http(s) URL with no query or fragment'
+      )
+    );
+    return;
+  }
+
+  const target = `${stripTrailingSlashes(instance.toString())}/hydra/status`;
+  try {
+    const response = await makeRequest(target, {
+      timeout: STATUS_TIMEOUT,
+      method: 'GET',
+    });
+    const body = response.ok ? await response.json().catch(() => null) : null;
+    const capabilities = (body as { capabilities?: unknown } | null)
+      ?.capabilities;
+    if (!capabilities) {
+      res
+        .status(200)
+        .json(createResponse({ success: true, data: { supported: false } }));
+      return;
+    }
+    // supported goes last: the upstream body is spread in wholesale and must
+    // not be able to set the field this route exists to report.
+    res.status(200).json(
+      createResponse({
+        success: true,
+        data: { ...(body as Record<string, unknown>), supported: true },
+      })
+    );
+  } catch (error) {
+    // An unreachable instance is indistinguishable from one without Hydra from
+    // here, and both mean the same thing to the person choosing an instance.
+    logger.debug(`AIOManager status probe failed for ${instance.host}`);
+    res
+      .status(200)
+      .json(createResponse({ success: true, data: { supported: false } }));
+  }
+});
+
+/**
+ * POST /reinstall — relay a sync to the user's manager instance.
+ *
+ * The browser never holds a connection to the manager, so the API key travels
+ * to this addon and no further.
+ */
+router.post('/reinstall', async (req, res, next) => {
+  const parsed = ReinstallSchema.safeParse(req.body);
+  if (!parsed.success) {
+    next(
+      new APIError(
+        constants.ErrorCode.MISSING_REQUIRED_FIELDS,
+        undefined,
+        'instanceUrl, apiKey and addonUrl are required, and both URLs must be valid'
+      )
+    );
+    return;
+  }
+
+  const { apiKey, addonUrl } = parsed.data;
+  const instance = managerUrlOrNull(parsed.data.instanceUrl);
+  if (!instance) {
+    next(
+      new APIError(
+        constants.ErrorCode.BAD_REQUEST,
+        undefined,
+        'instanceUrl must be a public http(s) URL with no query or fragment'
+      )
+    );
+    return;
+  }
+
+  // Only manifests this addon serves may be relayed. Without this the endpoint
+  // would install any addon into any manager the caller holds a key for.
+  const addon = parseUrlOrNull(addonUrl);
+  const self = parseUrlOrNull(Env.BASE_URL);
+  if (!addon || !self || addon.origin !== self.origin) {
+    next(
+      new APIError(
+        constants.ErrorCode.BAD_REQUEST,
+        undefined,
+        'addonUrl must be a manifest URL served by this instance'
+      )
+    );
+    return;
+  }
+
+  const target = `${stripTrailingSlashes(instance.toString())}/hydra/reinstall`;
+  try {
+    const response = await makeRequest(target, {
+      timeout: REINSTALL_TIMEOUT,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ addonUrl }),
+    });
+
+    const body = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const detail =
+        (body as { error?: string } | null)?.error ??
+        `AIOManager refused the sync (${response.status})`;
+      next(new APIError(constants.ErrorCode.BAD_REQUEST, undefined, detail));
+      return;
+    }
+
+    if (body === null) {
+      // A 2xx that is not JSON is the SPA catch-all, so this release has no
+      // Hydra API and the sync was not carried out. Checked after the status,
+      // because a 5xx error page is also unparseable and means something else.
+      next(
+        new APIError(
+          constants.ErrorCode.BAD_REQUEST,
+          undefined,
+          'This AIOManager instance does not serve the Hydra API yet, so nothing was synced. It needs a newer AIOManager release.'
+        )
+      );
+      return;
+    }
+
+    res.status(200).json(
+      createResponse({
+        success: true,
+        detail: 'Addon synced to AIOManager',
+        data: body as Record<string, unknown>,
+      })
+    );
+  } catch (error) {
+    logger.error(error);
+    next(new APIError(constants.ErrorCode.INTERNAL_SERVER_ERROR));
+  }
+});
+
+export default router;

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -12,6 +12,7 @@ export { default as animeApi } from './anime.js';
 export { default as proxyApi } from './proxy.js';
 export { default as templatesApi } from './templates.js';
 export { default as syncApi } from './sync.js';
+export { default as aiomanagerApi } from './aiomanager.js';
 export { default as authApi } from './auth/index.js';
 export { default as dashboardApi } from './dashboard/index.js';
 export { default as usenetApi } from './usenet.js';


### PR DESCRIPTION
Closes #1229

Adds an AIOManager card to the install page. It installs or updates this addon in the user's AIOManager account and propagates it to their connected platforms, so a config change doesn't mean reinstalling by hand everywhere.

AIOMetadata already ships this against the same API, and its integration is written around a manager list rather than a single hardcoded target — so this follows an established shape rather than inventing one.

**The key never leaves this origin.** The browser posts to AIOStreams and the server relays to the manager, so the manager API key isn't handled cross-origin. `reinstall` also refuses any `addonUrl` whose host isn't this instance's own `BASE_URL`, so the endpoint can't be used to push an arbitrary addon into someone's manager.

**Old instances degrade rather than fail.** Releases without the Hydra API answer `/hydra/status` with their SPA, so a non-JSON body means unsupported and the picker marks the instance instead of letting someone try and get an error. The listed instances are probed when the dialog opens and a typed URL is probed on a debounce, so there's no list of "who has upgraded" to keep current.

**What it touches**

| | |
| --- | --- |
| `packages/server/src/routes/api/aiomanager.ts` | new: `GET /status`, `POST /reinstall` |
| `packages/server/src/app.ts`, `routes/api/index.ts` | mount it |
| `packages/frontend/src/components/menu/aiomanager-sync-modal.tsx` | new: instance picker and sync |
| `packages/frontend/src/components/menu/save-install.tsx` | one `AppCard` under Other apps |
| `packages/frontend/src/lib/api.ts` | two client functions |

No new dependencies, no config or schema changes, and nothing is persisted server-side — the chosen instance is remembered in `localStorage`, the key is not. `tsc --noEmit` is clean on both packages.

Happy to change the placement, the copy, or drop the public instance list and leave it custom-URL only if you'd rather not carry one.

— Milo #5574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AIOManager integration to the save/install menu.
  - Users can select a public or custom instance, enter an API key, check compatibility, and sync addon manifests.
  - The selected instance is remembered for future use.
  - Added validation and clear success or error notifications.
  - Unsupported or unreachable instances cannot be synced.
  - Added secure server-side support for checking instances and processing sync requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->