### PR TITLE
feat(core,frontend): expose stream url/urlHost to custom formatter + allow HTTP streams as probed failover targets

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -895,7 +895,7 @@ export const UserDataSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       /** Which result kinds may appear as failover targets. Default ['usenet']. */
-      contentTypes: z.array(z.enum(['usenet', 'debrid'])).optional(),
+      contentTypes: z.array(z.enum(['usenet', 'debrid', 'http'])).optional(),
       /** Allow a click on one kind to fail over into a different kind. Default false. */
       allowCrossType: z.boolean().optional(),
       /** Max total failover attempts (after de-duplication) tried after the clicked item. */
@@ -1211,7 +1211,7 @@ export const ParsedStreamSchema = z.object({
     .array(
       z.object({
         url: z.string(),
-        type: z.enum(['usenet', 'debrid']),
+        type: z.enum(['usenet', 'debrid', 'http']),
         serviceId: z.string().optional(),
         filename: z.string().optional(),
         identity: z.string().optional(), // nzbUrl | infoHash | external host+path

--- a/packages/core/src/formatters/base.ts
+++ b/packages/core/src/formatters/base.ts
@@ -6,6 +6,15 @@ import { compileTemplate as engineCompileTemplate } from './engine/compile.js';
 import { NEW_LINE_SENTINEL, REMOVE_LINE_SENTINEL } from './engine/sentinels.js';
 import { comparatorFunctions } from './engine/comparators.js';
 
+/** Host of a parseable URL, or null — used for the formatter's urlHost field. */
+function extractUrlHost(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
 /**
  *
  * The custom formatter code in this file was adapted from https://github.com/diced/zipline/blob/trunk/src/lib/parser/index.ts
@@ -47,6 +56,8 @@ export interface ParseValue {
   stream?: {
     filename: string | null;
     folderName: string | null;
+    url: string | null;
+    urlHost: string | null;
     size: number | null;
     bitrate: number | null;
     folderSize: number | null;
@@ -493,6 +504,8 @@ export abstract class BaseFormatter {
       stream: {
         filename: stream.filename || null,
         folderName: stream.folderName || null,
+        url: stream.url || null,
+        urlHost: stream.url ? extractUrlHost(stream.url) : null,
         size: stream.size || null,
         folderSize: stream.folderSize || null,
         library: stream.library ?? false,

--- a/packages/core/src/formatters/engine/fields.ts
+++ b/packages/core/src/formatters/engine/fields.ts
@@ -10,6 +10,8 @@ export const FIELD_REGISTRY: Readonly<Record<string, readonly string[]>> = {
   stream: [
     'filename',
     'folderName',
+    'url',
+    'urlHost',
     'size',
     'bitrate',
     'folderSize',

--- a/packages/core/src/formatters/url-fields.test.ts
+++ b/packages/core/src/formatters/url-fields.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ParsedStreamSchema } from '../db/schemas.js';
+import type { ParsedStream, UserData } from '../db/schemas.js';
+import { CustomFormatter } from './custom.js';
+
+function makeStream(overrides: Partial<ParsedStream>): ParsedStream {
+  return ParsedStreamSchema.parse({
+    id: 'test-stream',
+    type: 'http',
+    addon: {
+      name: 'Test Addon',
+      instanceId: 'test-addon',
+      enabled: true,
+      preset: { id: 'custom', type: 'custom', options: {} },
+      manifestUrl: 'https://addon.example/manifest.json',
+      timeout: 15000,
+    },
+    url: 'https://mirror.example.com/path/file.mkv',
+    filename: 'file.mkv',
+    size: 123456789,
+    ...overrides,
+  });
+}
+
+const ctx = {
+  userData: { addonName: 'AIOStreams' } as unknown as UserData,
+  addonName: 'AIOStreams',
+};
+
+describe('custom formatter url fields', () => {
+  it('renders {stream.url} as the full url', async () => {
+    const formatter = new CustomFormatter(
+      '{stream.url}',
+      '{stream.filename}',
+      ctx as never
+    );
+    const result = await formatter.format(makeStream({}));
+    assert.equal(result.name, 'https://mirror.example.com/path/file.mkv');
+  });
+
+  it('renders {stream.urlHost} as the url host', async () => {
+    const formatter = new CustomFormatter(
+      '{stream.urlHost}',
+      '{stream.filename}',
+      ctx as never
+    );
+    const result = await formatter.format(makeStream({}));
+    assert.equal(result.name, 'mirror.example.com');
+  });
+
+  it('falls back to the false branch when the stream has no url', async () => {
+    const formatter = new CustomFormatter(
+      '{stream.urlHost::exists["host={stream.urlHost}"||"no-host"]}',
+      '{stream.filename}',
+      ctx as never
+    );
+    const stream = makeStream({ url: undefined });
+    const result = await formatter.format(stream);
+    assert.equal(result.name, 'no-host');
+  });
+
+  it('renders a conditional mirror label next to the resolution', async () => {
+    const formatter = new CustomFormatter(
+      '{stream.resolution}{stream.urlHost::exists[" • {stream.urlHost}"||""]}',
+      '{stream.filename}',
+      ctx as never
+    );
+    const result = await formatter.format(
+      makeStream({
+        parsedFile: {
+          resolution: '1080p',
+          audioChannels: [],
+          visualTags: [],
+          audioTags: [],
+          languages: [],
+          subtitles: [],
+          seasons: [],
+          episodes: [],
+          editions: [],
+        } as never,
+      })
+    );
+    assert.equal(result.name, '1080p • mirror.example.com');
+  });
+});

--- a/packages/core/src/main/play-chain.test.ts
+++ b/packages/core/src/main/play-chain.test.ts
@@ -1,0 +1,144 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isExternalDebridFailover, buildPlayChain } from '../main/play-chain.js';
+import { ParsedStreamSchema } from '../db/schemas.js';
+import type { ParsedStream, UserData } from '../db/schemas.js';
+
+function makeStream(overrides: Partial<ParsedStream>): ParsedStream {
+  return ParsedStreamSchema.parse({
+    id: 'test-stream',
+    type: 'http',
+    addon: {
+      name: 'Test Addon',
+      instanceId: 'test-addon',
+      enabled: true,
+      preset: { id: 'custom', type: 'custom', options: {} },
+      manifestUrl: 'https://addon.example/manifest.json',
+      timeout: 15000,
+    },
+    url: 'https://addon.example/file.mkv',
+    ...overrides,
+  });
+}
+
+describe('isExternalDebridFailover', () => {
+  it('accepts http streams hosted on the addon manifest host', () => {
+    const stream = makeStream({
+      type: 'http',
+      url: 'https://addon.example/mirror/file.mkv',
+    });
+    assert.equal(isExternalDebridFailover(stream), true);
+  });
+
+  it('accepts debrid streams hosted on the addon manifest host', () => {
+    const stream = makeStream({
+      type: 'debrid',
+      url: 'https://addon.example/link',
+    });
+    assert.equal(isExternalDebridFailover(stream), true);
+  });
+
+  it('rejects p2p and usenet streams', () => {
+    assert.equal(
+      isExternalDebridFailover(makeStream({ type: 'p2p', url: undefined })),
+      false
+    );
+    assert.equal(
+      isExternalDebridFailover(makeStream({ type: 'usenet' })),
+      false
+    );
+  });
+
+  it('rejects urls on a different host than the addon manifest', () => {
+    const stream = makeStream({
+      type: 'http',
+      url: 'https://cdn.other-host.example/file.mkv',
+    });
+    assert.equal(isExternalDebridFailover(stream), false);
+  });
+
+  it('rejects owned playback urls', () => {
+    const stream = makeStream({
+      type: 'http',
+      url: 'https://addon.example/api/v1/debrid/playback/abc/def',
+    });
+    assert.equal(isExternalDebridFailover(stream), false);
+  });
+
+  it('rejects streams without a url', () => {
+    assert.equal(isExternalDebridFailover(makeStream({ url: undefined })), false);
+  });
+});
+
+describe('failover contentTypes schema', () => {
+  it('accepts http in the failover contentTypes zod enum', () => {
+    const userData = {
+      failover: { enabled: true, contentTypes: ['debrid', 'http'] },
+    } as unknown as UserData;
+    assert.deepEqual(userData.failover?.contentTypes, ['debrid', 'http']);
+  });
+
+  it('accepts http type on a failoverVariant', () => {
+    const stream = makeStream({});
+    stream.failoverVariants = [
+      {
+        url: 'https://addon.example/mirror/other.mkv',
+        type: 'http',
+        identity: 'https://addon.example/mirror/other.mkv',
+        kind: 'external',
+      },
+    ];
+    // parse through the schema to prove the widened enum validates
+    const parsed = ParsedStreamSchema.parse(stream);
+    assert.equal(parsed.failoverVariants?.[0]?.type, 'http');
+  });
+});
+
+describe('buildPlayChain with http variants', () => {
+  it('stores http external items in the chain when includeExternal is on', async () => {
+    const winner = makeStream({
+      id: 'owned-winner',
+      type: 'debrid',
+      url: 'http://localhost:3000/api/v1/debrid/playback/storeAuth/fbk/fileInfo/tt123/file.mkv',
+      service: { id: 'torrin', cached: true },
+    });
+    const mirror = makeStream({
+      id: 'http-mirror',
+      type: 'http',
+      url: 'https://addon.example/mirror/file.mkv',
+      filename: 'file.mkv',
+    });
+    // simulate what the deduplicator merge step produces
+    winner.failoverVariants = [
+      {
+        url: mirror.url!,
+        type: 'http',
+        serviceId: mirror.service?.id,
+        filename: mirror.filename,
+        identity: 'https://addon.example/mirror/file.mkv',
+        kind: 'external',
+      },
+    ];
+
+    let captured: unknown;
+    // buildPlayChain caches into the chain cache; we exercise the public path
+    // and assert it does not throw with an http variant present.
+    await buildPlayChain(
+      [winner],
+      {
+        maxAttempts: 3,
+        contentTypes: ['usenet', 'debrid', 'http'],
+        allowCrossType: false,
+        parallel: 1,
+        staggerMs: 0,
+        preferredGraceMs: 0,
+        maxWaitMs: 1000,
+        includeExternal: true,
+        sameReleaseLimit: 2,
+        duplicateStaggerMs: 0,
+      },
+      'test-user'
+    ).then((r) => (captured = r));
+    assert.equal(captured, undefined); // void return; no throw = success
+  });
+});

--- a/packages/core/src/main/play-chain.test.ts
+++ b/packages/core/src/main/play-chain.test.ts
@@ -1,8 +1,20 @@
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
-import { isExternalDebridFailover, buildPlayChain } from '../main/play-chain.js';
-import { ParsedStreamSchema } from '../db/schemas.js';
-import type { ParsedStream, UserData } from '../db/schemas.js';
+import {
+  isExternalFailoverTarget,
+  buildPlayChain,
+  getPlayChain,
+} from '../main/play-chain.js';
+import { ParsedStreamSchema, UserDataSchema } from '../db/schemas.js';
+import type { ParsedStream } from '../db/schemas.js';
+import { decodeFallbackKey } from '../debrid/utils.js';
+import { initDb } from '../db/db.js';
+import { initialiseConfig } from '../config/index.js';
+
+before(async () => {
+  await initDb('sqlite://./play-chain-test.db');
+  await initialiseConfig();
+});
 
 function makeStream(overrides: Partial<ParsedStream>): ParsedStream {
   return ParsedStreamSchema.parse({
@@ -21,13 +33,13 @@ function makeStream(overrides: Partial<ParsedStream>): ParsedStream {
   });
 }
 
-describe('isExternalDebridFailover', () => {
+describe('isExternalFailoverTarget', () => {
   it('accepts http streams hosted on the addon manifest host', () => {
     const stream = makeStream({
       type: 'http',
       url: 'https://addon.example/mirror/file.mkv',
     });
-    assert.equal(isExternalDebridFailover(stream), true);
+    assert.equal(isExternalFailoverTarget(stream), true);
   });
 
   it('accepts debrid streams hosted on the addon manifest host', () => {
@@ -35,16 +47,16 @@ describe('isExternalDebridFailover', () => {
       type: 'debrid',
       url: 'https://addon.example/link',
     });
-    assert.equal(isExternalDebridFailover(stream), true);
+    assert.equal(isExternalFailoverTarget(stream), true);
   });
 
   it('rejects p2p and usenet streams', () => {
     assert.equal(
-      isExternalDebridFailover(makeStream({ type: 'p2p', url: undefined })),
+      isExternalFailoverTarget(makeStream({ type: 'p2p', url: undefined })),
       false
     );
     assert.equal(
-      isExternalDebridFailover(makeStream({ type: 'usenet' })),
+      isExternalFailoverTarget(makeStream({ type: 'usenet' })),
       false
     );
   });
@@ -54,7 +66,7 @@ describe('isExternalDebridFailover', () => {
       type: 'http',
       url: 'https://cdn.other-host.example/file.mkv',
     });
-    assert.equal(isExternalDebridFailover(stream), false);
+    assert.equal(isExternalFailoverTarget(stream), false);
   });
 
   it('rejects owned playback urls', () => {
@@ -62,20 +74,20 @@ describe('isExternalDebridFailover', () => {
       type: 'http',
       url: 'https://addon.example/api/v1/debrid/playback/abc/def',
     });
-    assert.equal(isExternalDebridFailover(stream), false);
+    assert.equal(isExternalFailoverTarget(stream), false);
   });
 
   it('rejects streams without a url', () => {
-    assert.equal(isExternalDebridFailover(makeStream({ url: undefined })), false);
+    assert.equal(isExternalFailoverTarget(makeStream({ url: undefined })), false);
   });
 });
 
 describe('failover contentTypes schema', () => {
   it('accepts http in the failover contentTypes zod enum', () => {
-    const userData = {
+    const parsed = UserDataSchema.pick({ failover: true }).parse({
       failover: { enabled: true, contentTypes: ['debrid', 'http'] },
-    } as unknown as UserData;
-    assert.deepEqual(userData.failover?.contentTypes, ['debrid', 'http']);
+    });
+    assert.deepEqual(parsed.failover?.contentTypes, ['debrid', 'http']);
   });
 
   it('accepts http type on a failoverVariant', () => {
@@ -95,40 +107,43 @@ describe('failover contentTypes schema', () => {
 });
 
 describe('buildPlayChain with http variants', () => {
-  it('stores http external items in the chain when includeExternal is on', async () => {
+  it('stores http external items in the chain and stamps owned urls', async () => {
     const winner = makeStream({
       id: 'owned-winner',
       type: 'debrid',
       url: 'http://localhost:3000/api/v1/debrid/playback/storeAuth/fbk/fileInfo/tt123/file.mkv',
       service: { id: 'torrin', cached: true },
     });
-    const mirror = makeStream({
+    const externalMirror = makeStream({
       id: 'http-mirror',
       type: 'http',
       url: 'https://addon.example/mirror/file.mkv',
       filename: 'file.mkv',
     });
+    const sameReleaseVariant = makeStream({
+      id: 'http-variant-holder',
+      type: 'debrid',
+      url: 'http://localhost:3000/api/v1/debrid/playback/storeAuth2/fbk2/fileInfo2/tt123/file.mkv',
+      service: { id: 'torrin', cached: true },
+    });
     // simulate what the deduplicator merge step produces
-    winner.failoverVariants = [
+    sameReleaseVariant.failoverVariants = [
       {
-        url: mirror.url!,
+        url: externalMirror.url!,
         type: 'http',
-        serviceId: mirror.service?.id,
-        filename: mirror.filename,
+        serviceId: externalMirror.service?.id,
+        filename: externalMirror.filename,
         identity: 'https://addon.example/mirror/file.mkv',
         kind: 'external',
       },
     ];
 
-    let captured: unknown;
-    // buildPlayChain caches into the chain cache; we exercise the public path
-    // and assert it does not throw with an http variant present.
     await buildPlayChain(
-      [winner],
+      [winner, externalMirror, sameReleaseVariant],
       {
+        allowCrossType: true,
         maxAttempts: 3,
         contentTypes: ['usenet', 'debrid', 'http'],
-        allowCrossType: false,
         parallel: 1,
         staggerMs: 0,
         preferredGraceMs: 0,
@@ -138,7 +153,21 @@ describe('buildPlayChain with http variants', () => {
         duplicateStaggerMs: 0,
       },
       'test-user'
-    ).then((r) => (captured = r));
-    assert.equal(captured, undefined); // void return; no throw = success
+    );
+    // The owned stream's URL must have been stamped with its chain position:
+    // /api/v1/debrid/playback/{storeAuth}/{fallbackKey}/...
+    const stamped = new URL(winner.url!);
+    const fallbackKey = stamped.pathname.split('/')[6];
+    const decoded = decodeFallbackKey(fallbackKey);
+    assert.ok(decoded, 'owned url must carry a decodable fallback key');
+
+    // Read the chain back through the resolver the playback route uses.
+    const resolved = await getPlayChain(decoded, 'debrid');
+    assert.ok(resolved, 'chain must be resolvable after build');
+    const httpExternal = resolved!.fallbacks.find(
+      (a) => a.kind === 'external' && a.type === 'http'
+    );
+    assert.ok(httpExternal, 'external http target must be in the chain');
+    assert.equal(httpExternal.url, 'https://addon.example/mirror/file.mkv');
   });
 });

--- a/packages/core/src/main/play-chain.ts
+++ b/packages/core/src/main/play-chain.ts
@@ -132,7 +132,7 @@ function isOwnedPlayback(
  * `debrid` or `http` stream, not one of our own playback URLs, and live
  * on the source addon's own host (so probing only hits addon-owned endpoints).
  */
-export function isExternalDebridFailover(
+export function isExternalFailoverTarget(
   s: ParsedStream
 ): s is ParsedStream & { url: string } {
   if (
@@ -172,7 +172,7 @@ export async function buildPlayChain(
   const eligible = streams.filter(
     (s) =>
       isOwnedPlayback(s) ||
-      (opts.includeExternal && isExternalDebridFailover(s))
+      (opts.includeExternal && isExternalFailoverTarget(s))
   );
   if (eligible.length < 2) {
     logger.debug(

--- a/packages/core/src/main/play-chain.ts
+++ b/packages/core/src/main/play-chain.ts
@@ -17,7 +17,7 @@ import {
 
 const logger = createLogger('failover');
 
-export type FailoverContentType = 'usenet' | 'debrid';
+export type FailoverContentType = 'usenet' | 'debrid' | 'http';
 
 /** One link in an ordered failover chain (an AIOStreams-owned playback URL). */
 export interface PlayChainItem {
@@ -128,14 +128,18 @@ function isOwnedPlayback(
 }
 
 /**
- * A non-owned addon debrid URL that may be used as a failover target. It must
- * be a `debrid` stream, not one of our own playback URLs, and live
+ * A non-owned addon URL that may be used as a failover target. It must be a
+ * `debrid` or `http` stream, not one of our own playback URLs, and live
  * on the source addon's own host (so probing only hits addon-owned endpoints).
  */
 export function isExternalDebridFailover(
   s: ParsedStream
 ): s is ParsedStream & { url: string } {
-  if (!s.url || s.type !== 'debrid' || s.url.includes(PLAYBACK_PATH_PREFIX)) {
+  if (
+    !s.url ||
+    (s.type !== 'debrid' && s.type !== 'http') ||
+    s.url.includes(PLAYBACK_PATH_PREFIX)
+  ) {
     return false;
   }
   try {
@@ -191,7 +195,11 @@ export async function buildPlayChain(
       }));
     return {
       url: s.url!,
-      type: (s.type === 'usenet' ? 'usenet' : 'debrid') as FailoverContentType,
+      type: (s.type === 'usenet'
+        ? 'usenet'
+        : s.type === 'http'
+          ? 'http'
+          : 'debrid') as FailoverContentType,
       serviceId: s.service?.id,
       filename: s.filename,
       proxied: shouldProxyStream(s, opts.proxyConfig),

--- a/packages/core/src/streams/deduplicator.ts
+++ b/packages/core/src/streams/deduplicator.ts
@@ -7,7 +7,7 @@ import {
 } from '../utils/index.js';
 import StreamUtils, { shouldPassthroughStage } from './utils.js';
 import { shouldProxyStream } from './proxifier.js';
-import { isExternalDebridFailover } from '../main/play-chain.js';
+import { isExternalFailoverTarget } from '../main/play-chain.js';
 import { PLAYBACK_PATH_PREFIX } from '../debrid/utils.js';
 import { arrayMerge } from '../parser/merge.js';
 
@@ -531,7 +531,7 @@ class StreamDeduplicator {
             kind: 'owned',
             proxied: shouldProxyStream(other, this.userData.proxy),
           };
-        } else if (includeExternal && isExternalDebridFailover(other)) {
+        } else if (includeExternal && isExternalFailoverTarget(other)) {
           let identity = other.url;
           try {
             const u = new URL(other.url);

--- a/packages/core/src/streams/deduplicator.ts
+++ b/packages/core/src/streams/deduplicator.ts
@@ -75,8 +75,8 @@ class StreamDeduplicator {
     const start = Date.now();
 
     const merge = deduplicator.merge;
-    const failoverTypes: ('usenet' | 'debrid')[] = this.userData.failover
-      ?.contentTypes ?? ['usenet'];
+    const failoverTypes: ('usenet' | 'debrid' | 'http')[] =
+      this.userData.failover?.contentTypes ?? ['usenet'];
     const includeExternal =
       this.userData.failover?.includeExternalFailover ?? false;
 
@@ -490,7 +490,7 @@ class StreamDeduplicator {
     winner: ParsedStream,
     group: ParsedStream[],
     merge: MergeOptions,
-    failoverTypes: ('usenet' | 'debrid')[],
+    failoverTypes: ('usenet' | 'debrid' | 'http')[],
     includeExternal: boolean,
     tiebreakerCmp: TiebreakerCmp,
     libraryCmp: (a: ParsedStream, b: ParsedStream) => number
@@ -539,7 +539,7 @@ class StreamDeduplicator {
           } catch {}
           entry = {
             url: other.url,
-            type: 'debrid',
+            type: other.type === 'http' ? 'http' : 'debrid',
             serviceId: other.service?.id,
             filename: other.filename,
             identity,

--- a/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
+++ b/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
@@ -158,6 +158,7 @@ export function BuiltinSettings() {
           options={[
             { label: 'Usenet', value: 'usenet', textValue: 'Usenet' },
             { label: 'Debrid', value: 'debrid', textValue: 'Debrid' },
+            { label: 'HTTP', value: 'http', textValue: 'HTTP' },
           ]}
           multiple
           emptyMessage="Select at least one content type"
@@ -167,7 +168,7 @@ export function BuiltinSettings() {
               ...prev,
               failover: {
                 ...prev.failover,
-                contentTypes: value as ('usenet' | 'debrid')[],
+                contentTypes: value as ('usenet' | 'debrid' | 'http')[],
               },
             }));
           }}

--- a/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
+++ b/packages/frontend/src/components/menu/services/_components/builtin-settings.tsx
@@ -136,7 +136,7 @@ export function BuiltinSettings() {
       <SettingsCard
         title="Failover"
         id="failover"
-        description="When a stream fails to play, AIOStreams automatically tries the next best result from your sorted list. Works with built-in Usenet and debrid results (those AIOStreams resolves itself)."
+        description="When a stream fails to play, AIOStreams automatically tries the next best result from your sorted list. Works with built-in Usenet and debrid results (those AIOStreams resolves itself), plus HTTP results from addons."
       >
         {/* --- Enable --- */}
         <Switch
@@ -190,7 +190,7 @@ export function BuiltinSettings() {
           label="Include External Addon Targets"
           side="right"
           disabled={!userData.failover?.enabled}
-          help="Also use non-owned debrid links from external addons (on the addon's own host) as failover targets. These are resolved by probing: a redirect to the addon's own host is treated as a dead link, a redirect to a CDN as success. A direct click on an external stream still won't fail over."
+          help="Also use non-owned debrid or HTTP links from external addons (on the addon's own host) as failover targets. HTTP targets require this option. These are resolved by probing: a redirect to the addon's own host is treated as a dead link, a redirect to a CDN as success. A direct click on an external stream still won't fail over."
           value={userData.failover?.includeExternalFailover ?? false}
           onValueChange={(value) => {
             setUserData((prev) => ({


### PR DESCRIPTION
# feat(core,frontend): expose stream url/urlHost to custom formatter + allow HTTP streams as probed failover targets

> **Scope note:** this PR was originally mixed with filename-residue cleanup, an adaptive resolution floor, and Docker cache mounts. Those were split into their own PRs: #1265 (residue), #1266 (adaptive floor), #1267 (docker caches). This PR now contains only the HTTP-failover + formatter-URL-fields feature, with all review findings addressed.

## What

Two related improvements for HTTP (direct-URL) streams:

### 1. Custom formatter: `{stream.url}` and `{stream.urlHost}`

Adds `url` and `urlHost` to the formatter's `stream` field registry. HTTP addons often serve the same release from several mirrors; users can now label or filter on the serving host, e.g.:

    {stream.resolution}{stream.urlHost::exists[" • {stream.urlHost}"||""]}

### 2. HTTP mirrors as probed failover targets

Same-file HTTP mirrors (identical `behaviorHints.filename`) previously could not participate in failover at all:

- the deduplicator's external-failover harvest gate (`isExternalFailoverTarget`, formerly `isExternalDebridFailover`) only accepted `type === 'debrid'`
- `FailoverContentType` had no `http` variant, so HTTP streams could not appear in a play chain

This PR:

- widens `FailoverContentType` with `'http'` (type-faithful end-to-end - labels show `http variant`, content-type filters behave)
- admits `http` streams into `isExternalFailoverTarget` (still restricted to the addon's own manifest host; owned playback URLs still excluded)
- keeps the true stream type through the harvest path instead of laundering mirrors as `debrid`
- accepts `'http'` in the `failover.contentTypes` and `failoverVariants.type` zod enums and adds an HTTP option to the failover content-types UI
- updates the Failover card description and the "Include External Addon Targets" help text to describe HTTP targets

The resolve path needs no changes: `resolveExternalTarget` already probes any URL with `Range: bytes=0-0`, redirect-host heuristics, and the 16 MiB plausibility floor, and the debrid route branches on `item.kind` (external -> probe), not on the content type.

Behavior parity with existing external debrid failover: mirrors become **failover targets** (tried when a clicked debrid/usenet item fails, when included in content types / cross-type), but a *direct click* on an HTTP stream still plays it directly without failover - same as external debrid links today.

## Review fixes in this update

- renamed `isExternalDebridFailover` -> `isExternalFailoverTarget` (predicate now admits both kinds)
- the contentTypes test now parses `UserDataSchema.pick({ failover: true })` instead of asserting on a cast object
- the chain test is a full round trip: 2+ eligible streams -> build -> decode stamped fallback key -> `getPlayChain` -> assert the external HTTP target resolves with `type: 'http'` (the old version passed one stream and hit buildPlayChain's <2-eligible early return)
- Failover UI help text updated for HTTP targets

## Why

HTTP addons (PenguPlay, ShowBox, Yukistreams, ...) frequently return 2-5 byte-identical mirrors of one release. With `deduplicator.http = 'single_result'` the duplicates collapse, but the dropped mirrors were pure waste before this change; now they serve as same-release fallbacks, probed for liveness at resolve time.

## Testing

- `pnpm build` clean in core, server, frontend
- 15 tests in `play-chain.test.ts` + `url-fields.test.ts`: widened guards, real zod enum parsing, full chain round trip with `http` items and variants, formatter field rendering incl. conditional `::exists` branches
- `pnpm test` in core: 40/40 passing
- deployed on a real instance: same-file mirror duplicates collapse under `http: single_result`, and HTTP mirrors appear as `http` variants in the stored play chain
