### PR TITLE
fix(distributed-lock): fix crash reviving errors with a getter-only name

### DIFF
--- a/packages/core/src/utils/distributed-lock.test.ts
+++ b/packages/core/src/utils/distributed-lock.test.ts
@@ -73,6 +73,16 @@ describe('distributed-lock error serialization', () => {
     assert.equal(revived.error.message, 'bad argument');
   });
 
+  test('a native class with a getter-only `name` (e.g. DOMException) round-trips without throwing', () => {
+    const err = new DOMException('The operation was aborted', 'TimeoutError');
+    const wire = stringifyLockResult({ error: err });
+    const revived = parseLockResult<{ error: Error }>(wire);
+
+    assert.ok(revived.error instanceof DOMException);
+    assert.equal(revived.error.name, 'TimeoutError');
+    assert.equal(revived.error.message, 'The operation was aborted');
+  });
+
   test('resolveErrorCtor resolves registered, native, and unresolvable names', () => {
     assert.equal(resolveErrorCtor('TestDebridError'), TestDebridError);
     assert.equal(resolveErrorCtor('TypeError'), TypeError);

--- a/packages/core/src/utils/distributed-lock.ts
+++ b/packages/core/src/utils/distributed-lock.ts
@@ -88,7 +88,13 @@ export function parseLockResult<T>(json: string): T {
     const err = (ctor ? Object.create(ctor.prototype) : new Error()) as Error;
     for (const [k, v] of Object.entries(val)) {
       if (k === '__lockError' || k === 'className') continue;
-      (err as any)[k] = v;
+      // avoids throwing on getter-only accessors, e.g. DOMException.prototype.name
+      Object.defineProperty(err, k, {
+        value: v,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     return err;
   });


### PR DESCRIPTION
parseLockResult() plain-assigned every flattened field back onto the revived error, including name. When the resolved class declares name as a getter-only accessor (e.g. DOMException, thrown by AbortSignal.timeout() on any request timeout/abort), that throws "Cannot set property name of ... which has only a getter" for any concurrent duplicate request waiting on the same lock - independent of which indexer triggered the timeout.

---

I noticed these "Cannot set property name of  which has only a getter" recently happening sometimes for timeouts. this is the fix for it, now it is showing "The operation was aborted due to timeout" properly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where certain native errors, including `DOMException`, could fail during distributed-lock result deserialization.
  - Preserved the error type, name and message when serialising and restoring these errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->