### PR TITLE
fix(core): stop stremthru treating subtitle flags as audio languages

### DIFF
--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -1,2 +1,3 @@
 export { default as FileParser } from './file.js';
 export { default as StreamParser } from './streams.js';
+export { getLanguagesAfterMarker } from './utils.js';

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -13,6 +13,7 @@ import {
   parseAgeString,
   parseDuration,
   extractInfoHashFromMagnet,
+  convertFlagToLanguage,
 } from './utils.js';
 import {
   mergeParsedFiles,
@@ -622,24 +623,9 @@ class StreamParser {
       ...(descriptionMatches ? [...new Set(descriptionMatches)] : []),
       ...(nameMatches ? [...new Set(nameMatches)] : []),
     ];
-    const languages = flags
-      .map((flag) => this.convertFlagToLanguage(flag))
+    return flags
+      .map((flag) => convertFlagToLanguage(flag))
       .filter((language) => language !== undefined);
-    return languages;
-  }
-
-  protected convertFlagToLanguage(flag: string): string | undefined {
-    const possibleLanguages = FULL_LANGUAGE_MAPPING.filter(
-      (language) => language.flag === flag
-    );
-
-    const language =
-      possibleLanguages.find((l) => l.flag_priority) || possibleLanguages[0];
-    if (!language) return undefined;
-    const languageName = getLanguageDisplayName(language);
-    return constants.LANGUAGES.includes(languageName as any)
-      ? languageName
-      : undefined;
   }
 
   protected convertISO6392ToLanguage(code: string): string | undefined {

--- a/packages/core/src/parser/utils.test.ts
+++ b/packages/core/src/parser/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { convertFlagToLanguage, getLanguagesAfterMarker } from './utils.js';
+
+describe('convertFlagToLanguage', () => {
+  it('maps a recognized flag to its language', () => {
+    assert.equal(convertFlagToLanguage('🇬🇧'), 'English');
+    assert.equal(convertFlagToLanguage('🇫🇷'), 'French');
+  });
+
+  it('returns undefined for a flag with no mapped language', () => {
+    assert.equal(convertFlagToLanguage('🇦🇶'), undefined);
+  });
+
+  it('returns undefined for non-flag input', () => {
+    assert.equal(convertFlagToLanguage('xx'), undefined);
+  });
+});
+
+describe('getLanguagesAfterMarker', () => {
+  it('returns undefined when the marker is not present', () => {
+    assert.equal(getLanguagesAfterMarker('hello world', '🎙️'), undefined);
+  });
+
+  it('extracts languages for flags after the marker', () => {
+    assert.deepEqual(getLanguagesAfterMarker('🎙️ 🇬🇧 🇫🇷 rest', '🎙️'), [
+      'English',
+      'French',
+    ]);
+  });
+
+  it('handles non-space whitespace between flags', () => {
+    assert.deepEqual(getLanguagesAfterMarker('🎙️ 🇬🇧\t\n🇫🇷 rest', '🎙️'), [
+      'English',
+      'French',
+    ]);
+  });
+
+  it('returns an empty array when the marker is present but no flag maps to a language', () => {
+    assert.deepEqual(getLanguagesAfterMarker('🎙️ 🇦🇶 rest', '🎙️'), []);
+  });
+
+  it('returns undefined for null or undefined text', () => {
+    assert.equal(getLanguagesAfterMarker(null, '🎙️'), undefined);
+    assert.equal(getLanguagesAfterMarker(undefined, '🎙️'), undefined);
+  });
+
+  it('escapes regex metacharacters in the indicator', () => {
+    // unescaped '.' would wrongly match any character as a stand-in marker
+    assert.equal(getLanguagesAfterMarker('x🇬🇧🇫🇷 rest', '.'), undefined);
+    assert.deepEqual(getLanguagesAfterMarker('x.🇩🇪🇮🇹 rest', '.'), [
+      'German',
+      'Italian',
+    ]);
+  });
+});

--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -1,5 +1,10 @@
 import { extract, FuzzballExtractOptions } from 'fuzzball';
-import { createLogger } from '../utils/index.js';
+import {
+  createLogger,
+  constants,
+  FULL_LANGUAGE_MAPPING,
+  getLanguageDisplayName,
+} from '../utils/index.js';
 import { MetadataTitle } from '../metadata/utils.js';
 
 const logger = createLogger('parser');
@@ -323,4 +328,43 @@ export function extractInfoHashFromMagnet(magnet: string): string | undefined {
   if (!match) return undefined;
   if (match.length === 40) return match.toLowerCase();
   return base32ToHex(match);
+}
+
+/** Matches one or more flag emojis (each two regional indicator chars) after an indicator emoji. */
+function getFlagRegex(indicator: string): RegExp {
+  const escapedIndicator = indicator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `${escapedIndicator}\\s*((?:[\\u{1F1E6}-\\u{1F1FF}]{2}\\s*)+)`,
+    'u'
+  );
+}
+
+export function convertFlagToLanguage(flag: string): string | undefined {
+  const possibleLanguages = FULL_LANGUAGE_MAPPING.filter(
+    (language) => language.flag === flag
+  );
+  const language =
+    possibleLanguages.find((l) => l.flag_priority) || possibleLanguages[0];
+  if (!language) return undefined;
+  const languageName = getLanguageDisplayName(language);
+  return constants.LANGUAGES.includes(languageName as any)
+    ? languageName
+    : undefined;
+}
+
+/** Extracts every flag emoji (two regional indicator chars) from text and converts each to a language. */
+function extractLanguagesFromFlags(text: string): string[] {
+  const flags = text.match(/[\u{1F1E6}-\u{1F1FF}]{2}/gu) ?? [];
+  return flags
+    .map(convertFlagToLanguage)
+    .filter((language) => language !== undefined);
+}
+
+/** Extracts languages from flag emojis after a marker emoji, or undefined if the marker isn't present. */
+export function getLanguagesAfterMarker(
+  text: string | null | undefined,
+  indicator: string
+): string[] | undefined {
+  const match = text?.match(getFlagRegex(indicator));
+  return match ? extractLanguagesFromFlags(match[1]) : undefined;
 }

--- a/packages/core/src/presets/meteor.ts
+++ b/packages/core/src/presets/meteor.ts
@@ -10,12 +10,13 @@ import {
 import { baseOptions, Preset } from './preset.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { config as appConfig } from '../config/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getLanguagesAfterMarker } from '../parser/index.js';
 
 class MeteorStreamParser extends StreamParser {
   protected get indexerEmojis(): string[] {
     return ['🔗', '📰'];
   }
+
   protected getInLibrary(
     stream: Stream,
     currentParsedStream: ParsedStream
@@ -44,35 +45,16 @@ class MeteorStreamParser extends StreamParser {
   ): Partial<ParsedFile> {
     const overrides: Partial<ParsedFile> = {};
 
-    // Matches one or more flag emojis (each is two regional indicator chars) after an indicator emoji
-    const getFlagRegex = (indicator: string) =>
-      new RegExp(`${indicator}\\s*((?:[\\u{1F1E6}-\\u{1F1FF}]{2}\\s*)+)`, 'u');
-    const audioRegex = getFlagRegex('🌐');
-    const subtitleRegex = getFlagRegex('💬');
-
-    const audioMatch = stream.description?.match(audioRegex);
-    const subtitleMatch = stream.description?.match(subtitleRegex);
-
-    if (audioMatch) {
-      const audioLangs = audioMatch[1]
-        .split(' ')
-        .map((part) => this.convertFlagToLanguage(part.trim()))
-        .filter((lang) => lang !== undefined) as string[];
-      if (audioLangs.length > 0) {
-        overrides.languages = audioLangs;
-        overrides.mediaInfoQuality = 'addon';
-      }
+    const audioLangs = getLanguagesAfterMarker(stream.description, '🌐');
+    if (audioLangs && audioLangs.length > 0) {
+      overrides.languages = audioLangs;
+      overrides.mediaInfoQuality = 'addon';
     }
 
-    if (subtitleMatch) {
-      const subtitleLangs = subtitleMatch[1]
-        .split(' ')
-        .map((part) => this.convertFlagToLanguage(part.trim()))
-        .filter((lang) => lang !== undefined) as string[];
-      if (subtitleLangs.length > 0) {
-        overrides.subtitles = subtitleLangs;
-        overrides.mediaInfoQuality = 'addon';
-      }
+    const subtitleLangs = getLanguagesAfterMarker(stream.description, '💬');
+    if (subtitleLangs && subtitleLangs.length > 0) {
+      overrides.subtitles = subtitleLangs;
+      overrides.mediaInfoQuality = 'addon';
     }
 
     return overrides;

--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -5,7 +5,7 @@ import {
   Stream,
   UserData,
 } from '../db/index.js';
-import { StreamParser } from '../parser/index.js';
+import { StreamParser, getLanguagesAfterMarker } from '../parser/index.js';
 import { constants, ServiceId } from '../utils/index.js';
 import { Preset } from './preset.js';
 
@@ -46,41 +46,32 @@ export class StremThruStreamParser extends StreamParser {
     return ['🔍'];
   }
 
+  // 🎙️/💬 are handled in getParsedFileMergeOverrides. 🌐 is ambiguous (probe
+  // vs. filename guess), so fall back to the generic scan for it.
+  protected override getLanguages(
+    stream: Stream,
+    currentParsedStream: ParsedStream
+  ): string[] {
+    if (!stream.description?.includes('🌐')) return [];
+    return super.getLanguages(stream, currentParsedStream);
+  }
+
   protected getParsedFileMergeOverrides(
     stream: Stream,
     currentParsedStream: ParsedStream
   ): Partial<ParsedFile> {
     const overrides: Partial<ParsedFile> = {};
 
-    // Matches one or more flag emojis (each is two regional indicator chars) after an indicator emoji
-    const getFlagRegex = (indicator: string) =>
-      new RegExp(`${indicator}\\s*((?:[\\u{1F1E6}-\\u{1F1FF}]{2}\\s*)+)`, 'u');
-    const audioRegex = getFlagRegex('🎙️');
-    const subtitleRegex = getFlagRegex('💬');
-
-    const audioMatch = stream.description?.match(audioRegex);
-    const subtitleMatch = stream.description?.match(subtitleRegex);
-
-    if (audioMatch) {
-      const audioLangs = audioMatch[1]
-        .split(' ')
-        .map((part) => this.convertFlagToLanguage(part.trim()))
-        .filter((lang) => lang !== undefined) as string[];
-      if (audioLangs.length > 0) {
-        overrides.languages = audioLangs;
-        overrides.mediaInfoQuality = 'probe';
-      }
+    const audioLangs = getLanguagesAfterMarker(stream.description, '🎙️');
+    if (audioLangs && audioLangs.length > 0) {
+      overrides.languages = audioLangs;
+      overrides.mediaInfoQuality = 'probe';
     }
 
-    if (subtitleMatch) {
-      const subtitleLangs = subtitleMatch[1]
-        .split(' ')
-        .map((part) => this.convertFlagToLanguage(part.trim()))
-        .filter((lang) => lang !== undefined) as string[];
-      if (subtitleLangs.length > 0) {
-        overrides.subtitles = subtitleLangs;
-        overrides.mediaInfoQuality = 'probe';
-      }
+    const subtitleLangs = getLanguagesAfterMarker(stream.description, '💬');
+    if (subtitleLangs && subtitleLangs.length > 0) {
+      overrides.subtitles = subtitleLangs;
+      overrides.mediaInfoQuality = 'probe';
     }
 
     return overrides;


### PR DESCRIPTION
getLanguages() scans the whole description for any flag emoji, so when there's no audio-line marker (🎙️), it picks up flags from the 💬 subtitle line too. Real example — Torz's first 4K YTS result for tt43657327:

```json
{
  "infoHash": "ace934e989a48837956307b1701b7ee856425def",
  "name": "[P2P]\nTorz\n4k",
  "description": "💿 WEB 🎞️ HEVC\n🎧 AAC | 5.1\n📦 4.4 GB 〽️ 800 KB/s\n💬 🇬🇧 🇸🇦 🇵🇹 🇭🇷 🇨🇿 🇩🇰 🇳🇱 🇪🇸 🇫🇮 🇫🇷 🇩🇪 🇬🇷 🇮🇱 🇭🇺 🇮🇩 🇮🇹 🇯🇵 🇰🇷 🇲🇾 🇵🇱 🇷🇴 🇷🇺 🇨🇳 🇸🇪 🇹🇭 🇹🇷 🇺🇦 🇻🇳\n📄 Big.Chicken.A.Fast.Food.Conspiracy.2026.2160p.4K.WEB.x265.10bit.AAC5.1-[YTS.GG - YTS.BZ].mkv",
  ...
}
```

No 🎙️/🌐 line — StremThru's probe found zero audio tracks, so it correctly omits the line. AIOStreams then fell back to scanning the whole description and misread the 28 subtitle flags as spoken languages.

getLanguages() now returns `[]` unless 🌐 is present. 🌐 is ambiguous (StremThru also uses it for an unprobed filename guess), so only then does it fall back to the generic scan. 🎙️/💬 extraction is unchanged.

Flag extraction is consolidated into a single getLanguagesAfterMarker() helper (fixes indicator escaping and non-space whitespace between flags along the way), with tests. Verified against 1,585 real Torz + 227 real Meteor results across 5 titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language detection from flag emojis in stream descriptions.
  * Added support for identifying multiple audio and subtitle languages following their respective markers.
  * Standardised language names and handled unsupported flags gracefully.

* **Bug Fixes**
  * Improved handling of missing markers, whitespace, null content and special characters during language detection.

* **Tests**
  * Added coverage for recognised, unknown and unmapped flags, multiple languages and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->