### PR TITLE
feat(core): parse StremThru's edition data, fix emoji-boundary regex

### DIFF
--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -1,2 +1,3 @@
 export { default as FileParser } from './file.js';
 export { default as StreamParser } from './streams.js';
+export { getRegexForTextAfterEmojis } from './utils.js';

--- a/packages/core/src/parser/streams.test.ts
+++ b/packages/core/src/parser/streams.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRegexForTextAfterEmojis } from './utils.js';
+
+describe('getRegexForTextAfterEmojis', () => {
+  it('stops at a default-presentation emoji', () => {
+    const re = getRegexForTextAfterEmojis(['🎞️']);
+    assert.equal('🎞️ HEVC\n🎧 DD'.match(re)?.[1], 'HEVC');
+  });
+
+  it('stops at a text-presentation emoji forced via U+FE0F (e.g. gear)', () => {
+    const re = getRegexForTextAfterEmojis(['🏷️']);
+    assert.equal(
+      '🏷️ Extended Edition ⚙️ GROUP'.match(re)?.[1].trim(),
+      'Extended Edition'
+    );
+  });
+
+  it('stops at end of string', () => {
+    const re = getRegexForTextAfterEmojis(['🏷️']);
+    assert.equal('🏷️ Extended Edition'.match(re)?.[1], 'Extended Edition');
+  });
+
+  it('stops at a newline', () => {
+    const re = getRegexForTextAfterEmojis(['🏷️']);
+    assert.equal(
+      '🏷️ Extended Edition\n📄 movie.mkv'.match(re)?.[1],
+      'Extended Edition'
+    );
+  });
+
+  it('matches any of multiple given emojis', () => {
+    const re = getRegexForTextAfterEmojis(['📄', '📁']);
+    assert.equal('📄 file.mkv\n👤 5'.match(re)?.[1], 'file.mkv');
+    assert.equal('📁 folder\n👤 5'.match(re)?.[1], 'folder');
+  });
+});

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -13,6 +13,7 @@ import {
   parseAgeString,
   parseDuration,
   extractInfoHashFromMagnet,
+  getRegexForTextAfterEmojis,
 } from './utils.js';
 import {
   mergeParsedFiles,
@@ -59,18 +60,11 @@ class StreamParser {
   }
 
   protected get indexerRegex(): RegExp | undefined {
-    return this.getRegexForTextAfterEmojis(this.indexerEmojis);
+    return getRegexForTextAfterEmojis(this.indexerEmojis);
   }
 
   protected get ageRegex(): RegExp | undefined {
     return undefined;
-  }
-
-  protected getRegexForTextAfterEmojis(emojis: string[]): RegExp {
-    return new RegExp(
-      `(?:${emojis.join('|')})\\s*([^\\p{Emoji_Presentation}\\n]*?)(?=\\p{Emoji_Presentation}|$|\\n)`,
-      'u'
-    );
   }
 
   constructor(protected readonly addon: Addon) {}

--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -324,3 +324,12 @@ export function extractInfoHashFromMagnet(magnet: string): string | undefined {
   if (match.length === 40) return match.toLowerCase();
   return base32ToHex(match);
 }
+
+export function getRegexForTextAfterEmojis(emojis: string[]): RegExp {
+  // Some emoji (e.g. ⚙️) are text-presentation by default, so also treat
+  // any char + U+FE0F (emoji variation selector) as a boundary.
+  return new RegExp(
+    `(?:${emojis.join('|')})\\s*([^\\p{Emoji_Presentation}\\n]*?)(?=\\p{Emoji_Presentation}|.\\uFE0F|$|\\n)`,
+    'u'
+  );
+}

--- a/packages/core/src/presets/builtin.ts
+++ b/packages/core/src/presets/builtin.ts
@@ -1,5 +1,5 @@
 import { ParsedStream, Stream, UserData } from '../db/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getRegexForTextAfterEmojis } from '../parser/index.js';
 import FileParser from '../parser/file.js';
 import {
   arrayMerge,
@@ -204,7 +204,7 @@ export class BuiltinStreamParser extends StreamParser {
     currentParsedStream: ParsedStream
   ): string | undefined {
     return stream.description?.match(
-      this.getRegexForTextAfterEmojis(['🏷️'])
+      getRegexForTextAfterEmojis(['🏷️'])
     )?.[1];
   }
 }

--- a/packages/core/src/presets/easynewsPlusPlus.ts
+++ b/packages/core/src/presets/easynewsPlusPlus.ts
@@ -8,7 +8,7 @@ import { EasynewsPreset, EasynewsParser } from './easynews.js';
 import { constants } from '../utils/index.js';
 import { baseOptions } from './preset.js';
 import { config as appConfig } from '../config/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getRegexForTextAfterEmojis } from '../parser/index.js';
 import { arrayMerge } from '../parser/merge.js';
 
 class EasynewsPlusPlusParser extends EasynewsParser {
@@ -24,7 +24,7 @@ class EasynewsPlusPlusParser extends EasynewsParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string[] {
-    const regex = this.getRegexForTextAfterEmojis(['🌐']);
+    const regex = getRegexForTextAfterEmojis(['🌐']);
     const langs = stream.description?.match(regex)?.[1];
     return (
       langs
@@ -46,7 +46,7 @@ class EasynewsPlusPlusParser extends EasynewsParser {
     // Easynews++ emits a `💬` subtitle-language line alongside the `🌐` audio
     // line, using the same comma-separated ISO 639-2 codes. Parse it the same way
     // getLanguages() handles audio, and merge into the file's subtitle languages.
-    const regex = this.getRegexForTextAfterEmojis(['💬']);
+    const regex = getRegexForTextAfterEmojis(['💬']);
     const subtitles =
       stream.description
         ?.match(regex)?.[1]

--- a/packages/core/src/presets/mediafusion.ts
+++ b/packages/core/src/presets/mediafusion.ts
@@ -10,7 +10,7 @@ import { baseOptions, CacheKeyRequestOptions, Preset } from './preset.js';
 import { createLogger, getSimpleTextHash } from '../utils/index.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getRegexForTextAfterEmojis } from '../parser/index.js';
 
 const logger = createLogger('core');
 
@@ -43,8 +43,8 @@ class MediaFusionStreamParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    const nameRegex = this.getRegexForTextAfterEmojis(['📂']);
-    const filenameRegex = this.getRegexForTextAfterEmojis(['📄']);
+    const nameRegex = getRegexForTextAfterEmojis(['📂']);
+    const filenameRegex = getRegexForTextAfterEmojis(['📄']);
 
     const name = stream.description?.match(nameRegex)?.[1];
     const filename = stream.description?.match(filenameRegex)?.[1];
@@ -100,7 +100,7 @@ class MediaFusionStreamParser extends StreamParser {
   ): string | undefined {
     const indexer = super.getIndexer(stream, currentParsedStream);
     const contributor = stream.description?.match(
-      this.getRegexForTextAfterEmojis(['🧑‍💻'])
+      getRegexForTextAfterEmojis(['🧑‍💻'])
     )?.[1];
     let indexerParts = [];
     if (indexer) {
@@ -117,7 +117,7 @@ class MediaFusionStreamParser extends StreamParser {
     currentParsedStream: ParsedStream
   ): string[] {
     const languages = super.getLanguages(stream, currentParsedStream);
-    const regex = this.getRegexForTextAfterEmojis(['🌐']);
+    const regex = getRegexForTextAfterEmojis(['🌐']);
     const languagesString = stream.description?.match(regex)?.[1];
     if (languagesString) {
       return languages.concat(

--- a/packages/core/src/presets/streamasia.ts
+++ b/packages/core/src/presets/streamasia.ts
@@ -10,7 +10,7 @@ import { baseOptions, Preset } from './preset.js';
 import { createLogger } from '../utils/index.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getRegexForTextAfterEmojis } from '../parser/index.js';
 
 const logger = createLogger('core');
 
@@ -33,12 +33,12 @@ class StreamAsiaStreamParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    const regex = this.getRegexForTextAfterEmojis(['🚫', '⚠']);
+    const regex = getRegexForTextAfterEmojis(['🚫', '⚠']);
     const match = stream.description?.match(regex);
     if (match) {
       return match[1];
     }
-    const proxyRegex = this.getRegexForTextAfterEmojis(['🔗 Proxy:']);
+    const proxyRegex = getRegexForTextAfterEmojis(['🔗 Proxy:']);
     const proxyMatch = stream.description?.match(proxyRegex);
     if (proxyMatch) {
       return proxyMatch[1];

--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -5,7 +5,7 @@ import {
   Stream,
   UserData,
 } from '../db/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getRegexForTextAfterEmojis } from '../parser/index.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { Preset } from './preset.js';
 
@@ -28,7 +28,7 @@ export class StremThruStreamParser extends StreamParser {
   }
 
   protected get filenameRegex(): RegExp | undefined {
-    return this.getRegexForTextAfterEmojis(['📄', '📁']);
+    return getRegexForTextAfterEmojis(['📄', '📁']);
   }
 
   protected override getFolderSize(
@@ -79,6 +79,13 @@ export class StremThruStreamParser extends StreamParser {
       if (subtitleLangs.length > 0) {
         overrides.subtitles = subtitleLangs;
       }
+    }
+
+    const editionText = stream.description
+      ?.match(getRegexForTextAfterEmojis(['🏷️']))?.[1]
+      .trim();
+    if (editionText) {
+      overrides.editions = [editionText];
     }
 
     return overrides;

--- a/packages/core/src/presets/webstreamr.ts
+++ b/packages/core/src/presets/webstreamr.ts
@@ -13,7 +13,11 @@ import { Preset, baseOptions } from './preset.js';
 import { SERVICE_DETAILS } from '../utils/index.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
-import { FileParser, StreamParser } from '../parser/index.js';
+import {
+  FileParser,
+  StreamParser,
+  getRegexForTextAfterEmojis,
+} from '../parser/index.js';
 
 class WebStreamrStreamParser extends StreamParser {
   protected get indexerEmojis(): string[] {
@@ -37,7 +41,7 @@ class WebStreamrStreamParser extends StreamParser {
     currentParsedStream: ParsedStream
   ): ParsedStream['error'] | undefined {
     const indexer = this.getIndexer(stream, currentParsedStream);
-    const errorRegex = this.getRegexForTextAfterEmojis([
+    const errorRegex = getRegexForTextAfterEmojis([
       '❌',
       '⏳',
       '🐢',
@@ -61,7 +65,7 @@ class WebStreamrStreamParser extends StreamParser {
     stream: Stream,
     currentParsedStream: ParsedStream
   ): string | undefined {
-    const messageRegex = this.getRegexForTextAfterEmojis(['⚠️']);
+    const messageRegex = getRegexForTextAfterEmojis(['⚠️']);
     return (
       stream.name?.match(messageRegex)?.[1] ||
       stream.description?.match(messageRegex)?.[1]


### PR DESCRIPTION
getRegexForTextAfterEmojis missed emoji that only render via a variation selector (e.g. ⚙️), silently swallowing whatever followed them into the match. Extracted it into parser/utils.ts, fixed the boundary check, and updated every preset call site; added the first core test suite to cover it.

---

stremthru got the edition field with https://github.com/MunifTanjim/stremthru/pull/582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of text following emoji markers, including variation-selector emojis, line endings and multiple supported emojis.
  - Improved extraction of audio, subtitle, release group, folder, message, proxy and error details from stream information.
  - Edition information following the 🏷️ marker is now correctly captured for file merging.
- **Improvements**
  - More consistent emoji-based metadata detection across supported stream sources.
  - Enhanced handling of end-of-line and end-of-text boundaries during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->