### PR TITLE
fix(core): encode Service Wrap store credentials

### DIFF
--- a/packages/core/src/main/serviceWrapper.test.ts
+++ b/packages/core/src/main/serviceWrapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { constants } from '../utils/index.js';
+import { getServiceCredential } from './serviceWrapper.js';
+
+describe('getServiceCredential', () => {
+  it('encodes PikPak credentials for StremThru basic auth', () => {
+    assert.equal(
+      getServiceCredential({
+        id: constants.PIKPAK_SERVICE,
+        credentials: {
+          email: 'user@example.com',
+          password: 'secret:with:colons',
+        },
+      }),
+      'user@example.com:secret:with:colons'
+    );
+  });
+
+  it('encodes Offcloud credentials for StremThru basic auth', () => {
+    assert.equal(
+      getServiceCredential({
+        id: constants.OFFCLOUD_SERVICE,
+        credentials: {
+          email: 'user@example.com',
+          password: 'secret:with:colons',
+        },
+      }),
+      'user@example.com:secret:with:colons'
+    );
+  });
+
+  it('skips incomplete email/password credentials', () => {
+    assert.equal(
+      getServiceCredential({
+        id: constants.PIKPAK_SERVICE,
+        credentials: { email: 'user@example.com', apiKey: 'legacy' },
+      }),
+      undefined
+    );
+    assert.equal(
+      getServiceCredential({
+        id: constants.OFFCLOUD_SERVICE,
+        credentials: { password: 'secret' },
+      }),
+      undefined
+    );
+  });
+});

--- a/packages/core/src/main/serviceWrapper.ts
+++ b/packages/core/src/main/serviceWrapper.ts
@@ -23,6 +23,7 @@ import { isServiceWrapEligibleP2PStream } from '../streams/utils.js';
 import { parseTorrentTitleCached } from '../parser/title.js';
 import { PresetManager } from '../presets/presetManager.js';
 
+import { stremthruSpecialCases } from '../presets/stremthru.js';
 const logger = createLogger('serviceWrapper');
 
 export interface ServiceWrapResult {
@@ -602,16 +603,12 @@ export function getServiceCredential(service: {
   const creds = service.credentials;
   if (!creds) return undefined;
 
-  // Only need to handle torrent-based services.
-  switch (service.id) {
-    case constants.SEEDR_SERVICE:
-      return creds.encodedToken;
-    case constants.PIKPAK_SERVICE:
-      return JSON.stringify({
-        email: creds.email,
-        password: creds.password,
-      });
-    default:
-      return creds.apiKey;
-  }
+  // Service Wrap uses StremThru for torrent services, so reuse its credential
+  // encoding contract rather than maintaining a second representation here.
+  const specialCase =
+    stremthruSpecialCases[service.id as keyof typeof stremthruSpecialCases];
+  if (!specialCase) return creds.apiKey;
+
+  const specialCredential = specialCase(creds);
+  return typeof specialCredential === 'string' ? specialCredential : undefined;
 }

--- a/packages/core/src/presets/stremthru.ts
+++ b/packages/core/src/presets/stremthru.ts
@@ -13,13 +13,16 @@ import {
 import { constants, ServiceId } from '../utils/index.js';
 import { Preset } from './preset.js';
 
+function encodeEmailPassword(credentials: any): string | undefined {
+  if (!credentials?.email || !credentials?.password) return undefined;
+  return `${credentials.email}:${credentials.password}`;
+}
+
 export const stremthruSpecialCases: Partial<
   Record<ServiceId, (credentials: any) => any>
 > = {
-  [constants.OFFCLOUD_SERVICE]: (credentials: any) =>
-    `${credentials.email}:${credentials.password}`,
-  [constants.PIKPAK_SERVICE]: (credentials: any) =>
-    `${credentials.email}:${credentials.password}`,
+  [constants.OFFCLOUD_SERVICE]: encodeEmailPassword,
+  [constants.PIKPAK_SERVICE]: encodeEmailPassword,
   [constants.STREMTHRU_NEWZ_SERVICE]: (credentials: any) => credentials,
 };
 


### PR DESCRIPTION
## Summary

- reuse the existing `stremthruSpecialCases` credential map directly from Service Wrap instead of maintaining a second encoding path
- encode both PikPak and Offcloud credentials as `email:password` for the StremThru store contract
- skip incomplete email/password pairs instead of forwarding `undefined:undefined` or falling back to an unrelated API-key field
- add regression coverage for both providers, passwords containing colons, and incomplete credentials
- remove the unreachable Seedr-only branch; Seedr is not a Service Wrap-supported builtin provider

Fixes #1257

## Verification

- `pnpm --filter @aiostreams/core test` — 30 passed
- `pnpm --filter @aiostreams/core build`
- TypeScript diagnostics clean for changed implementation and tests
- Prettier check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StremThru credential handling for Offcloud and PikPak services.
  * Credentials containing colons are now correctly encoded for basic authentication.
  * Incomplete credentials are rejected instead of being sent as invalid authentication data.

* **Tests**
  * Added coverage for valid Offcloud credentials and incomplete PikPak and Offcloud credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->