### PR TITLE
fix: resolve cross-provider episode numbering by title

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Public HTTPS URL Nuvio uses to reach this add-on (no trailing slash).
+BASE_URL=https://aiostreams.example.com
+
+# Generate once with: openssl rand -hex 32
+# Do not change it after you have saved an AIOStreams configuration.
+SECRET_KEY=
+
+# Keep this private unless a reverse proxy serves the add-on publicly.
+AIO_BIND_IP=127.0.0.1

--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -1,0 +1,15 @@
+# Local production build of the cross-season resolver fork.
+# Copy .env.example to .env and set BASE_URL plus a persistent SECRET_KEY.
+services:
+  aiostreams:
+    build:
+      context: .
+    image: aiostreams-season-resolver:local
+    container_name: aiostreams-season-resolver
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "${AIO_BIND_IP:-127.0.0.1}:3000:3000"
+    volumes:
+      - ./data:/app/data

--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -71,6 +71,10 @@ export interface SearchMetadata extends TitleMetadata {
   episodeAirDate?: string;
   /** First episode number of the resolved season (>1 means continuous absolute numbering). */
   resolvedSeasonFirstEpisode?: number;
+  /** TVDB-facing season number resolved from the requested TMDB episode title. */
+  resolvedSeasonNumber?: number;
+  /** TVDB-facing episode number resolved from the requested TMDB episode title. */
+  resolvedEpisodeNumber?: number;
   /** Scene-mapping search titles, best (non-identity) first. */
   sceneTitles?: string[];
   titleConflicts?: TitleConflict[];
@@ -826,6 +830,8 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       isDateBased: metadata.isDateBased,
       airDates: metadata.episodeAirDates,
       episodeAirDate: metadata.episodeAirDate,
+      resolvedSeasonNumber: metadata.resolvedSeasonNumber,
+      resolvedEpisodeNumber: metadata.resolvedEpisodeNumber,
       resolvedSeasonFirstEpisode: metadata.resolvedSeasonFirstEpisode,
       sceneTitles: metadata.sceneTitles,
       country: metadata.country,

--- a/packages/core/src/builtins/base/nab/addon.ts
+++ b/packages/core/src/builtins/base/nab/addon.ts
@@ -89,6 +89,14 @@ export abstract class BaseNabAddon<
     meta: SearchResultMetadata;
   }> {
     const forceIncludeSeasonEpInParams = ['StremThru'];
+    // Metadata can reconcile TMDB and TVDB season partitions by episode title.
+    // Use those source-facing numbers consistently for both native S/E params
+    // and fallback text queries, while preserving the original id elsewhere.
+    const effectiveParsedId: ParsedId = {
+      ...parsedId,
+      season: metadata.resolvedSeasonNumber?.toString() ?? parsedId.season,
+      episode: metadata.resolvedEpisodeNumber?.toString() ?? parsedId.episode,
+    };
     const start = Date.now();
     const queryParams: Record<string, string> = {};
     const queryLimit = createQueryLimit();
@@ -154,18 +162,18 @@ export abstract class BaseNabAddon<
         forceIncludeSeasonEpInParams.includes(
           capabilities.server.title || ''
         )) &&
-      parsedId.season
+      effectiveParsedId.season
     )
-      queryParams.season = parsedId.season.toString();
+      queryParams.season = effectiveParsedId.season.toString();
     if (
       ((!this.userData.forceQuerySearch &&
         searchCapabilities.supportedParams.includes('ep')) ||
         forceIncludeSeasonEpInParams.includes(
           capabilities.server.title || ''
         )) &&
-      parsedId.episode
+      effectiveParsedId.episode
     )
-      queryParams.ep = parsedId.episode.toString();
+      queryParams.ep = effectiveParsedId.episode.toString();
     if (
       !this.userData.forceQuerySearch &&
       searchCapabilities.supportedParams.includes('year') &&
@@ -226,7 +234,7 @@ export abstract class BaseNabAddon<
       searchCapabilities.supportedParams.includes('q') &&
       metadata.primaryTitle
     ) {
-      queries = this.buildQueries(parsedId, metadata, {
+      queries = this.buildQueries(effectiveParsedId, metadata, {
         // add year if it is not already in the query params
         addYear: !queryParams.year,
         // add season and episode if they are not already in the query params

--- a/packages/core/src/metadata/episode-resolver.test.ts
+++ b/packages/core/src/metadata/episode-resolver.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveEpisodeFacts } from './episode-resolver.js';
+
+test('maps a TMDB episode title to its differently-numbered TVDB episode', async () => {
+  const episodes = new Map([
+    [11, [{ number: 5, aired: '2024-01-01', name: 'A Different Episode' }]],
+    [14, [{ number: 5, aired: '2024-01-01', name: "Related to Items You've Viewed" }]],
+  ]);
+
+  const resolution = await resolveEpisodeFacts({
+    season: 11,
+    episode: 5,
+    isAnime: false,
+    seasons: [
+      { season_number: 11, episode_count: 10 },
+      { season_number: 14, episode_count: 10 },
+    ],
+    fetchTmdbEpisode: async () => ({
+      airDate: '2024-01-01',
+      titles: [{ title: 'Related to Items Youve Viewed!' }],
+    }),
+    fetchTvdbSeasonEpisodes: async (season) => episodes.get(season),
+    config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
+  });
+
+  assert.equal(resolution.resolvedSeasonNumber, 14);
+  assert.equal(resolution.resolvedEpisodeNumber, 5);
+});
+
+test('does not remap when the direct TVDB episode title already agrees', async () => {
+  const resolution = await resolveEpisodeFacts({
+    season: 11,
+    episode: 5,
+    isAnime: false,
+    seasons: [
+      { season_number: 11, episode_count: 10 },
+      { season_number: 14, episode_count: 10 },
+    ],
+    fetchTmdbEpisode: async () => ({ titles: [{ title: 'The Correct Episode' }] }),
+    fetchTvdbSeasonEpisodes: async (season) => [
+      {
+        number: 5,
+        aired: '2024-01-01',
+        name: season === 11 ? 'The Correct Episode' : 'A Different Episode',
+      },
+    ],
+    config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
+  });
+
+  assert.equal(resolution.resolvedSeasonNumber, 11);
+  assert.equal(resolution.resolvedEpisodeNumber, undefined);
+});

--- a/packages/core/src/metadata/episode-resolver.test.ts
+++ b/packages/core/src/metadata/episode-resolver.test.ts
@@ -14,7 +14,6 @@ test('maps a TMDB episode title to its differently-numbered TVDB episode', async
     isAnime: false,
     seasons: [
       { season_number: 11, episode_count: 10 },
-      { season_number: 14, episode_count: 10 },
     ],
     fetchTmdbEpisode: async () => ({
       airDate: '2024-01-01',

--- a/packages/core/src/metadata/episode-resolver.test.ts
+++ b/packages/core/src/metadata/episode-resolver.test.ts
@@ -5,16 +5,23 @@ import { resolveEpisodeFacts } from './episode-resolver.js';
 test('maps a TMDB episode title to its differently-numbered TVDB episode', async () => {
   const episodes = new Map([
     [11, [{ number: 5, aired: '2024-01-01', name: 'A Different Episode' }]],
-    [14, [{ number: 5, aired: '2024-01-01', name: "Related to Items You've Viewed" }]],
+    [
+      14,
+      [
+        {
+          number: 5,
+          aired: '2024-01-01',
+          name: "Related to Items You've Viewed",
+        },
+      ],
+    ],
   ]);
 
   const resolution = await resolveEpisodeFacts({
     season: 11,
     episode: 5,
     isAnime: false,
-    seasons: [
-      { season_number: 11, episode_count: 10 },
-    ],
+    seasons: [{ season_number: 11, episode_count: 10 }],
     fetchTmdbEpisode: async () => ({
       airDate: '2024-01-01',
       titles: [{ title: 'Related to Items Youve Viewed!' }],
@@ -36,7 +43,9 @@ test('does not remap when the direct TVDB episode title already agrees', async (
       { season_number: 11, episode_count: 10 },
       { season_number: 14, episode_count: 10 },
     ],
-    fetchTmdbEpisode: async () => ({ titles: [{ title: 'The Correct Episode' }] }),
+    fetchTmdbEpisode: async () => ({
+      titles: [{ title: 'The Correct Episode' }],
+    }),
     fetchTvdbSeasonEpisodes: async (season) => [
       {
         number: 5,
@@ -44,6 +53,90 @@ test('does not remap when the direct TVDB episode title already agrees', async (
         name: season === 11 ? 'The Correct Episode' : 'A Different Episode',
       },
     ],
+    config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
+  });
+
+  assert.equal(resolution.resolvedSeasonNumber, 11);
+  assert.equal(resolution.resolvedEpisodeNumber, undefined);
+});
+
+test('maps a regular TMDB episode to a TVDB Season 0 special by title', async () => {
+  const resolution = await resolveEpisodeFacts({
+    season: 2,
+    episode: 1,
+    isAnime: false,
+    seasons: [{ season_number: 2, episode_count: 10 }],
+    fetchTmdbEpisode: async () => ({
+      airDate: '2024-02-01',
+      titles: [{ title: 'The Lost Special' }],
+    }),
+    fetchTvdbSeasonEpisodes: async (season) => {
+      if (season === 2) {
+        return [{ number: 1, aired: '2024-02-01', name: 'Different Episode' }];
+      }
+      if (season === 0) {
+        return [{ number: 7, aired: '2024-02-01', name: 'The Lost Special' }];
+      }
+      return undefined;
+    },
+    config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
+  });
+
+  assert.equal(resolution.resolvedSeasonNumber, 0);
+  assert.equal(resolution.resolvedEpisodeNumber, 7);
+});
+
+test('disambiguates duplicate TVDB episode titles using the TMDB air date', async () => {
+  const resolution = await resolveEpisodeFacts({
+    season: 11,
+    episode: 5,
+    isAnime: false,
+    seasons: [
+      { season_number: 11, episode_count: 10 },
+      { season_number: 14, episode_count: 10 },
+    ],
+    fetchTmdbEpisode: async () => ({
+      airDate: '2024-03-14',
+      titles: [{ title: 'Same Title' }],
+    }),
+    fetchTvdbSeasonEpisodes: async (season) => {
+      if (season === 11) {
+        return [{ number: 5, aired: '2024-01-01', name: 'Different Episode' }];
+      }
+      if (season === 12) {
+        return [{ number: 3, aired: '2024-01-01', name: 'Same Title' }];
+      }
+      if (season === 14) {
+        return [{ number: 8, aired: '2024-03-14', name: 'Same Title' }];
+      }
+      return undefined;
+    },
+    config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
+  });
+
+  assert.equal(resolution.resolvedSeasonNumber, 14);
+  assert.equal(resolution.resolvedEpisodeNumber, 8);
+});
+
+test('preserves source numbering when duplicate title matches remain ambiguous', async () => {
+  const resolution = await resolveEpisodeFacts({
+    season: 11,
+    episode: 5,
+    isAnime: false,
+    seasons: [{ season_number: 11, episode_count: 10 }],
+    fetchTmdbEpisode: async () => ({
+      airDate: '2024-03-14',
+      titles: [{ title: 'Same Title' }],
+    }),
+    fetchTvdbSeasonEpisodes: async (season) => {
+      if (season === 11) {
+        return [{ number: 5, aired: '2024-01-01', name: 'Different Episode' }];
+      }
+      if (season === 12 || season === 14) {
+        return [{ number: 3, aired: '2024-03-14', name: 'Same Title' }];
+      }
+      return undefined;
+    },
     config: { enabled: true, episodeCountThreshold: 100, minSeasons: 3 },
   });
 

--- a/packages/core/src/metadata/episode-resolver.ts
+++ b/packages/core/src/metadata/episode-resolver.ts
@@ -33,12 +33,19 @@ export interface EpisodeResolverInput {
   /** Returns the episodes of a TVDB season (default order), or undefined when unavailable. */
   fetchTvdbSeasonEpisodes?: (
     seasonNumber: number
-  ) => Promise<{ number: number; aired: string | null }[] | undefined>;
+  ) => Promise<
+    | {
+        number: number;
+        aired: string | null;
+        name?: string;
+      }[]
+    | undefined
+  >;
   /** Returns TMDB episode details, undefined on 404/unavailable. */
   fetchTmdbEpisode?: (
     seasonNumber: number,
     episodeNumber: number
-  ) => Promise<{ airDate?: string } | undefined>;
+  ) => Promise<{ airDate?: string; titles?: { title: string }[] } | undefined>;
   config: {
     enabled: boolean;
     episodeCountThreshold: number;
@@ -50,6 +57,8 @@ export interface EpisodeResolution {
   isDateBased: boolean;
   episodeAirDates?: string[];
   resolvedSeasonNumber?: number;
+  /** Episode number in the resolved season when title matching changes schemes. */
+  resolvedEpisodeNumber?: number;
   resolvedSeasonFirstEpisode?: number;
 }
 
@@ -131,6 +140,51 @@ export async function resolveEpisodeFacts(
     resolvedSeasonFirstEpisode,
   };
 
+  // TMDB and TVDB can use different season partitions (for example, a
+  // streaming revival may be one TMDB season but several TVDB seasons). A
+  // direct S/E lookup is deliberately retained when the titles agree. Only
+  // when they disagree do we scan the available TVDB seasons for TMDB's title.
+  // This makes the resolved numbers safe to use for provider queries without
+  // changing normally-numbered series.
+  if (
+    !input.isAnime &&
+    input.fetchTmdbEpisode &&
+    input.fetchTvdbSeasonEpisodes &&
+    nonSpecialSeasons.length
+  ) {
+    try {
+      const tmdbEpisode = await input.fetchTmdbEpisode(season, episode);
+      const tmdbTitles = new Set(
+        (tmdbEpisode?.titles ?? [])
+          .map((item) => normaliseEpisodeTitle(item.title))
+          .filter(Boolean)
+      );
+      if (tmdbTitles.size) {
+        const directEpisodes = await input.fetchTvdbSeasonEpisodes(season);
+        const directEpisode = directEpisodes?.find((item) => item.number === episode);
+        const directMatches = directEpisode?.name
+          ? tmdbTitles.has(normaliseEpisodeTitle(directEpisode.name))
+          : false;
+        if (!directMatches) {
+          for (const candidateSeason of nonSpecialSeasons) {
+            const episodes = await input.fetchTvdbSeasonEpisodes(candidateSeason.season_number);
+            const match = episodes?.find(
+              (item) => item.name && tmdbTitles.has(normaliseEpisodeTitle(item.name))
+            );
+            if (match) {
+              resolution.resolvedSeasonNumber = candidateSeason.season_number;
+              resolution.resolvedEpisodeNumber = match.number;
+              break;
+            }
+          }
+        }
+      }
+    } catch {
+      // Number-based and date-based resolution remains available if either
+      // metadata provider is temporarily unavailable.
+    }
+  }
+
   if (!isDateBased) {
     return resolution;
   }
@@ -187,4 +241,14 @@ export async function resolveEpisodeFacts(
     resolution.episodeAirDates = [airDate];
   }
   return resolution;
+}
+
+function normaliseEpisodeTitle(title: string): string {
+  return String(title)
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\u0027\u2018\u2019]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
 }

--- a/packages/core/src/metadata/episode-resolver.ts
+++ b/packages/core/src/metadata/episode-resolver.ts
@@ -146,12 +146,11 @@ export async function resolveEpisodeFacts(
   // when they disagree do we scan the available TVDB seasons for TMDB's title.
   // This makes the resolved numbers safe to use for provider queries without
   // changing normally-numbered series.
-  if (
-    !input.isAnime &&
-    input.fetchTmdbEpisode &&
-    input.fetchTvdbSeasonEpisodes &&
-    nonSpecialSeasons.length
-  ) {
+  // A source's season list can use the same partitioning as the request
+  // (TMDB), so do not use it as the upper bound for a TVDB title lookup.
+  // The conventional TVDB range keeps this rare fallback bounded while
+  // allowing a shorter TMDB list to resolve a later TVDB season.
+  if (!input.isAnime && input.fetchTmdbEpisode && input.fetchTvdbSeasonEpisodes) {
     try {
       const tmdbEpisode = await input.fetchTmdbEpisode(season, episode);
       const tmdbTitles = new Set(
@@ -166,13 +165,19 @@ export async function resolveEpisodeFacts(
           ? tmdbTitles.has(normaliseEpisodeTitle(directEpisode.name))
           : false;
         if (!directMatches) {
-          for (const candidateSeason of nonSpecialSeasons) {
-            const episodes = await input.fetchTvdbSeasonEpisodes(candidateSeason.season_number);
+          const candidateSeasonNumbers = [
+            ...new Set([
+              ...nonSpecialSeasons.map((item) => item.season_number),
+              ...Array.from({ length: 40 }, (_, index) => index + 1),
+            ]),
+          ];
+          for (const candidateSeasonNumber of candidateSeasonNumbers) {
+            const episodes = await input.fetchTvdbSeasonEpisodes(candidateSeasonNumber);
             const match = episodes?.find(
               (item) => item.name && tmdbTitles.has(normaliseEpisodeTitle(item.name))
             );
             if (match) {
-              resolution.resolvedSeasonNumber = candidateSeason.season_number;
+              resolution.resolvedSeasonNumber = candidateSeasonNumber;
               resolution.resolvedEpisodeNumber = match.number;
               break;
             }

--- a/packages/core/src/metadata/episode-resolver.ts
+++ b/packages/core/src/metadata/episode-resolver.ts
@@ -31,9 +31,7 @@ export interface EpisodeResolverInput {
   seasons?: SeasonRecord[];
   cinemetaVideos?: CinemetaVideo[];
   /** Returns the episodes of a TVDB season (default order), or undefined when unavailable. */
-  fetchTvdbSeasonEpisodes?: (
-    seasonNumber: number
-  ) => Promise<
+  fetchTvdbSeasonEpisodes?: (seasonNumber: number) => Promise<
     | {
         number: number;
         aired: string | null;
@@ -60,6 +58,12 @@ export interface EpisodeResolution {
   /** Episode number in the resolved season when title matching changes schemes. */
   resolvedEpisodeNumber?: number;
   resolvedSeasonFirstEpisode?: number;
+}
+
+interface EpisodeTitleMatch {
+  seasonNumber: number;
+  episodeNumber: number;
+  aired?: string | null;
 }
 
 /**
@@ -150,7 +154,11 @@ export async function resolveEpisodeFacts(
   // (TMDB), so do not use it as the upper bound for a TVDB title lookup.
   // The conventional TVDB range keeps this rare fallback bounded while
   // allowing a shorter TMDB list to resolve a later TVDB season.
-  if (!input.isAnime && input.fetchTmdbEpisode && input.fetchTvdbSeasonEpisodes) {
+  if (
+    !input.isAnime &&
+    input.fetchTmdbEpisode &&
+    input.fetchTvdbSeasonEpisodes
+  ) {
     try {
       const tmdbEpisode = await input.fetchTmdbEpisode(season, episode);
       const tmdbTitles = new Set(
@@ -160,27 +168,61 @@ export async function resolveEpisodeFacts(
       );
       if (tmdbTitles.size) {
         const directEpisodes = await input.fetchTvdbSeasonEpisodes(season);
-        const directEpisode = directEpisodes?.find((item) => item.number === episode);
+        const directEpisode = directEpisodes?.find(
+          (item) => item.number === episode
+        );
         const directMatches = directEpisode?.name
           ? tmdbTitles.has(normaliseEpisodeTitle(directEpisode.name))
           : false;
         if (!directMatches) {
           const candidateSeasonNumbers = [
             ...new Set([
+              // TVDB occasionally classifies an episode from a regular TMDB
+              // season as a special. Include Season 0 in the title fallback.
+              0,
               ...nonSpecialSeasons.map((item) => item.season_number),
               ...Array.from({ length: 40 }, (_, index) => index + 1),
             ]),
           ];
+          const titleMatches = new Map<string, EpisodeTitleMatch>();
           for (const candidateSeasonNumber of candidateSeasonNumbers) {
-            const episodes = await input.fetchTvdbSeasonEpisodes(candidateSeasonNumber);
-            const match = episodes?.find(
-              (item) => item.name && tmdbTitles.has(normaliseEpisodeTitle(item.name))
+            const episodes = await input.fetchTvdbSeasonEpisodes(
+              candidateSeasonNumber
             );
-            if (match) {
-              resolution.resolvedSeasonNumber = candidateSeasonNumber;
-              resolution.resolvedEpisodeNumber = match.number;
-              break;
+            for (const candidate of episodes ?? []) {
+              if (
+                candidate.name &&
+                tmdbTitles.has(normaliseEpisodeTitle(candidate.name))
+              ) {
+                const match: EpisodeTitleMatch = {
+                  seasonNumber: candidateSeasonNumber,
+                  episodeNumber: candidate.number,
+                  aired: candidate.aired,
+                };
+                titleMatches.set(
+                  `${match.seasonNumber}:${match.episodeNumber}`,
+                  match
+                );
+              }
             }
+          }
+
+          const matches = [...titleMatches.values()];
+          const tmdbAirDate = tmdbEpisode?.airDate;
+          const dateMatches = tmdbAirDate
+            ? matches.filter((match) =>
+                sameCalendarDate(match.aired, tmdbAirDate)
+              )
+            : [];
+          const resolvedMatch =
+            matches.length === 1
+              ? matches[0]
+              : dateMatches.length === 1
+                ? dateMatches[0]
+                : undefined;
+          if (resolvedMatch) {
+            resolution.resolvedSeasonNumber = resolvedMatch.seasonNumber;
+            resolution.resolvedEpisodeNumber = resolvedMatch.episodeNumber;
           }
         }
       }
@@ -256,4 +298,11 @@ function normaliseEpisodeTitle(title: string): string {
     .replace(/[\u0027\u2018\u2019]/g, '')
     .replace(/[^a-z0-9]+/g, ' ')
     .trim();
+}
+
+function sameCalendarDate(
+  firstAired: string | null | undefined,
+  tmdbAirDate: string
+): boolean {
+  return !!firstAired && firstAired.slice(0, 10) === tmdbAirDate.slice(0, 10);
 }

--- a/packages/core/src/metadata/service.test.ts
+++ b/packages/core/src/metadata/service.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getProviderEpisodeNumbers } from './service.js';
+
+test('uses remapped season and episode numbers for downstream provider lookups', () => {
+  assert.deepEqual(
+    getProviderEpisodeNumbers(11, 5, {
+      resolvedSeasonNumber: 14,
+      resolvedEpisodeNumber: 8,
+    }),
+    { seasonNumber: 14, episodeNumber: 8 }
+  );
+});
+
+test('keeps the requested numbering when no provider remap is available', () => {
+  assert.deepEqual(getProviderEpisodeNumbers(11, 5), {
+    seasonNumber: 11,
+    episodeNumber: 5,
+  });
+});

--- a/packages/core/src/metadata/service.ts
+++ b/packages/core/src/metadata/service.ts
@@ -611,6 +611,10 @@ export class MetadataService {
             let episodeYear: number | undefined;
             let seasonYear: number | undefined;
             if (type === 'series' && id.season && id.episode) {
+              // Cinemeta describes the request as it was originally made.
+              // Its videos must not be queried using TVDB-facing remaps.
+              const cinemetaSeason = Number(id.season);
+              const cinemetaEpisode = Number(id.episode);
               const { seasonNumber, episodeNumber } = getProviderEpisodeNumbers(
                 id.season,
                 id.episode,
@@ -697,7 +701,7 @@ export class MetadataService {
               }
               if (!seasonYear && cinemetaVideos?.length) {
                 for (const video of cinemetaVideos) {
-                  if (video.season !== seasonNumber || !video.released)
+                  if (video.season !== cinemetaSeason || !video.released)
                     continue;
                   const year = yearOf(video.released);
                   if (year && (seasonYear === undefined || year < seasonYear)) {
@@ -713,7 +717,7 @@ export class MetadataService {
               // request was made in says they mean.
               const cinemetaReleased = cinemetaVideos?.find(
                 (v) =>
-                  v.season === Number(id.season) && v.episode === episodeNumber
+                  v.season === cinemetaSeason && v.episode === cinemetaEpisode
               )?.released;
               const referenceAirDate =
                 // the request's own provider is authoritative

--- a/packages/core/src/metadata/service.ts
+++ b/packages/core/src/metadata/service.ts
@@ -817,6 +817,7 @@ export class MetadataService {
               episodeAirDates: episodeFacts?.episodeAirDates,
               episodeAirDate: episodeFacts?.episodeAirDates?.[0],
               resolvedSeasonNumber: episodeFacts?.resolvedSeasonNumber,
+              resolvedEpisodeNumber: episodeFacts?.resolvedEpisodeNumber,
               resolvedSeasonFirstEpisode:
                 episodeFacts?.resolvedSeasonFirstEpisode,
               sceneTitles,

--- a/packages/core/src/metadata/service.ts
+++ b/packages/core/src/metadata/service.ts
@@ -45,6 +45,24 @@ export interface MetadataServiceConfig {
   tvdbApiKey?: string;
 }
 
+/**
+ * TVDB and Skyhook use the resolved provider-facing numbering when a title
+ * match has reconciled different TMDB and TVDB season partitions.
+ */
+export function getProviderEpisodeNumbers(
+  season: string | number,
+  episode: string | number,
+  episodeFacts?: Pick<
+    EpisodeResolution,
+    'resolvedSeasonNumber' | 'resolvedEpisodeNumber'
+  >
+): { seasonNumber: number; episodeNumber: number } {
+  return {
+    seasonNumber: episodeFacts?.resolvedSeasonNumber ?? Number(season),
+    episodeNumber: episodeFacts?.resolvedEpisodeNumber ?? Number(episode),
+  };
+}
+
 export class MetadataService {
   private readonly lock: DistributedLock;
   private readonly config: MetadataServiceConfig;
@@ -593,9 +611,11 @@ export class MetadataService {
             let episodeYear: number | undefined;
             let seasonYear: number | undefined;
             if (type === 'series' && id.season && id.episode) {
-              const seasonNumber =
-                episodeFacts?.resolvedSeasonNumber ?? Number(id.season);
-              const episodeNumber = Number(id.episode);
+              const { seasonNumber, episodeNumber } = getProviderEpisodeNumbers(
+                id.season,
+                id.episode,
+                episodeFacts
+              );
               const yearOf = (date?: string | null) => {
                 if (!date) return undefined;
                 const year = new Date(date).getFullYear();

--- a/packages/core/src/metadata/utils.ts
+++ b/packages/core/src/metadata/utils.ts
@@ -108,6 +108,8 @@ export interface Metadata {
   episodeAirDate?: string;
   /** Season number the requested season resolved to (differs from the request under ordinal fallback). */
   resolvedSeasonNumber?: number;
+  /** Episode number in resolvedSeasonNumber when cross-provider title matching succeeds. */
+  resolvedEpisodeNumber?: number;
   /** First episode number of the resolved season (>1 means continuous absolute numbering). */
   resolvedSeasonFirstEpisode?: number;
   /** Scene-mapping search titles for this series, best (non-identity) first. */


### PR DESCRIPTION
Resolves episode requests whose source metadata uses a different season number than the provider.\n\nThe resolver now verifies the direct TVDB episode title, then searches TVDB seasons by normalized title when it differs. The resolved season and episode numbers are used for Bitmagnet Torznab/Newznab lookups.\n\nThis covers cases such as Futurama, where TMDB numbering and provider numbering diverge.\n\nTests added for direct matches, mismatches, special seasons, and a target season beyond the source metadata season list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local Docker Compose support with configurable networking and persistent data.
  * Added configuration guidance for the public URL, secret key, and bind address.
  * Improved episode matching across metadata providers when season and episode numbering differs.

* **Bug Fixes**
  * Search requests now use corrected season and episode details.
  * Improved handling of TV specials and ambiguous episode matches using air dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->