### PR TITLE
fix(core): avoid double-applying episode offset for TMDB details

### DIFF
--- a/packages/core/src/streams/context-episode-details.test.ts
+++ b/packages/core/src/streams/context-episode-details.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { AnimeDatabase, type AnimeEntry } from '../utils/index.js';
+import { TMDBMetadata } from '../metadata/tmdb.js';
+import type { UserData } from '../db/schemas.js';
+import { settingsStore } from '../config/index.js';
+import { SettingsRepository } from '../db/repositories/settings.js';
+import { StreamContext } from './context.js';
+
+describe('TMDB episode details for enriched anime requests', () => {
+  for (const fixture of [
+    {
+      name: 'Kitsu double offset across seasons',
+      id: 'kitsu:49444:4',
+      parentSeason: 17,
+      parentOffset: 41,
+      expected: 44,
+    },
+    {
+      name: 'MAL double offset across seasons',
+      id: 'mal:1:3',
+      parentSeason: 17,
+      parentOffset: 41,
+      expected: 43,
+    },
+    {
+      name: 'different offsets within the same season',
+      id: 'kitsu:1:4',
+      parentSeason: 2,
+      parentOffset: 51,
+      expected: 44,
+    },
+    {
+      name: 'local episode above the offset',
+      id: 'kitsu:1:50',
+      parentSeason: 2,
+      parentOffset: 1,
+      expected: 90,
+    },
+    {
+      name: 'explicit TMDB season stays in external coordinates',
+      id: 'tmdb:1:2:44',
+      parentSeason: 2,
+      parentOffset: 41,
+      expected: 44,
+    },
+    {
+      name: 'IMDb already mapped episode stays unchanged',
+      id: 'tt1:2:44',
+      parentSeason: 2,
+      parentOffset: 41,
+      expected: 44,
+    },
+    {
+      name: 'IMDb retains the existing cross-season fallback',
+      id: 'tt1:17:4',
+      parentSeason: 17,
+      parentOffset: 41,
+      expected: 44,
+    },
+  ]) {
+    it(fixture.name, async (t) => {
+      t.mock.method(SettingsRepository, 'getAll', async () => []);
+      t.mock.method(SettingsRepository, 'getVersion', async () => 0);
+      await settingsStore.initialise();
+      const entry = {
+        title: 'Example Anime',
+        mappings: { kitsuId: 1 },
+        imdb: {
+          seasonNumber: fixture.parentSeason,
+          fromEpisode: fixture.parentOffset,
+        },
+        tmdb: { seasonNumber: 2, fromEpisode: 41 },
+      } as AnimeEntry;
+      t.mock.method(AnimeDatabase, 'getInstance', () => ({
+        getEntryById: async () => entry,
+      }));
+      t.mock.method(StreamContext.prototype, 'getMetadata', async () => ({
+        tmdbId: 123,
+      }));
+      const details = t.mock.method(
+        TMDBMetadata.prototype,
+        'getEpisodeDetails',
+        async () => ({ airDate: '2026-01-01', runtime: 24 })
+      );
+      const context = await StreamContext.create('series', fixture.id, {
+        tmdbApiKey: 'test',
+      } as UserData);
+      assert.equal(await context.getEpisodeAirDate(), '2026-01-01');
+      assert.equal(await context.getEpisodeRuntime(), 24);
+      assert.equal(details.mock.callCount(), 1);
+      assert.deepEqual(details.mock.calls[0].arguments, [
+        123,
+        2,
+        fixture.expected,
+      ]);
+    });
+  }
+});

--- a/packages/core/src/streams/context.ts
+++ b/packages/core/src/streams/context.ts
@@ -403,11 +403,24 @@ export class StreamContext {
           seasonNumber = this.animeEntry.tmdb?.seasonNumber ?? seasonNumber;
           if (this.animeEntry.tmdb?.fromEpisode) {
             const fromEpisode = Number(this.animeEntry.tmdb.fromEpisode);
+            // Seasonless Kitsu/MAL IDs carry entry-local episodes. Recover the
+            // original coordinate before translating it, even when enrichment
+            // chose the same season with a different episode offset.
+            const requestParsedId = IdParser.parse(this.id, this.type);
+            const requestEpisode =
+              requestParsedId &&
+              !requestParsedId.season &&
+              requestParsedId.episode &&
+              ['kitsuId', 'malId'].includes(requestParsedId.type)
+                ? Number(requestParsedId.episode)
+                : undefined;
             if (
+              requestEpisode !== undefined ||
               seasonNumber !== originalSeason ||
               episodeNumber < fromEpisode
             ) {
-              episodeNumber = fromEpisode + episodeNumber - 1;
+              episodeNumber =
+                fromEpisode + (requestEpisode ?? episodeNumber) - 1;
             }
           }
           logger.debug(


### PR DESCRIPTION
## Summary

Fixes incorrect TMDB episode-detail lookups for seasonless Kitsu/MAL requests that have already been enriched into external season and episode numbering.

The incorrect lookup can return missing or wrong episode air dates and runtimes, affecting features such as `daysSinceRelease` and metadata-based bitrate calculations.

## Problem

For example, `kitsu:49444:4` is enriched into `S17E44`. The anime entry maps to TMDB season 2 with `fromEpisode: 41`.

Previously, the TMDB lookup could apply that offset to the already-enriched episode:

`41 + 44 - 1 = 84`

This requests `S2E84` instead of the correct `S2E44`.

The existing season/episode heuristic can also miss the required translation when the enriched season matches the TMDB season but uses a different episode offset, or when the entry-local episode number is already above `fromEpisode`.

## Changes

* Recover the entry-local episode from the original seasonless Kitsu/MAL request.
* Apply the TMDB offset to that original episode, independently of the existing season/episode heuristic.
* Preserve the existing fallback calculation for other request types.

For the example above, the lookup becomes:

`41 + 4 - 1 = 44` → TMDB `S2E44`.

## Validation

Seven automated tests pass, covering:

* Kitsu and MAL requests with enriched episode numbers.
* Matching season numbers with different episode offsets.
* Entry-local episodes above the TMDB offset.
* Existing explicit TMDB and IMDb request behavior.

The two additional offset edge cases fail on the previous PR revision and pass with this adjustment. Core TypeScript checking also passes.
