### PR TITLE
feat(core): add mediaInfoQuality

### DIFF
--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -52,6 +52,7 @@ export function parseNabParsedFileInfo(args: {
   subtitleLanguages?: string | number | boolean;
 }): ParsedMediaInfo | undefined {
   return normaliseParsedMediaInfo({
+    mediaInfoQuality: 'indexer',
     languages: parseNabLanguages(args.audioLanguages),
     subtitles: parseNabLanguages(args.subtitleLanguages),
   });

--- a/packages/core/src/builtins/easynews-search/addon.ts
+++ b/packages/core/src/builtins/easynews-search/addon.ts
@@ -200,6 +200,7 @@ export class EasynewsSearchAddon extends BaseDebridAddon<EasynewsSearchAddonConf
 
       const audioTag = easynewsAudioTag(item.acodec, item.title);
       const parsedMediaInfo = normaliseParsedMediaInfo({
+        mediaInfoQuality: 'indexer',
         languages: item.audioLangs,
         subtitles: item.subLangs,
         audioTags: audioTag ? [audioTag] : undefined,

--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -1087,6 +1087,7 @@ export const ParsedFileSchema = z.object({
   audioChannels: z.array(z.string()),
   visualTags: z.array(z.string()),
   audioTags: z.array(z.string()),
+  mediaInfoQuality: z.enum(['probe', 'indexer', 'addon']).optional(),
   languages: z.array(z.string()),
   subtitles: z.array(z.string()).optional(),
   subbed: z.boolean().optional(),

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -59,6 +59,7 @@ export interface ParseValue {
     resolution: string | null;
     subbed: boolean;
     dubbed: boolean;
+    mediaInfoQuality: string | null;
     languages: string[] | null;
     uLanguages: string[] | null;
     subtitles: string[] | null;
@@ -498,6 +499,7 @@ export abstract class BaseFormatter {
         subbed:
           stream.parsedFile?.subbed || !!stream.parsedFile?.subtitles?.length,
         dubbed: stream.parsedFile?.dubbed || false,
+        mediaInfoQuality: stream.parsedFile?.mediaInfoQuality ?? null,
         get languages() {
           return languageVariants().sortedValues;
         },

--- a/packages/core/src/formatters/engine/fields.ts
+++ b/packages/core/src/formatters/engine/fields.ts
@@ -19,6 +19,7 @@ export const FIELD_REGISTRY: Readonly<Record<string, readonly string[]>> = {
     'subbed',
     'dubbed',
     'languages',
+    'mediaInfoQuality',
     'uLanguages',
     'subtitles',
     'uSubtitles',

--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -840,6 +840,29 @@ export abstract class StreamExpressionEngine {
 
     this.parser.functions.subtitles = this.parser.functions.subtitle;
 
+    this.parser.functions.mediaInfoQuality = function (
+      streams: ParsedStream[],
+      ...qualities: string[]
+    ) {
+      if (!Array.isArray(streams) || streams.some((stream) => !stream.type)) {
+        throw new Error('Your streams input must be an array of streams');
+      } else if (
+        qualities.length === 0 ||
+        qualities.some((q) => typeof q !== 'string')
+      ) {
+        throw new Error(
+          'You must provide one or more mediaInfoQuality strings'
+        );
+      }
+      return streams.filter((stream) =>
+        qualities
+          .map((q) => q.toLowerCase())
+          .includes(
+            stream.parsedFile?.mediaInfoQuality?.toLowerCase() || 'unknown'
+          )
+      );
+    };
+
     this.parser.functions.seeders = function (
       streams: ParsedStream[],
       minSeeders?: number,

--- a/packages/core/src/presets/meteor.ts
+++ b/packages/core/src/presets/meteor.ts
@@ -60,6 +60,7 @@ class MeteorStreamParser extends StreamParser {
         .filter((lang) => lang !== undefined) as string[];
       if (audioLangs.length > 0) {
         overrides.languages = audioLangs;
+        overrides.mediaInfoQuality = 'addon';
       }
     }
 
@@ -70,6 +71,7 @@ class MeteorStreamParser extends StreamParser {
         .filter((lang) => lang !== undefined) as string[];
       if (subtitleLangs.length > 0) {
         overrides.subtitles = subtitleLangs;
+        overrides.mediaInfoQuality = 'addon';
       }
     }
 

--- a/packages/core/src/presets/nekoBt.ts
+++ b/packages/core/src/presets/nekoBt.ts
@@ -190,31 +190,39 @@ export class NekoBtStreamParser extends BuiltinStreamParser {
         }
       }
       // audio languages
-      [...(fileMetadata.audioLanguages ?? [])]
+      const normalizedAudioLanguages = [...(fileMetadata.audioLanguages ?? [])]
         .map(NekoBtStreamParser.normalizeNekoBtLangCode)
         .map(mapLanguageCode)
         .map(convertLangCodeToName)
-        .forEach((lang: string | undefined) => {
-          if (lang && !parsedFile.languages?.includes(lang)) {
-            parsedFile.languages = parsedFile.languages || [];
-            parsedFile.languages.push(lang);
-          }
-        });
+        .filter((lang): lang is string => !!lang);
+      if (normalizedAudioLanguages.length > 0) {
+        parsedFile.mediaInfoQuality = 'indexer';
+      }
+      normalizedAudioLanguages.forEach((lang) => {
+        if (!parsedFile.languages?.includes(lang)) {
+          parsedFile.languages = parsedFile.languages || [];
+          parsedFile.languages.push(lang);
+        }
+      });
 
       // subtitle languages (includes fansubs)
-      [
+      const normalizedSubtitleLanguages = [
         ...(fileMetadata.fansubLanguages ?? []),
         ...(fileMetadata.subtitleLanguages ?? []),
       ]
         .map(NekoBtStreamParser.normalizeNekoBtLangCode)
         .map(mapLanguageCode)
         .map(convertLangCodeToName)
-        .forEach((lang: string | undefined) => {
-          if (lang && !parsedFile.subtitles?.includes(lang)) {
-            parsedFile.subtitles = parsedFile.subtitles || [];
-            parsedFile.subtitles.push(lang);
-          }
-        });
+        .filter((lang): lang is string => !!lang);
+      if (normalizedSubtitleLanguages.length > 0) {
+        parsedFile.mediaInfoQuality = 'indexer';
+      }
+      normalizedSubtitleLanguages.forEach((lang) => {
+        if (!parsedFile.subtitles?.includes(lang)) {
+          parsedFile.subtitles = parsedFile.subtitles || [];
+          parsedFile.subtitles.push(lang);
+        }
+      });
     }
 
     // add back after parsing so it is not interfering with filename parsing.

--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -68,6 +68,7 @@ export class StremThruStreamParser extends StreamParser {
         .filter((lang) => lang !== undefined) as string[];
       if (audioLangs.length > 0) {
         overrides.languages = audioLangs;
+        overrides.mediaInfoQuality = 'probe';
       }
     }
 
@@ -78,6 +79,7 @@ export class StremThruStreamParser extends StreamParser {
         .filter((lang) => lang !== undefined) as string[];
       if (subtitleLangs.length > 0) {
         overrides.subtitles = subtitleLangs;
+        overrides.mediaInfoQuality = 'probe';
       }
     }
 

--- a/packages/core/src/utils/media-info.ts
+++ b/packages/core/src/utils/media-info.ts
@@ -2,6 +2,8 @@ import * as constants from './constants.js';
 import { normaliseLanguage, normaliseLangCode } from './languages.js';
 
 export interface ParsedMediaInfo {
+  /** Provenance tier; unset means unconfirmed. */
+  mediaInfoQuality?: 'probe' | 'indexer' | 'addon';
   languages?: string[];
   subtitles?: string[];
   audioTags?: string[];
@@ -265,7 +267,22 @@ export function normaliseParsedMediaInfo(
       : undefined;
   }
 
+  const hasAnyData =
+    languages.length > 0 ||
+    subtitles.length > 0 ||
+    audioTags.length > 0 ||
+    audioChannels.length > 0 ||
+    visualTags.length > 0 ||
+    !!encode ||
+    !!resolution ||
+    !!parsedMediaInfo?.duration ||
+    !!parsedMediaInfo?.bitrate ||
+    !!parsedMediaInfo?.hasChapters;
+
   const result: ParsedMediaInfo = {
+    ...(parsedMediaInfo.mediaInfoQuality && hasAnyData
+      ? { mediaInfoQuality: parsedMediaInfo.mediaInfoQuality }
+      : {}),
     ...(languages.length > 0 ? { languages } : {}),
     ...(subtitles.length > 0 ? { subtitles } : {}),
     ...(audioTags.length > 0 ? { audioTags } : {}),
@@ -333,6 +350,7 @@ export function parseMediaInfo(
       : undefined;
 
   const normalised = normaliseParsedMediaInfo({
+    mediaInfoQuality: 'probe',
     languages,
     subtitles,
     audioTags,
@@ -355,6 +373,7 @@ export function mergeParsedMediaInfo(
   if (!base && !preferred) return undefined;
 
   const merged = normaliseParsedMediaInfo({
+    mediaInfoQuality: preferred?.mediaInfoQuality ?? base?.mediaInfoQuality,
     languages: preferred?.languages ?? base?.languages,
     subtitles: preferred?.subtitles ?? base?.subtitles,
     audioTags: preferred?.audioTags ?? base?.audioTags,

--- a/packages/docs/content/docs/reference/stream-expressions.mdx
+++ b/packages/docs/content/docs/reference/stream-expressions.mdx
@@ -285,6 +285,24 @@ encode(streams, 'H.265', 'HEVC')
 
 ---
 
+#### `mediaInfoQuality()`
+
+Filter by how a stream's media info (languages, subtitles, audio, etc.) was determined. Streams with no confirmed media info match `'unknown'`.
+
+**Accepted values:** `'probe'` `'indexer'` `'addon'` `'unknown'`
+
+```
+mediaInfoQuality(streams, 'probe', 'indexer')
+```
+
+To select only streams with *any* confirmed media info, negate the `'unknown'` match:
+
+```
+negate(mediaInfoQuality(streams, 'unknown'), streams)
+```
+
+---
+
 #### `type()`
 
 Filter by stream type.

--- a/packages/frontend/src/components/menu/formatter/preview/tabs/parsed-file.tsx
+++ b/packages/frontend/src/components/menu/formatter/preview/tabs/parsed-file.tsx
@@ -151,6 +151,14 @@ const COMMON_ROWS: readonly Row[] = [
     options: constants.LANGUAGES,
   },
   {
+    key: 'mediaInfoQuality',
+    label: 'Media info quality',
+    field: 'stream.mediaInfoQuality',
+    kind: 'enum',
+    options: ['probe', 'indexer', 'addon'],
+    help: 'Set when media info is confirmed, rather than guessed',
+  },
+  {
     key: 'subtitles',
     label: 'Subtitles',
     field: SUBTITLE_FIELDS,


### PR DESCRIPTION
Track media info provenance as mediaInfoQuality ('probe' | 'indexer' | 'addon', unset = filename/flag guess), expose it as a formatter option, and add a mediaInfoQuality() stream expression function.

---

I'm sure I'm missing some add-ons or implementations where this can be set stricter. e.g. easynews++? but can be improved later. also for meteor we might be able to set it to "probe", but I didn't get a confirmation, so I'd rather play it safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added media information quality tracking for parsed streams.
- Displayed quality indicators for probe, indexer, and addon-provided metadata.
- Added stream-expression filtering by media information quality.
- Preserved quality information when combining media metadata.

## Improvements
- Improved transparency and accuracy for language, subtitle, and audio metadata.
- Unconfirmed media information is now identified as unknown.

## Documentation
- Documented quality filtering, supported values, and handling of unconfirmed media information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->