### PR TITLE
feat(sel): add `folderSize()` function

### DIFF
--- a/packages/core/src/parser/streamExpression.ts
+++ b/packages/core/src/parser/streamExpression.ts
@@ -950,6 +950,50 @@ export abstract class StreamExpressionEngine {
       });
     };
 
+    this.parser.functions.folderSize = function (
+      streams: ParsedStream[],
+      minSize?: string | number,
+      maxSize?: string | number
+    ) {
+      if (!Array.isArray(streams) || streams.some((stream) => !stream.type)) {
+        throw new Error('Your streams input must be an array of streams');
+      } else if (
+        (minSize !== undefined &&
+          typeof minSize !== 'number' &&
+          typeof minSize !== 'string') ||
+        (maxSize !== undefined &&
+          typeof maxSize !== 'number' &&
+          typeof maxSize !== 'string')
+      ) {
+        throw new Error('Min and max folder size must be a number or string');
+      } else if (minSize === undefined && maxSize === undefined) {
+        throw new Error('You must provide at least one folder size boundary');
+      }
+
+      const minSizeInBytes =
+        typeof minSize === 'string' ? bytes.parse(minSize) : minSize;
+      const maxSizeInBytes =
+        typeof maxSize === 'string' ? bytes.parse(maxSize) : maxSize;
+
+      return streams.filter((stream) => {
+        if (
+          minSize &&
+          minSizeInBytes &&
+          (stream.folderSize ?? 0) < minSizeInBytes
+        ) {
+          return false;
+        }
+        if (
+          maxSize &&
+          maxSizeInBytes &&
+          (stream.folderSize ?? 0) > maxSizeInBytes
+        ) {
+          return false;
+        }
+        return true;
+      });
+    };
+
     this.parser.functions.bitrate = function (
       streams: ParsedStream[],
       minBitrate?: string | number,

--- a/packages/docs/content/docs/reference/stream-expressions.mdx
+++ b/packages/docs/content/docs/reference/stream-expressions.mdx
@@ -408,6 +408,22 @@ size(streams, '1GB', '10GB')
 
 ---
 
+#### `folderSize()`
+
+Filter by folder/torrent size. Accepts human-readable strings (`'1GB'`, `'500MB'`) or raw byte counts.
+
+| Parameter | Type                | Description         |
+| --------- | ------------------- | ------------------- |
+| `streams` | `ParsedStream[]` | Stream list         |
+| `min`     | `number \| string?` | Minimum folder size |
+| `max`     | `number \| string?` | Maximum folder size |
+
+```
+folderSize(streams, '10GB')
+```
+
+---
+
 #### `bitrate()`
 
 Filter by bitrate. Accepts `'5Mbps'`, `'5000kbps'`, or raw bits-per-second.


### PR DESCRIPTION
## Summary

Adds a `folderSize()` filter function to the Stream Expression Language.

`folderSize()` mirrors the existing `size()` filter, but operates on a stream's total folder/torrent size instead of the selected file size.

This is useful when a stream resolves to a single file from a much larger torrent or folder, where filtering by the selected file size alone is not sufficient.

## Example

```text
folderSize(streams, '10GB')
folderSize(streams, '1GB', '50GB')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `folderSize()` stream filter to select folders based on minimum and/or maximum size.
  * Supports numeric byte values and human-readable sizes.

* **Documentation**
  * Added reference documentation, parameter details, accepted size formats, and usage examples for `folderSize()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->