### PR TITLE
perf(builtins): skip .torrent download for pre-validated bad matches

### DIFF
--- a/packages/core/src/builtins/base/debrid.ts
+++ b/packages/core/src/builtins/base/debrid.ts
@@ -37,7 +37,11 @@ import {
   fileInfoStore,
   FileInfo,
 } from '../../debrid/index.js';
-import { processTorrents, processNZBs } from '../utils/debrid.js';
+import {
+  processTorrents,
+  processNZBs,
+  filterUnprocessedTorrentsPreDownload,
+} from '../utils/debrid.js';
 import {
   calculateAbsoluteEpisode,
   isNonAnimeAbsoluteEligible,
@@ -256,8 +260,9 @@ export abstract class BaseDebridAddon<T extends BaseDebridConfig> {
       ];
     }
 
-    const torrentsToDownload = torrentResults.filter(
-      (t) => !t.hash && t.downloadUrl
+    const torrentsToDownload = filterUnprocessedTorrentsPreDownload(
+      torrentResults.filter((t) => !t.hash && t.downloadUrl),
+      searchMetadata
     );
     torrentResults = torrentResults.filter((t) => t.hash);
     if (torrentsToDownload.length > 0) {

--- a/packages/core/src/builtins/utils/debrid.ts
+++ b/packages/core/src/builtins/utils/debrid.ts
@@ -14,6 +14,7 @@ import {
   TorrentWithSelectedFile,
   NZBWithSelectedFile,
   NZB,
+  UnprocessedTorrent,
   isSeasonWrong,
   isEpisodeWrong,
   isTitleWrong,
@@ -50,6 +51,74 @@ export function extractTrackersFromMagnet(magnet: string): string[] {
   return new URL(magnet.replace('&amp;', '&')).searchParams
     .getAll('tr')
     .filter((tracker) => tracker.trim() !== '');
+}
+
+function getValidationFailureReason(
+  rawTitle: string | undefined,
+  parsed: ParsedResult,
+  metadata: Metadata,
+  confirmed: boolean | undefined,
+  normTitles: Set<string> | null
+): 'country' | 'title' | 'season' | 'episode' | null {
+  if (confirmed !== true) {
+    if (isCountryWrong(parsed, metadata)) return 'country';
+    if (normTitles !== null) {
+      const preprocessedTitle = preprocessTitle(
+        parsed.title ?? '',
+        [rawTitle],
+        metadata.titles
+      );
+      if (
+        !normTitles.has(normaliseTitle(preprocessedTitle)) &&
+        isTitleWrong({ title: preprocessedTitle }, metadata)
+      ) {
+        return 'title';
+      }
+    }
+  }
+  if (isSeasonWrong(parsed, metadata)) return 'season';
+  if (isEpisodeWrong(parsed, metadata)) return 'episode';
+  return null;
+}
+
+// Runs before .torrent download to skip resolving results that
+// processTorrents would discard anyway.
+export function filterUnprocessedTorrentsPreDownload<
+  T extends UnprocessedTorrent,
+>(torrents: T[], metadata?: Metadata): T[] {
+  if (!metadata || torrents.length === 0) return torrents;
+
+  const parsedTitlesMap = new Map<string, ParsedResult>();
+  for (const t of torrents) {
+    const key = t.title ?? '';
+    if (!parsedTitlesMap.has(key)) {
+      parsedTitlesMap.set(key, parseTorrentTitleCached(key));
+    }
+  }
+  const normTitles: Set<string> | null = metadata.titles?.length
+    ? new Set(metadata.titles.map(normaliseTitle))
+    : null;
+
+  const filtered = torrents.filter((torrent) => {
+    const parsed = parsedTitlesMap.get(torrent.title ?? '');
+    if (!parsed) return true;
+    return !getValidationFailureReason(
+      torrent.title,
+      parsed,
+      metadata,
+      torrent.confirmed,
+      normTitles
+    );
+  });
+
+  if (filtered.length < torrents.length) {
+    logger.debug(`Filtered torrents before .torrent download`, {
+      before: torrents.length,
+      after: filtered.length,
+    });
+  }
+
+  return filtered;
 }
 
 export async function processTorrents(
@@ -283,33 +352,22 @@ async function processTorrentsForDebridService(
     );
 
     if (metadata && parsedTorrent) {
-      const preprocessedTitle = preprocessTitle(
-        parsedTorrent.title ?? '',
-        [torrent.title ?? magnetCheckResult?.name],
-        metadata.titles
+      const reason = getValidationFailureReason(
+        torrent.title ?? magnetCheckResult?.name,
+        parsedTorrent,
+        metadata,
+        torrent.confirmed,
+        normTitles
       );
-      if (torrent.confirmed !== true) {
-        if (isCountryWrong(parsedTorrent, metadata)) {
-          filteredTitle++;
-          continue;
-        }
-        if (normTitles !== null) {
-          const normParsed = normaliseTitle(preprocessedTitle);
-          const exactMatch = normTitles.has(normParsed);
-          if (
-            !exactMatch &&
-            isTitleWrong({ title: preprocessedTitle }, metadata)
-          ) {
-            filteredTitle++;
-            continue;
-          }
-        }
+      if (reason === 'country' || reason === 'title') {
+        filteredTitle++;
+        continue;
       }
-      if (isSeasonWrong(parsedTorrent, metadata)) {
+      if (reason === 'season') {
         filteredSeason++;
         continue;
       }
-      if (isEpisodeWrong(parsedTorrent, metadata)) {
+      if (reason === 'episode') {
         filteredEpisode++;
         continue;
       }
@@ -667,30 +725,14 @@ async function processNZBsForDebridService(
     );
 
     if (metadata && parsedNzb) {
-      const preprocessedTitle = preprocessTitle(
-        parsedNzb.title ?? '',
-        [nzb.title ?? nzbCheckResult?.name],
-        metadata.titles
+      const reason = getValidationFailureReason(
+        nzb.title ?? nzbCheckResult?.name,
+        parsedNzb,
+        metadata,
+        nzb.confirmed,
+        normTitles
       );
-      if (nzb.confirmed !== true) {
-        if (isCountryWrong(parsedNzb, metadata)) {
-          continue;
-        }
-        if (normTitles !== null) {
-          const normParsed = normaliseTitle(preprocessedTitle);
-          const exactMatch = normTitles.has(normParsed);
-          if (
-            !exactMatch &&
-            isTitleWrong({ title: preprocessedTitle }, metadata)
-          ) {
-            continue;
-          }
-        }
-      }
-      if (isSeasonWrong(parsedNzb, metadata)) {
-        continue;
-      }
-      if (isEpisodeWrong(parsedNzb, metadata)) {
+      if (reason) {
         continue;
       }
     }


### PR DESCRIPTION
Validate title/season/episode/country against UnprocessedTorrent.title before TorrentGrabber resolves a hash, instead of only after. Wrong matches never trigger a .torrent download/magnet-redirect request now. The check itself is factored out of processTorrentsForDebridService and processNZBsForDebridService into a shared helper so all three call sites stay in sync.

---

a small change which avoids unnecessary .torrent downloads in some edge cases, especially with entry-level private indexers which don't have the best curation of content and return unelated episodes when searching for season packs. but I admit that this is not a huuge perf improvement, so if the complexity added outweighs the benefit it might not be worth it.

> {"level":"info","time":"2026-09-01T15:00:55.006Z","module":"torznab","results":15,"msg":"Completed search for Jackett in 388.00ms"}
> {"level":"debug","time":"2026-09-01T15:00:55.008Z","module":"debrid","before":15,"after":5,"msg":"Filtered torrents before .torrent download"}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent filtering before downloads begin, helping exclude invalid or mismatched results earlier.
  * Applied consistent validation for country, title, season and episode details across torrent and NZB processing.
  * Reduced unnecessary metadata downloads for torrents that do not meet validation criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->