### PR TITLE
fix: recognize Torrin TRN short name

### DIFF
--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -897,7 +897,7 @@ const SERVICE_DETAILS: Record<
     id: TORRIN_SERVICE,
     name: 'Torrin',
     shortName: 'TR',
-    knownNames: ['TR', 'TI', 'Torrin'],
+    knownNames: ['TR', 'TI', 'TRN', 'Torrin'],
     signUpText:
       "Don't have an account? [Sign up here](https://torrin.app). Torrin is an open-source debrid service.",
     credentials: [


### PR DESCRIPTION
MediaFusion 6.1.5 formats Torrin streams with the short name `TRN`, while AIOStreams currently recognizes only `TR`, `TI`, and `Torrin`. As a result, these streams are parsed without a service and are classified as HTTP instead of debrid.

This adds `TRN` to Torrin's known names so MediaFusion Torrin streams are identified correctly.

No tests run; one-line alias update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `TRN` as a recognised Torrin service name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->