### PR TITLE
feat(core,frontend): adaptive resolution floor - show available streams when the floor is unmatched

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -554,6 +554,8 @@ export const UserDataSchema = z.object({
   excludedResolutions: z.array(Resolutions).optional(),
   includedResolutions: z.array(Resolutions).optional(),
   requiredResolutions: z.array(Resolutions).optional(),
+  /** When no stream matches requiredResolutions, keep everything instead of showing nothing. */
+  adaptiveResolutionFloor: z.boolean().optional(),
   preferredResolutions: z.array(Resolutions).optional(),
   excludedQualities: z.array(Qualities).optional(),
   includedQualities: z.array(Qualities).optional(),

--- a/packages/core/src/streams/adaptive-floor.test.ts
+++ b/packages/core/src/streams/adaptive-floor.test.ts
@@ -55,9 +55,10 @@ describe('adaptiveResolutionFloor', () => {
   const floor = ['2160p', '1440p', '1080p', '720p'];
 
   // ':memory:' doesn't survive connect.ts's URL parsing and absolute
-  // Windows paths don't fit its URL scheme, so use a relative path in the
-  // package cwd; after() removes every artifact.
-  const dbPath = 'adaptive-floor-test.db';
+  // Windows paths don't fit its URL scheme, so use a relative path in
+  // the package cwd, unique per process so concurrent runs can't touch
+  // each other's files; after() removes every artifact.
+  const dbPath = `adaptive-floor-test-${process.pid}.db`;
   before(async () => {
     await initDb(`sqlite://./${dbPath}`);
     await initialiseConfig();
@@ -128,5 +129,36 @@ describe('adaptiveResolutionFloor', () => {
     assert.ok(resolutions.includes('1080p'));
     assert.ok(!resolutions.includes('480p'));
     assert.ok(!resolutions.includes('Unknown'));
+  });
+
+  it('retracts earlier off-floor batches once a later batch meets the floor', () => {
+    // Request-scope semantics: per-batch filter() calls saw only their
+    // own batch, so batch 1 kept 480p rows; the merged-set pass must
+    // drop them because batch 2 contains a floor-meeting stream.
+    const filterer = new StreamFilterer(
+      makeUserData({ requiredResolutions: floor, adaptiveResolutionFloor: true })
+    );
+    const batch1 = [makeStream({}, '480p'), makeStream({}, 'Unknown')];
+    const batch2 = [makeStream({}, '1080p')];
+    const merged = [...batch1, ...batch2];
+    const result = filterer.applyResolutionFloor(merged);
+    assert.deepEqual(
+      result.map((s) => s.parsedFile?.resolution),
+      ['1080p']
+    );
+  });
+
+  it('keeps all merged streams when no batch ever meets the floor', () => {
+    const filterer = new StreamFilterer(
+      makeUserData({ requiredResolutions: floor, adaptiveResolutionFloor: true })
+    );
+    const merged = [makeStream({}, '480p'), makeStream({}, 'Unknown')];
+    assert.equal(filterer.applyResolutionFloor(merged).length, 2);
+  });
+
+  it('is a no-op when no floor is configured', () => {
+    const filterer = new StreamFilterer(makeUserData({}));
+    const merged = [makeStream({}, '480p')];
+    assert.equal(filterer.applyResolutionFloor(merged).length, 1);
   });
 });

--- a/packages/core/src/streams/adaptive-floor.test.ts
+++ b/packages/core/src/streams/adaptive-floor.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import StreamFilterer from './filterer.js';
+import { StreamContext } from './context.js';
+import { ParsedStreamSchema } from '../db/schemas.js';
+import type { ParsedStream, UserData } from '../db/schemas.js';
+import { initDb } from '../db/db.js';
+import { initialiseConfig } from '../config/index.js';
+
+function makeStream(
+  overrides: Partial<ParsedStream>,
+  resolution?: string
+): ParsedStream {
+  const stream = ParsedStreamSchema.parse({
+    id: 'test-stream-' + Math.random().toString(36).slice(2),
+    type: 'http',
+    addon: {
+      name: 'Test Addon',
+      instanceId: 'test-addon',
+      enabled: true,
+      preset: { id: 'custom', type: 'custom', options: {} },
+      manifestUrl: 'https://addon.example/manifest.json',
+      timeout: 15000,
+    },
+    url: 'https://addon.example/file.mkv',
+    ...overrides,
+  });
+  if (resolution) {
+    stream.parsedFile = {
+      ...stream.parsedFile,
+      resolution,
+    } as ParsedStream['parsedFile'];
+  }
+  return stream;
+}
+
+function makeUserData(overrides: Partial<UserData>): UserData {
+  // The filterer only reads specific fields; a full UserDataSchema.parse
+  // would drag in required sortCriteria/formatter shapes irrelevant here.
+  return { ...overrides } as unknown as UserData;
+}
+async function filterWith(
+  userData: UserData,
+  streams: ParsedStream[]
+): Promise<ParsedStream[]> {
+  const filterer = new StreamFilterer(userData);
+  const context = await StreamContext.create('series', 'tt0000001:1:1', userData);
+  return filterer.filter(streams, context);
+}
+
+describe('adaptiveResolutionFloor', () => {
+  const floor = ['2160p', '1440p', '1080p', '720p'];
+
+  before(async () => {
+    // ':memory:' doesn't survive connect.ts's URL parsing; a relative
+    // sqlite://./file URI lands in the process cwd (packages/core when run
+    // via the test script) and behaves identically for these tests.
+    await initDb('sqlite://./adaptive-floor-test.db');
+    await initialiseConfig();
+  });
+
+  it('enforces the floor when at least one stream meets it', async () => {
+    const userData = makeUserData({
+      requiredResolutions: floor,
+      adaptiveResolutionFloor: true,
+    });
+    const streams = [
+      makeStream({}, '720p'),
+      makeStream({}, '480p'),
+      makeStream({}, 'Unknown'),
+    ];
+    const result = await filterWith(userData, streams);
+    const resolutions = result.map((s) => s.parsedFile?.resolution);
+    assert.deepEqual(resolutions.sort(), ['480p', 'Unknown', '720p'].sort().filter(r => r === '720p'));
+  });
+
+  it('drops the floor when nothing meets it, keeping all streams', async () => {
+    const userData = makeUserData({
+      requiredResolutions: floor,
+      adaptiveResolutionFloor: true,
+    });
+    const streams = [
+      makeStream({}, '576p'),
+      makeStream({}, '480p'),
+      makeStream({}, 'Unknown'),
+    ];
+    const result = await filterWith(userData, streams);
+    assert.equal(result.length, 3);
+  });
+
+  it('hard-filters when the floor is not adaptive', async () => {
+    const userData = makeUserData({
+      requiredResolutions: floor,
+    });
+    const streams = [
+      makeStream({}, '576p'),
+      makeStream({}, '480p'),
+    ];
+    const result = await filterWith(userData, streams);
+    assert.equal(result.length, 0);
+  });
+
+  it('keeps hard filtering when some streams meet the floor (adaptive on)', async () => {
+    const userData = makeUserData({
+      requiredResolutions: floor,
+      adaptiveResolutionFloor: true,
+    });
+    const streams = [
+      makeStream({}, '1080p'),
+      makeStream({}, '480p'),
+      makeStream({}, 'Unknown'),
+    ];
+    const result = await filterWith(userData, streams);
+    const resolutions = result.map((s) => s.parsedFile?.resolution);
+    assert.ok(resolutions.includes('1080p'));
+    assert.ok(!resolutions.includes('480p'));
+    assert.ok(!resolutions.includes('Unknown'));
+  });
+});

--- a/packages/core/src/streams/adaptive-floor.test.ts
+++ b/packages/core/src/streams/adaptive-floor.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, before } from 'node:test';
+import { describe, it, before, after } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import assert from 'node:assert/strict';
 import StreamFilterer from './filterer.js';
 import { StreamContext } from './context.js';
 import { ParsedStreamSchema } from '../db/schemas.js';
 import type { ParsedStream, UserData } from '../db/schemas.js';
-import { initDb } from '../db/db.js';
+import { initDb, closeDb } from '../db/db.js';
 import { initialiseConfig } from '../config/index.js';
 
 function makeStream(
@@ -51,12 +54,20 @@ async function filterWith(
 describe('adaptiveResolutionFloor', () => {
   const floor = ['2160p', '1440p', '1080p', '720p'];
 
+  // ':memory:' doesn't survive connect.ts's URL parsing and absolute
+  // Windows paths don't fit its URL scheme, so use a relative path in the
+  // package cwd; after() removes every artifact.
+  const dbPath = 'adaptive-floor-test.db';
   before(async () => {
-    // ':memory:' doesn't survive connect.ts's URL parsing; a relative
-    // sqlite://./file URI lands in the process cwd (packages/core when run
-    // via the test script) and behaves identically for these tests.
-    await initDb('sqlite://./adaptive-floor-test.db');
+    await initDb(`sqlite://./${dbPath}`);
     await initialiseConfig();
+  });
+
+  after(async () => {
+    await closeDb();
+    for (const suffix of ['', '-shm', '-wal']) {
+      fs.rmSync(dbPath + suffix, { force: true });
+    }
   });
 
   it('enforces the floor when at least one stream meets it', async () => {
@@ -70,8 +81,10 @@ describe('adaptiveResolutionFloor', () => {
       makeStream({}, 'Unknown'),
     ];
     const result = await filterWith(userData, streams);
-    const resolutions = result.map((s) => s.parsedFile?.resolution);
-    assert.deepEqual(resolutions.sort(), ['480p', 'Unknown', '720p'].sort().filter(r => r === '720p'));
+    assert.deepEqual(
+      result.map((s) => s.parsedFile?.resolution),
+      ['720p']
+    );
   });
 
   it('drops the floor when nothing meets it, keeping all streams', async () => {

--- a/packages/core/src/streams/fetcher.ts
+++ b/packages/core/src/streams/fetcher.ts
@@ -673,6 +673,11 @@ class StreamFetcher {
     for (let i = 0; i < allStatisticStreams.length; i++) {
       allStatisticStreams[i] = statStreamsWithTime[i].stat;
     }
+    // The adaptive floor must be decided at REQUEST scope: per-batch
+    // filter() calls only see their own batch (dynamic fetching/groups),
+    // so a floor met by a late batch has to retract off-floor streams
+    // that earlier batches were allowed to keep.
+    allStreams = this.filter.applyResolutionFloor(allStreams);
     return {
       streams: allStreams,
       errors: allErrors,

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -2408,14 +2408,13 @@ class StreamFilterer {
       this.userData.requiredResolutions &&
       this.userData.requiredResolutions.length > 0
     ) {
+      const floorResolutions = this.userData.requiredResolutions;
       const anyMeetsFloor = streams.some((stream) =>
-        this.userData.requiredResolutions!.includes(
+        floorResolutions!.includes(
           (stream.parsedFile?.resolution ||
-            'Unknown') as UserData['requiredResolutions'] extends infer R
-            ? R extends readonly (infer T)[]
-              ? T
-              : never
-            : never
+            'Unknown') as NonNullable<
+            UserData['requiredResolutions']
+          >[number]
         )
       );
       if (!anyMeetsFloor) {

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -1442,6 +1442,10 @@ class StreamFilterer {
           return undefined;
       }
     };
+    // Set once filterableStreams is known: when the resolution floor is
+    // adaptive and NOTHING in the result set meets it, the floor is dropped
+    // for this request so users see what exists instead of nothing.
+    let bypassRequiredResolutions = false;
 
     const shouldKeepStream = (stream: ParsedStream): boolean => {
       const file = stream.parsedFile;
@@ -1762,6 +1766,7 @@ class StreamFilterer {
       }
 
       if (
+        !bypassRequiredResolutions &&
         this.userData.requiredResolutions &&
         this.userData.requiredResolutions.length > 0 &&
         !this.userData.requiredResolutions.includes(
@@ -2397,6 +2402,29 @@ class StreamFilterer {
     const filterableStreams = streams.filter(
       (stream) => !includedWithoutPassthrough.some((s) => s.id === stream.id)
     );
+
+    if (
+      this.userData.adaptiveResolutionFloor &&
+      this.userData.requiredResolutions &&
+      this.userData.requiredResolutions.length > 0
+    ) {
+      const anyMeetsFloor = streams.some((stream) =>
+        this.userData.requiredResolutions!.includes(
+          (stream.parsedFile?.resolution ||
+            'Unknown') as UserData['requiredResolutions'] extends infer R
+            ? R extends readonly (infer T)[]
+              ? T
+              : never
+            : never
+        )
+      );
+      if (!anyMeetsFloor) {
+        bypassRequiredResolutions = true;
+        logger.info(
+          `No stream meets the required resolutions [${this.userData.requiredResolutions.join(', ')}]; adaptive floor dropped for this request`
+        );
+      }
+    }
 
     const hasAnyRegexFilter = !!(
       excludedRegexPatterns ||

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -269,6 +269,36 @@ class StreamFilterer {
     );
   }
 
+  /**
+   * Request-scope resolution floor pass. filter() runs once per fetch
+   * batch (dynamic fetching / addon groups), so its adaptive-floor
+   * decision only sees that batch. After the fetcher merges every
+   * batch, this re-evaluates the requiredResolutions floor against the
+   * FULL request set and re-applies it: if any stream anywhere meets
+   * the floor, off-floor streams from earlier batches are dropped; if
+   * nothing meets it, everything is kept. No-op when the floor is
+   * unset; statistics counters are untouched (batches already counted).
+   */
+  public applyResolutionFloor(streams: ParsedStream[]): ParsedStream[] {
+    const required = this.userData.requiredResolutions;
+    if (!required || required.length === 0) return streams;
+    const anyMeetsFloor = streams.some((stream) =>
+      required.includes(
+        (stream.parsedFile?.resolution ||
+          'Unknown') as NonNullable<UserData['requiredResolutions']>[number]
+      )
+    );
+    if (anyMeetsFloor) {
+      return streams.filter((stream) =>
+        required.includes(
+          (stream.parsedFile?.resolution ||
+            'Unknown') as NonNullable<UserData['requiredResolutions']>[number]
+        )
+      );
+    }
+    return streams;
+  }
+
   public getFilterTimings(): FilterTimings {
     return {
       ...this.filterTimings,

--- a/packages/core/src/utils/fieldMeta.ts
+++ b/packages/core/src/utils/fieldMeta.ts
@@ -90,6 +90,7 @@ export const FIELD_META: Omit<Record<keyof UserData, FieldMeta>, IgnoredKeys> = 
   excludedResolutions: { label: 'Excluded Resolutions', group: 'filters', type: 'list', menu: 'filters', subTab: 'resolution' },
   includedResolutions: { label: 'Included Resolutions', group: 'filters', type: 'list', menu: 'filters', subTab: 'resolution' },
   requiredResolutions: { label: 'Required Resolutions', group: 'filters', type: 'list', menu: 'filters', subTab: 'resolution' },
+  adaptiveResolutionFloor: { label: 'Adaptive Resolution Floor', group: 'filters', type: 'scalar', menu: 'filters', subTab: 'resolution', keywords: ['fallback'] },
   preferredResolutions: { label: 'Preferred Resolutions', group: 'filters', type: 'list', menu: 'filters', subTab: 'resolution' },
 
   excludedQualities: { label: 'Excluded Qualities', group: 'filters', type: 'list', menu: 'filters', subTab: 'quality' },

--- a/packages/frontend/src/components/menu/filters/index.tsx
+++ b/packages/frontend/src/components/menu/filters/index.tsx
@@ -716,6 +716,21 @@ function Content() {
                   value: resolution,
                 }))}
               />
+              <SettingsCard>
+                <Switch
+                  label="Adaptive Resolution Floor"
+                  side="right"
+                  value={userData.adaptiveResolutionFloor ?? false}
+                  help="When Required Resolutions is set and NO stream meets it, show everything available instead of removing all streams."
+                  moreHelp="Applies per request: if at least one stream matches the required resolutions, the requirement is enforced as usual; only when nothing matches is the floor dropped for that request."
+                  onValueChange={(checked) =>
+                    setUserData((prev) => ({
+                      ...prev,
+                      adaptiveResolutionFloor: checked,
+                    }))
+                  }
+                />
+              </SettingsCard>
             </>
           </TabsContent>
           <TabsContent

--- a/packages/frontend/src/components/menu/filters/index.tsx
+++ b/packages/frontend/src/components/menu/filters/index.tsx
@@ -716,7 +716,7 @@ function Content() {
                   value: resolution,
                 }))}
               />
-              <SettingsCard>
+              <SettingsCard id="adaptiveResolutionFloor">
                 <Switch
                   label="Adaptive Resolution Floor"
                   side="right"


### PR DESCRIPTION
# feat(core,frontend): adaptive resolution floor

## What

`requiredResolutions` currently hard-removes every stream whose parsed resolution is not in the allowlist. On sources that don't declare a resolution (many Asian-drama/HTTP addons), that surfaces a **"Required Resolution (4) - 4x Unknown"** removal-reasons card and an empty player.

This adds an opt-in `userData.adaptiveResolutionFloor` flag (new toggle: **Filters → Resolution → Adaptive Resolution Floor**):

- Before the filter pass, the filterer checks whether **any** stream in the result set meets the floor.
- **At least one matches** → the floor is enforced as usual (only the allowed resolutions are shown).
- **Nothing matches** → the floor is dropped for that request and everything is shown, so the user sees what exists instead of nothing.

Per-request, set-aware, zero cost when the flag is off.

## Implementation

- `packages/core/src/db/schemas.ts`: `adaptiveResolutionFloor: z.boolean().optional()`
- `packages/core/src/streams/filterer.ts`: after `filterableStreams` is computed, one `streams.some(...)` decides a `bypassRequiredResolutions` flag that the existing `requiredResolutions` check consults; bypass logs an info line for traceability
- `packages/core/src/utils/fieldMeta.ts` + filters UI: field metadata and a labelled `SettingsCard` (id `adaptiveResolutionFloor` for command-palette scroll)

## Testing

- 4 new tests (`adaptive-floor.test.ts`): floor enforced when a match exists / floor dropped when nothing matches / hard-filter unchanged when flag off / mixed set keeps enforcement
- full core suite green (51/51); verified live: a 720p+-available title shows only 720p+ rows, a no-resolution drama shows all streams instead of a removal card

Split out of #1264 per scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Adaptive Resolution Floor** setting under Resolution filters.
  * When enabled, streams remain available if none meet the configured required resolution; the requirement is relaxed for that request.
  * Required resolution filtering continues to apply whenever at least one stream meets the configured requirement.
  * Resolution filtering is now evaluated across the complete set of streams for each request, ensuring consistent results across multiple sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->