### PR TITLE
feat(builtins): add Anime Tosho (New) built-in addon

### DIFF
--- a/packages/core/src/config/schema/builtins.ts
+++ b/packages/core/src/config/schema/builtins.ts
@@ -698,6 +698,26 @@ export const builtinsSchema = {
       secret: false,
     },
   },
+  animeToshoNew: {
+    url: {
+      schema: urlString,
+      default: 'https://feed.animetosho.xyz',
+      label: 'Anime Tosho (New) URL',
+      env: 'BUILTIN_ANIME_TOSHO_NEW_URL',
+      description: 'Base URL for the Anime Tosho (New) built-in addon.',
+      requiresRestart: false,
+      secret: false,
+    },
+    timeout: {
+      schema: optionalPositiveInt,
+      default: null,
+      label: 'Anime Tosho (New) timeout (ms)',
+      env: 'BUILTIN_DEFAULT_ANIME_TOSHO_NEW_TIMEOUT',
+      description: 'Timeout for Anime Tosho (New) requests.',
+      requiresRestart: false,
+      secret: false,
+    },
+  },
   nekobt: {
     url: {
       schema: urlString,

--- a/packages/core/src/presets/animeToshoNew.ts
+++ b/packages/core/src/presets/animeToshoNew.ts
@@ -1,0 +1,112 @@
+import { Option, UserData } from '../db/index.js';
+import { appConfig, constants } from '../utils/index.js';
+import { baseOptions } from './preset.js';
+import { StremThruPreset } from './stremthru.js';
+import { TorznabPreset } from './torznab.js';
+
+export class AnimeToshoNewPreset extends TorznabPreset {
+  static override get METADATA() {
+    const supportedResources = [constants.STREAM_RESOURCE];
+    const options: Option[] = [
+      ...baseOptions(
+        'Anime Tosho (New)',
+        supportedResources,
+        appConfig.builtins.animeToshoNew.timeout ??
+          appConfig.presets.defaultTimeout
+      ).filter((option) => option.id !== 'url' && option.id !== 'resources'),
+      {
+        id: 'apiKey',
+        name: 'API Key',
+        description:
+          'Anime Tosho (New) API key. Register a free account and find this in your profile settings.',
+        type: 'password',
+        required: true,
+      },
+      {
+        id: 'services',
+        name: 'Services',
+        description:
+          'Optionally override the services that are used. If not specified, then the services that are enabled and supported will be used.',
+        type: 'multi-select',
+        required: false,
+        showInSimpleMode: false,
+        options: StremThruPreset.supportedServices.map((service) => ({
+          value: service,
+          label: constants.SERVICE_DETAILS[service].name,
+        })),
+        default: undefined,
+        emptyIsUndefined: true,
+      },
+      {
+        id: 'mediaTypes',
+        name: 'Media Types',
+        description:
+          'Limits this addon to the selected media types for streams. For example, selecting "Movie" means this addon will only be used for movie streams (if the addon supports them). Leave empty to allow all.',
+        type: 'multi-select',
+        required: false,
+        showInSimpleMode: false,
+        default: [],
+        options: [
+          {
+            label: 'Movie',
+            value: 'movie',
+          },
+          {
+            label: 'Series',
+            value: 'series',
+          },
+          {
+            label: 'Anime',
+            value: 'anime',
+          },
+        ],
+      },
+      {
+        id: 'useMultipleInstances',
+        name: 'Use Multiple Instances',
+        description:
+          'Anime Tosho (New) supports multiple services in one instance of the addon - which is used by default. If this is enabled, then the addon will be created for each service.',
+        type: 'boolean',
+        default: false,
+        showInSimpleMode: false,
+      },
+    ];
+
+    return {
+      ID: 'anime-tosho-new',
+      NAME: 'Anime Tosho (New)',
+      LOGO: '/assets/animetosho_logo.png',
+      URL: [appConfig.builtins.animeToshoNew.url],
+      TIMEOUT:
+        appConfig.builtins.animeToshoNew.timeout ??
+        appConfig.presets.defaultTimeout,
+      USER_AGENT: appConfig.http.defaultUserAgent,
+      SUPPORTED_SERVICES: StremThruPreset.supportedServices,
+      DESCRIPTION:
+        'An addon to get debrid results from Anime Tosho, mirroring Nyaa.si, TokyoTosho and other anime release sources. Requires a free API key.',
+      OPTIONS: options,
+      SUPPORTED_STREAM_TYPES: [constants.DEBRID_STREAM_TYPE],
+      SUPPORTED_RESOURCES: supportedResources,
+      BUILTIN: true,
+    };
+  }
+
+  protected static override generateManifestUrl(
+    userData: UserData,
+    services: constants.ServiceId[],
+    options: Record<string, any>
+  ): string {
+    const animeToshoNewUrl = this.DEFAULT_URL;
+
+    const config = {
+      ...this.getBaseConfig(userData, services),
+      url: animeToshoNewUrl,
+      apiPath: '/api',
+      apiKey: options.apiKey,
+      paginate: false,
+    };
+
+    const configString = this.base64EncodeJSON(config, 'urlSafe');
+    return `${appConfig.bootstrap.internalUrl}/builtins/torznab/${configString}/manifest.json`;
+  }
+}

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -61,6 +61,7 @@ import { TorznabPreset } from './torznab.js';
 import { AStreamPreset } from './aStream.js';
 import { ZileanPreset } from './zilean.js';
 import { AnimeToshoPreset } from './animetosho.js';
+import { AnimeToshoNewPreset } from './animeToshoNew.js';
 import { NewznabPreset } from './newznab.js';
 import { ProwlarrPreset } from './prowlarr.js';
 import { JackettPreset } from './jackett.js';
@@ -104,6 +105,7 @@ let PRESET_LIST: string[] = [
   'bitmagnet',
   'seadex',
   'animetosho',
+  'anime-tosho-new',
   'neko-bt',
   'prowlarr',
   'jackett',
@@ -311,6 +313,8 @@ export class PresetManager {
         return ZileanPreset;
       case 'animetosho':
         return AnimeToshoPreset;
+      case 'anime-tosho-new':
+        return AnimeToshoNewPreset;
       case 'neko-bt':
         return NekoBtPreset;
       case 'prowlarr':

--- a/packages/docs/content/docs/configuration/environment-variables.mdx
+++ b/packages/docs/content/docs/configuration/environment-variables.mdx
@@ -972,6 +972,13 @@ neither the environment variable nor a stored value is present.
 | `BUILTIN_ANIMETOSHO_URL`             | Animetosho › URL     | string | `https://feed.animetosho.org` | Base URL for the AnimeTosho built-in addon. |
 | `BUILTIN_DEFAULT_ANIMETOSHO_TIMEOUT` | Animetosho › Timeout | number | —                             | Timeout for AnimeTosho requests.            |
 
+#### Anime Tosho New
+
+| Environment Variable                      | UI Setting                | Type   | Default                       | Description                                        |
+| ----------------------------------------- | ------------------------- | ------ | ----------------------------- | -------------------------------------------------- |
+| `BUILTIN_ANIME_TOSHO_NEW_URL`             | Anime Tosho New › URL     | string | `https://feed.animetosho.xyz` | Base URL for the Anime Tosho (New) built-in addon. |
+| `BUILTIN_DEFAULT_ANIME_TOSHO_NEW_TIMEOUT` | Anime Tosho New › Timeout | number | —                             | Timeout for Anime Tosho (New) requests.            |
+
 #### Nekobt
 
 | Environment Variable             | UI Setting       | Type   | Default                         | Description                             |


### PR DESCRIPTION
The original animetosho.org has stopped receiving new torrents. This targets the actively maintained successor (feed.animetosho.xyz) via the existing torznab builtin, same pattern as nekoBT: a required user-supplied API key.

---

it looks like this is going to stay and since the newznab variant exists in the template too, I thought it would be consistent to add this for torznab too. also briefly checked, it seems to outperform Knaben in both amount of results and performance. and it is a good replacement for the unmaintained animetosho of course. should that one be removed at some point I wonder?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Anime Tosho New built-in addon.
  - Added configuration for its service URL and optional request timeout.
  - Added options for API key, services, media types, and multiple instances.
  - Added automatic manifest URL generation for configured instances.

- **Documentation**
  - Documented the new Anime Tosho New environment variables, including their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->