### PR TITLE
build(docker): persist pnpm store and build cache across builds

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -96,8 +96,11 @@ jobs:
           context: .
           file: ./Dockerfile
           outputs: type=image,name=ghcr.io/viren070/aiostreams,push-by-digest=true,name-canonical=true
-          cache-from: type=gha,scope=${{ matrix.suffix }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
+          # Trust separation: dev/PR builds must never share cache scopes with
+          # the deployment workflow, so poisoned cache data cannot flow into
+          # production images.
+          cache-from: type=gha,scope=dev-${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=dev-${{ matrix.suffix }}
 
       - name: Export digest
         run: echo "${{ steps.build.outputs.digest }}" > "/tmp/${{ matrix.suffix }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,10 @@ RUN rm -rf packages/server/node_modules
 RUN rm -rf packages/frontend/node_modules
 RUN rm -rf packages/seanime-extensions/node_modules
 
-RUN pnpm install --prod --frozen-lockfile
+# The store cache mount matches the earlier install step, so production
+# dependencies resolve from cache instead of being re-downloaded.
+RUN --mount=type=cache,target=/pnpm/store \
+    pnpm install --prod --frozen-lockfile
 
 
 FROM builder AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24.18.1-slim AS base
 
 ENV PNPM_HOME="/pnpm"
@@ -30,9 +31,9 @@ COPY packages/crypto/package*.json ./packages/crypto/
 COPY pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY pnpm-lock.yaml ./pnpm-lock.yaml
 COPY patches ./patches
-
 # Cache the pnpm store across builds; lockfile changes still invalidate correctly.
-RUN --mount=type=cache,target=/pnpm/store \
+# Explicit id + locked sharing prevents corruption under parallel builds.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
     pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile
 
 # Copy source files.
@@ -47,8 +48,8 @@ COPY scripts ./scripts
 COPY resources ./resources
 
 
-# Build the project.
-RUN --mount=type=cache,target=/build/node_modules/.cache \
+# Build the project; the bundler cache persists across builds.
+RUN --mount=type=cache,id=build-cache,target=/build/node_modules/.cache,sharing=locked \
     pnpm run build
 
 # Remove development dependencies.
@@ -60,7 +61,7 @@ RUN rm -rf packages/seanime-extensions/node_modules
 
 # The store cache mount matches the earlier install step, so production
 # dependencies resolve from cache instead of being re-downloaded.
-RUN --mount=type=cache,target=/pnpm/store \
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
     pnpm install --prod --frozen-lockfile
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,9 @@ COPY pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY pnpm-lock.yaml ./pnpm-lock.yaml
 COPY patches ./patches
 
-# Install dependencies.
-RUN pnpm install --frozen-lockfile
+# Cache the pnpm store across builds; lockfile changes still invalidate correctly.
+RUN --mount=type=cache,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile
 
 # Copy source files.
 COPY tsconfig.*json ./
@@ -47,7 +48,8 @@ COPY resources ./resources
 
 
 # Build the project.
-RUN pnpm run build
+RUN --mount=type=cache,target=/build/node_modules/.cache \
+    pnpm run build
 
 # Remove development dependencies.
 RUN rm -rf node_modules


### PR DESCRIPTION
# build(docker): persist pnpm store and build cache across builds

## What

Every image build currently re-downloads all dependencies and rebuilds tooling artifacts from scratch. This mounts BuildKit cache volumes:

1. `pnpm store` at `/pnpm/store` for the dependency install (`pnpm config set store-dir /pnpm/store` inside the same `RUN`), so package tarballs download once and are reused across builds
2. `/build/node_modules/.cache` for the build step, so frontend bundler artifacts persist
3. the production `pnpm install --prod` also mounts the same store, so prod dependencies resolve from cache after `node_modules` is cleared (previously only the first install was cached)

Cache mounts never enter the image layers - they only speed up builds on the same builder, so the runtime image is unchanged.

## Testing

- `docker build` locally on linux/arm64: cold build unchanged, warm build skips the dependency download step
- deployed via CI-equivalent builds on a live instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved container build efficiency by using stable, dedicated caches for package installation and build processes.
  * Reduced repeated downloads and processing during development and deployment builds.
* **Reliability**
  * Prevented concurrent builds from corrupting shared build caches.
  * Isolated development and pull request build caches from deployment workflow caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->