### PR TITLE
feat(core): show editions in gdrive formatter

### DIFF
--- a/packages/core/src/utils/formatter-definitions.ts
+++ b/packages/core/src/utils/formatter-definitions.ts
@@ -24,7 +24,7 @@ Languages: {?{stream.languages::join(', ')}?}{stream.subtitles::exists::and::str
   },
   gdrive: {
     name: `{stream.proxied["🕵️ "||""]}{stream.private["🔑 "||""]}{stream.type::=p2p["[P2P] "||""]}{?[{service.shortName}?}{service.cached["⚡] "||"⏳] "]}{addon.name}{stream.library[" (Your Media)"||""]} {?{stream.resolution}?}{stream.seadexBest[" (Best)"||""]}{stream.seadex::and::stream.seadexBest::isfalse[" (SeaDex Alt.)"||""]}{stream.rseMatched::exists::and::stream.seadex::isfalse::and::stream.rseMatched::string::~T1::or::stream.rseMatched::string::~T2::or::stream.rseMatched::string::~T3::or::stream.rseMatched::string::~T4::or::stream.rseMatched::string::~T5::or::stream.rseMatched::string::~T6::or::stream.rseMatched::string::~T7::or::stream.rseMatched::string::~T8[" ({stream.rseMatched::first})"||""]}{stream.regexMatched::exists::and::stream.rseMatched::exists::isfalse::and::stream.seadex::isfalse[" ({stream.regexMatched})"||""]}`,
-    description: `{?🎥 {stream.quality} ?}{?🎞️ {stream.encode} ?}{?🏷️ {stream.releaseGroup} ?}{?📡 {stream.network} ?}
+    description: `{?🎥 {stream.quality} ?}{?🎞️ {stream.encode} ?}{?🏷️ {stream.releaseGroup} ?}{?📡 {stream.network} ?}{stream.editions::exists["🏆 {stream.editions::join(' | ')} "||""]}
 {?📺 {stream.visualTags::join(' | ')} ?}{?🎧 {stream.audioTags::join(' | ')} ?}{?🔊 {stream.audioChannels::join(' | ')}?}
 {stream.size::>0["📦 {stream.size::sbytes} "||""]}{stream.folderSize::>0["/ {stream.folderSize::sbytes} "||""]}{stream.bitrate::>0["({stream.bitrate::sbitrate})"||""]}{stream.duration::>0["⏱️ {stream.duration::time} "||""]}{stream.seeders::>0["👥 {stream.seeders} "||""]}{?📅 {stream.age} ?}{?🔍 {stream.indexer}?}
 {?🌎 {stream.languages::join(' | ')}?}{?📝 {stream.subtitles::join(' | ')}?}


### PR DESCRIPTION
Same placement as lightgdrive/prism: appended to the end of the technical-specs line, next to quality/encode/releaseGroup/network.

🎥 BluRay REMUX 🎞️ x265 🏷️ FraMeSToR 🏆 Director's Cut
📺 HDR10 | DV 🎧 DTS-HD MA 🔊 5.1
📦 73 GB (58 Mbps)⏱️ 2h:5m:0s 👥 12 📅 5 🔍 TheRARBG
🌎 English📝 English | French
📁 Inception.2010.REMUX.2160p.x265-FraMeSToR.mkv

missed in https://github.com/Viren070/AIOStreams/pull/1214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The Google Drive formatter description now displays available stream editions more clearly.
  * Stream editions are shown with a trophy icon and separated by vertical bars for easier scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->