### PR TITLE
feat(core): parse Torz's probed codec/HDR/audio/bitrate data

### DIFF
--- a/packages/core/src/parser/file.ts
+++ b/packages/core/src/parser/file.ts
@@ -4,7 +4,7 @@ import { parseTorrentTitleCached } from './title.js';
 import { RESOLUTIONS } from '../utils/constants.js';
 import { mapLanguageCode, convertLangCodeToName } from '../utils/languages.js';
 
-function matchPattern(
+export function matchPattern(
   filename: string,
   patterns: Record<string, RegExp>
 ): string | undefined {
@@ -48,7 +48,7 @@ function normaliseResolution(
   return undefined;
 }
 
-function matchMultiplePatterns(
+export function matchMultiplePatterns(
   filename: string,
   patterns: Record<string, RegExp>
 ): string[] {

--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -10,6 +10,8 @@ import {
   getLanguagesAfterMarker,
   getRegexForTextAfterEmojis,
 } from '../parser/index.js';
+import { matchPattern, matchMultiplePatterns } from '../parser/file.js';
+import { PARSE_REGEX } from '../parser/regex.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { Preset } from './preset.js';
 
@@ -50,6 +52,28 @@ export class StremThruStreamParser extends StreamParser {
     return ['🔍'];
   }
 
+  private getProbedBitrate(stream: Stream): number | undefined {
+    const match = stream.description?.match(
+      /〽️\s*([\d.]+)\s*(B|KB|MB)\/s/i
+    );
+    if (!match) return undefined;
+    const value = parseFloat(match[1]);
+    const unit = match[2].toUpperCase();
+    const bytesPerSecond =
+      unit === 'MB' ? value * 1_000_000 : unit === 'KB' ? value * 1_000 : value;
+    return Math.round(bytesPerSecond * 8);
+  }
+
+  protected override getBitrate(
+    stream: Stream,
+    currentParsedStream: ParsedStream
+  ): number | undefined {
+    return (
+      this.getProbedBitrate(stream) ??
+      super.getBitrate(stream, currentParsedStream)
+    );
+  }
+
   // 🎙️/💬 are handled in getParsedFileMergeOverrides. 🌐 is ambiguous (probe
   // vs. filename guess), so fall back to the generic scan for it.
   protected override getLanguages(
@@ -60,6 +84,8 @@ export class StremThruStreamParser extends StreamParser {
     return super.getLanguages(stream, currentParsedStream);
   }
 
+  // Emoji layout mirrors StremThru's own rendering, see:
+  // https://github.com/MunifTanjim/stremthru/blob/0.103.2/internal/stremio/transformer/stream_template_default.go
   protected getParsedFileMergeOverrides(
     stream: Stream,
     currentParsedStream: ParsedStream
@@ -75,6 +101,39 @@ export class StremThruStreamParser extends StreamParser {
     const subtitleLangs = getLanguagesAfterMarker(stream.description, '💬');
     if (subtitleLangs && subtitleLangs.length > 0) {
       overrides.subtitles = subtitleLangs;
+      overrides.mediaInfoQuality = 'probe';
+    }
+
+    const codecText = stream.description?.match(
+      getRegexForTextAfterEmojis(['🎞️'])
+    )?.[1];
+    if (codecText) {
+      const encode = matchPattern(codecText, PARSE_REGEX.encodes);
+      if (encode) overrides.encode = encode;
+    }
+
+    const hdrText = stream.description?.match(
+      getRegexForTextAfterEmojis(['📺'])
+    )?.[1];
+    if (hdrText) {
+      const visualTags = matchMultiplePatterns(hdrText, PARSE_REGEX.visualTags);
+      if (visualTags.length > 0) overrides.visualTags = visualTags;
+    }
+
+    const audioLine = stream.description?.match(
+      getRegexForTextAfterEmojis(['🎧'])
+    )?.[1];
+    if (audioLine) {
+      const audioTags = matchMultiplePatterns(audioLine, PARSE_REGEX.audioTags);
+      if (audioTags.length > 0) overrides.audioTags = audioTags;
+      const audioChannels = matchMultiplePatterns(
+        audioLine.replace(/\bstereo\b/gi, '2.0'),
+        PARSE_REGEX.audioChannels
+      );
+      if (audioChannels.length > 0) overrides.audioChannels = audioChannels;
+    }
+
+    if (this.getProbedBitrate(stream) !== undefined) {
       overrides.mediaInfoQuality = 'probe';
     }
 


### PR DESCRIPTION
Extracts Codec, HDR, audio tags/channels, and BitRate from StremThru Torz descriptions, reusing the existing filename regex patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved StremThru media information detection.
  * Bitrate values are now recognised and converted accurately.
  * More metadata is extracted from descriptions, including video codec, HDR format, audio tags, audio channels, audio language and subtitles.
  * Media details are identified as probe-quality when relevant technical metadata is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->