### PR TITLE
fix(utils): make pathSuffix optional in NZB URL shapes

### DIFF
--- a/packages/core/src/debrid/utils.ts
+++ b/packages/core/src/debrid/utils.ts
@@ -58,15 +58,15 @@ export function cleanNzbUrl(url: string): string {
  * Known NZB download URL shapes that have identifiers in query parameters.
  */
 const NZB_URL_SHAPES: ReadonlyArray<{
-  pathSuffix: string;
+  pathSuffix?: string;
   /** Params retained in the hashed URL; all must be present for a match. */
   keep: readonly string[];
   matches?: (params: URLSearchParams) => boolean;
 }> = [
   {
-    // newznab t=get / t=g requests. `t` is kept as part of the canonical form,
-    // not because it identifies the release.
-    pathSuffix: '/api',
+    // Newznab t=get / t=g requests. Newznab-compatible services can expose
+    // this endpoint at arbitrary paths (e.g. /api/newznab/aiostreams), so the
+    // query shape is the reliable discriminator rather than the URL path.
     keep: ['t', 'id'],
     matches: (params) => ['get', 'g'].includes(params.get('t')!),
   },
@@ -86,7 +86,7 @@ export function hashNzbUrl(url: string, clean: boolean = true): string {
     const u = new URL(url);
     const pathName = u.pathname.replace(/\/$/, '');
     for (const shape of NZB_URL_SHAPES) {
-      if (!pathName.endsWith(shape.pathSuffix)) continue;
+      if (shape.pathSuffix && !pathName.endsWith(shape.pathSuffix)) continue;
       if (shape.keep.some((key) => !u.searchParams.get(key))) continue;
       if (shape.matches && !shape.matches(u.searchParams)) continue;
       for (const key of Array.from(u.searchParams.keys())) {


### PR DESCRIPTION
Newznab URLs were only detected when the endpoint path ended in `/api`. This caused different releases using paths such as `/api/newznab/aiostreams` to produce the same hash after query parameters were removed.

The detection now uses the Newznab query format instead:

```text
/path/to/endpoint?t=get&id=AAA&apikey=TOKEN
→ /path/to/endpoint?t=get&id=AAA
→ unique hash
```

It also supports `t=g` and continues to ignore API keys and unrelated parameters. Existing `/download?link=...` and `/getnzb?id=...` handling is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Newznab URLs regardless of their path, provided they use supported query parameters.
  * Prevented valid Newznab requests from being excluded when no path suffix is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->