### PR TITLE
docs: move mediaInfoQuality negate() example to a variant recipe

### DIFF
--- a/packages/docs/content/docs/reference/config-expressions.mdx
+++ b/packages/docs/content/docs/reference/config-expressions.mdx
@@ -290,6 +290,13 @@ set requiredLanguages = ["German", "Multi", "Dual Audio"]
 prepend preferredLanguages "German"
 ```
 
+**A different language, with confirmed media info only.**
+
+```
+set requiredLanguages = ["German"]
+add excludedStreamExpressions { "expression": "mediaInfoQuality(streams, 'unknown')", "enabled": true }
+```
+
 **Reordering the sort.** Put resolution above cache status for a machine that does not mind waiting.
 
 ```

--- a/packages/docs/content/docs/reference/stream-expressions.mdx
+++ b/packages/docs/content/docs/reference/stream-expressions.mdx
@@ -295,12 +295,6 @@ Filter by how a stream's media info (languages, subtitles, audio, etc.) was dete
 mediaInfoQuality(streams, 'probe', 'indexer')
 ```
 
-To select only streams with *any* confirmed media info, negate the `'unknown'` match:
-
-```
-negate(mediaInfoQuality(streams, 'unknown'), streams)
-```
-
 ---
 
 #### `type()`


### PR DESCRIPTION
The `negate()` one-liner under `mediaInfoQuality()` was confusing. Replaced with a config-expressions recipe pairing a language filter with an `excludedStreamExpressions` entry that drops unconfirmed media info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a recipe for selecting content in a different language while requiring confirmed media information.
  * Updated the media information quality reference by removing the example for selecting streams with confirmed media information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->