### PR TITLE
fix(parser): strip provider-appended media-info residue from HTTP stream filenames

### DIFF
--- a/packages/core/src/parser/filename-clean.test.ts
+++ b/packages/core/src/parser/filename-clean.test.ts
@@ -43,6 +43,11 @@ describe('stripProviderResidue', () => {
       'Reacher.2022'
     );
   });
+  it('keeps a hex-id name whose tilde suffix has no bitrate marker', () => {
+    const name = 'Show.abcdefabcdefabcdef~Director.Cut';
+    assert.equal(stripProviderResidue(name), name);
+  });
+
 
   it('keeps a filename whose post-extension junk has no provider marker', () => {
     const name = 'Reacher.S01E01.mkvReacher fake no marker';

--- a/packages/core/src/parser/filename-clean.test.ts
+++ b/packages/core/src/parser/filename-clean.test.ts
@@ -47,6 +47,11 @@ describe('stripProviderResidue', () => {
     const name = 'Show.abcdefabcdefabcdef~Director.Cut';
     assert.equal(stripProviderResidue(name), name);
   });
+  it('keeps a legit ".pad-" suffix that has no media-info echo before it', () => {
+    const name = 'Movie.mkv.pad-notes';
+    assert.equal(stripProviderResidue(name), name);
+  });
+
 
 
   it('keeps a filename whose post-extension junk has no provider marker', () => {

--- a/packages/core/src/parser/filename-clean.test.ts
+++ b/packages/core/src/parser/filename-clean.test.ts
@@ -32,7 +32,16 @@ describe('stripProviderResidue', () => {
 
   it('keeps a legit filename untouched', () => {
     const name = 'Reacher.S01E01.1080p.WEB.h264-KOGi.mkv';
+
     assert.equal(stripProviderResidue(name), name);
+  });
+  it('cuts hex-id glue when the provider dropped the extension entirely', () => {
+    assert.equal(
+      stripProviderResidue(
+        'Reacher.2022.0385306a6e148b9e6afb060f41249b581080pMKVWEB-DLH.264FSL~5.8Mbps1080pmkvweb-dlh.264fsl~5.8mbps.pad-'
+      ),
+      'Reacher.2022'
+    );
   });
 
   it('keeps a filename whose post-extension junk has no provider marker', () => {

--- a/packages/core/src/parser/filename-clean.test.ts
+++ b/packages/core/src/parser/filename-clean.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripProviderResidue } from './providerResidue.js';
+
+describe('stripProviderResidue', () => {
+  it('strips bitrate-marker residue glued to the extension (4KHDHub bluray)', () => {
+    assert.equal(
+      stripProviderResidue(
+        'Reacher.S01E01.UHD.BluRay.2160p.10bit.HEVC.HDR.[Hindi.DDP5.1.+.English.DTS-HD.MA.5.1].(HDS-Ionicboy).mkv4KMKVBluRayHDR10+10BitHEVCDdp5.1~26.2Mbps4kmkvblurayhdr10+10bithevcdp5.1~26.2mbps.pad-4KHDHub'
+      ),
+      'Reacher.S01E01.UHD.BluRay.2160p.10bit.HEVC.HDR.[Hindi.DDP5.1.+.English.DTS-HD.MA.5.1].(HDS-Ionicboy).mkv'
+    );
+  });
+
+  it('strips residue with bitrate and .pad- suffix (2Peckle form)', () => {
+    assert.equal(
+      stripProviderResidue(
+        'Reacher.S01E01.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv1080pMP4WEB-DLx264~9.5Mbps1080pmp4web-dlx264~9.5mbps.pad-2Peckle'
+      ),
+      'Reacher.S01E01.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv'
+    );
+  });
+
+  it('strips pad-only residue without a bitrate marker', () => {
+    assert.equal(
+      stripProviderResidue(
+        'Movie.2023.1080p.BluRay.x264.mkv1080pMKVBluRayx264.pad-VAPlayer'
+      ),
+      'Movie.2023.1080p.BluRay.x264.mkv'
+    );
+  });
+
+  it('keeps a legit filename untouched', () => {
+    const name = 'Reacher.S01E01.1080p.WEB.h264-KOGi.mkv';
+    assert.equal(stripProviderResidue(name), name);
+  });
+
+  it('keeps a filename whose post-extension junk has no provider marker', () => {
+    const name = 'Reacher.S01E01.mkvReacher fake no marker';
+    assert.equal(stripProviderResidue(name), name);
+  });
+
+  it('keeps a name with numbers glued to the extension but no marker', () => {
+    const name = 'A.Movie.2023.mkvandmp4weird';
+    assert.equal(stripProviderResidue(name), name);
+  });
+});

--- a/packages/core/src/parser/providerResidue.ts
+++ b/packages/core/src/parser/providerResidue.ts
@@ -1,0 +1,31 @@
+const MEDIA_EXTENSIONS =
+  /\.(mkv|mp4|avi|mov|wmv|flv|webm|m4v|mpg|mpeg|ts|m2ts|iso)/gi;
+
+/** Residue markers appended by some HTTP providers after the real extension. */
+const RESIDUE_MARKER = /~\d+(?:\.\d+)?mbps|\.pad-/i;
+
+/**
+ * Strip provider-appended media-info residue from a release filename.
+ *
+ * Some HTTP providers (4KHDHub, VAPlayer, 2Peckle, …) glue a media-info echo
+ * onto the real file name, e.g.:
+ *   "Movie.2023.mkv4KMKVBluRayHDR10+10BitHEVCDdp5.1~26.2Mbps...pad-4KHDHub"
+ *
+ * The residue is glued directly to the extension (".mkv4K..."), so a
+ * negative-lookahead match can't be used. Instead, take the LAST extension
+ * candidate and cut there only when the trailing residue carries a provider
+ * marker (a "~N.Mbps" bitrate echo or a ".pad-<tag>" suffix) — legit names
+ * are returned unchanged.
+ */
+export function stripProviderResidue(filename: string): string {
+  const extPattern = new RegExp(MEDIA_EXTENSIONS.source, 'gi');
+  let last: RegExpExecArray | undefined;
+  for (let m = extPattern.exec(filename); m; m = extPattern.exec(filename)) {
+    last = m;
+  }
+  if (!last) return filename;
+  const end = last.index + last[0].length;
+  const residue = filename.slice(end);
+  if (!residue || !RESIDUE_MARKER.test(residue)) return filename;
+  return filename.slice(0, end);
+}

--- a/packages/core/src/parser/providerResidue.ts
+++ b/packages/core/src/parser/providerResidue.ts
@@ -23,9 +23,20 @@ export function stripProviderResidue(filename: string): string {
   for (let m = extPattern.exec(filename); m; m = extPattern.exec(filename)) {
     last = m;
   }
-  if (!last) return filename;
-  const end = last.index + last[0].length;
-  const residue = filename.slice(end);
-  if (!residue || !RESIDUE_MARKER.test(residue)) return filename;
-  return filename.slice(0, end);
+  if (last) {
+    const end = last.index + last[0].length;
+    const residue = filename.slice(end);
+    if (!residue || !RESIDUE_MARKER.test(residue)) return filename;
+    return filename.slice(0, end);
+  }
+
+  // No media extension at all: some providers drop it entirely and glue a
+  // hex id plus the residue straight onto the title, e.g.
+  //   "Show.2022.<32-hex>1080pMKVWEB-DL...~5.8Mbps....pad-X"
+  // Cut at the hex token when a container/bitrate marker follows it.
+  const hashGlue =
+    /\.[a-f0-9]{16,}(?=[0-9]{3,4}(?:p)?(?:MKV|MP4|WEB|BLURAY)|~)/i;
+  const hashMatch = hashGlue.exec(filename);
+  if (hashMatch) return filename.slice(0, hashMatch.index);
+  return filename;
 }

--- a/packages/core/src/parser/providerResidue.ts
+++ b/packages/core/src/parser/providerResidue.ts
@@ -35,7 +35,7 @@ export function stripProviderResidue(filename: string): string {
   //   "Show.2022.<32-hex>1080pMKVWEB-DL...~5.8Mbps....pad-X"
   // Cut at the hex token when a container/bitrate marker follows it.
   const hashGlue =
-    /\.[a-f0-9]{16,}(?=[0-9]{3,4}(?:p)?(?:MKV|MP4|WEB|BLURAY)|~)/i;
+    /\.[a-f0-9]{16,}(?=[0-9]{3,4}(?:p)?(?:MKV|MP4|WEB|BLURAY)|~\d+(?:\.\d+)?mbps)/i;
   const hashMatch = hashGlue.exec(filename);
   if (hashMatch) return filename.slice(0, hashMatch.index);
   return filename;

--- a/packages/core/src/parser/providerResidue.ts
+++ b/packages/core/src/parser/providerResidue.ts
@@ -2,7 +2,8 @@ const MEDIA_EXTENSIONS =
   /\.(mkv|mp4|avi|mov|wmv|flv|webm|m4v|mpg|mpeg|ts|m2ts|iso)/gi;
 
 /** Residue markers appended by some HTTP providers after the real extension. */
-const RESIDUE_MARKER = /~\d+(?:\.\d+)?mbps|\.pad-/i;
+const RESIDUE_MARKER =
+  /(?:~\d+(?:\.\d+)?mbps)|(?:(?:mkv|mp4|avi|webm|bluray|web-?dl|x264|x265|hevc|av1|\d{3,4}p)[a-z0-9.+-]*\.pad-)/i;
 
 /**
  * Strip provider-appended media-info residue from a release filename.

--- a/packages/core/src/parser/streams.ts
+++ b/packages/core/src/parser/streams.ts
@@ -21,6 +21,7 @@ import {
   arrayMerge,
   applySeasonPackHeuristics,
 } from './merge.js';
+import { stripProviderResidue } from './providerResidue.js';
 
 const logger = createLogger('parser');
 
@@ -251,6 +252,7 @@ class StreamParser {
     return undefined;
   }
 
+
   protected getFilename(
     stream: Stream,
     currentParsedStream: ParsedStream
@@ -258,7 +260,7 @@ class StreamParser {
     let filename = stream.behaviorHints?.filename;
 
     if (filename) {
-      return filename;
+      return stripProviderResidue(filename);
     }
 
     const description = stream.description || stream.title;


### PR DESCRIPTION
# fix(parser): strip provider-appended media-info residue from HTTP stream filenames

## What

Some HTTP providers (4KHDHub, VAPlayer, 2Peckle, CineFreak) glue a media-info echo onto the real release filename after the extension, e.g.:

```
Reacher.S01E01.1080p.WEB-DL.DDP5.1.H.264-NTb.mkv1080pMP4WEB-DLx264~9.5Mbps1080pmp4web-dlx264~9.5mbps.pad-2Peckle
```

That polluted `behaviorHints.filename` leaks into custom formatter output and into dedup keys, producing garbled stream descriptions like `26.2 Mbps4kmkvblurayhdr10+10`.

`stripProviderResidue` (new module `packages/core/src/parser/providerResidue.ts`) removes the residue:

- **Extension present**: takes the LAST media-extension candidate and cuts there when the trailing residue carries a provider marker (a `~N.Mbps` bitrate echo or a `.pad-<tag>` suffix). The residue is glued directly to the extension (`.mkv4KMKV…`), so a negative-lookahead match cannot work.
- **Extension dropped**: some providers glue a hex id plus the residue straight onto the title (`Show.2022.<32-hex>1080pMKVWEB-DL…~5.8Mbps…pad-X`). When no extension candidate exists, the cut happens at the hex token — and only when a container/bitrate marker follows (a bare `~Director.Cut` suffix is NOT treated as residue).
- **Legit names are returned byte-identical.**

`StreamParser.getFilename` applies it, so formatters, dedup keys and parsed metadata all see the cleaned name.

## Testing

- 8 new tests (`filename-clean.test.ts`): all four real-world polluted patterns from a live instance, pad-only residue, hex-glue without extension, and four negative cases (legit names untouched, junk without markers kept, non-bitrate tilde suffix kept)
- full core suite green; deployed on a live instance — polluted rows now render as `Reacher.S01E01.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb.mkv`

Residue cleanup for HTTP stream filenames, split out of #1264 per scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filename handling for media streams by removing recognised provider-generated metadata.
  - Preserved legitimate filenames and unrelated trailing text when no recognised provider markers are present.
  - Improved handling of filenames with missing extensions when identifiable provider metadata follows a recognised identifier.
  - Reduced false positives when processing `.pad-` suffixes by requiring relevant media information before removing them.
  - Applied consistent cleanup to filenames provided through stream metadata hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->