### PR TITLE
fix(builtins/eztv): match season packs (episode "0")

### DIFF
--- a/packages/core/src/builtins/eztv/addon.ts
+++ b/packages/core/src/builtins/eztv/addon.ts
@@ -138,11 +138,13 @@ export class EztvAddon extends BaseDebridAddon<EztvAddonConfig> {
     const seasonStr = String(requestedSeason);
     const episodeStr = String(requestedEpisode);
 
-    // date-named uploads carry season/episode "0" on EZTV; match them by air date
+    // date-named uploads carry season/episode "0" on EZTV; match them by air date.
+    // season packs also carry episode "0", but with the requested season set.
     const airDates = metadata.airDates;
     const matchingTorrents = allTorrents.filter(
       (t) =>
-        (t.season === seasonStr && t.episode === episodeStr) ||
+        (t.season === seasonStr &&
+          (t.episode === episodeStr || t.episode === '0')) ||
         (!!airDates?.length && titleContainsAirDate(t.title, airDates))
     );
 


### PR DESCRIPTION
EZTV returns season packs as the requested season with `episode: "0"`, e.g.:

https://eztvx.to/api/get-torrents?imdb_id=1190634&limit=100&page=1

```json
{
  "title": "The Boys S04 COMPLETE 720p AMZN WEBRip x264 EZTV",
  "season": "4",
  "episode": "0"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EZTV season searches now correctly include season-pack torrents marked with episode `0` when the requested season matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->