### PR TITLE
fix(builtins): add server-side category filtering to TorrentGalaxy and TheRARBG

### DIFF
--- a/packages/core/src/builtins/therarbg/addon.ts
+++ b/packages/core/src/builtins/therarbg/addon.ts
@@ -5,7 +5,7 @@ import {
   getTimeTakenSincePoint,
   ParsedId,
 } from '../../utils/index.js';
-import TheRARBGAPI, { getTheRARBGUrl } from './api.js';
+import TheRARBGAPI, { TheRARBGCategory, getTheRARBGUrl } from './api.js';
 import { NZB, UnprocessedTorrent } from '../../debrid/utils.js';
 import { validateInfoHash } from '../utils/debrid.js';
 import { config as appConfig } from '../../config/index.js';
@@ -16,8 +16,6 @@ const logger = createLogger('therarbg');
 export const TheRARBGAddonConfigSchema = BaseDebridConfigSchema;
 
 export type TheRARBGAddonConfig = z.infer<typeof TheRARBGAddonConfigSchema>;
-
-const WHITELISTED_CATEGORIES = ['Movies', 'TV', 'Anime'];
 
 export class TheRARBGAddon extends BaseDebridAddon<TheRARBGAddonConfig> {
   readonly id = 'therarbg';
@@ -55,7 +53,15 @@ export class TheRARBGAddon extends BaseDebridAddon<TheRARBGAddonConfig> {
       return [];
     }
 
-    logger.info(`Performing TheRARBG search`, { queries });
+    const categories = [
+      ...(parsedId.mediaType === 'movie' ? [TheRARBGCategory.Movies] : []),
+      ...(parsedId.mediaType === 'series'
+        ? [TheRARBGCategory.TV, TheRARBGCategory.TVShows]
+        : []),
+      ...(metadata.isAnime ? [TheRARBGCategory.Anime] : []),
+    ];
+
+    logger.info(`Performing TheRARBG search`, { queries, categories });
 
     const searchPromises = queries.map((q) =>
       queryLimit(async () => {
@@ -65,6 +71,7 @@ export class TheRARBGAddon extends BaseDebridAddon<TheRARBGAddonConfig> {
         const firstPageResponse = await this.api.search({
           query: q,
           page: 1,
+          categories,
         });
 
         const { total, pageSize } = firstPageResponse;
@@ -100,6 +107,7 @@ export class TheRARBGAddon extends BaseDebridAddon<TheRARBGAddonConfig> {
           const { results } = await this.api.search({
             query: q,
             page: pageNum,
+            categories,
           });
           logger.debug(`Fetched page ${pageNum} for query "${q}"`, {
             newResults: results.length,
@@ -126,12 +134,9 @@ export class TheRARBGAddon extends BaseDebridAddon<TheRARBGAddonConfig> {
       .flat()
       .filter(
         (result) =>
-          WHITELISTED_CATEGORIES.some(
-            (category) => result.category === category
-          ) ||
-          (metadata.imdbId && result.imdbId
-            ? result.imdbId === metadata.imdbId
-            : true)
+          !result.imdbId ||
+          !metadata.imdbId ||
+          result.imdbId === metadata.imdbId
       );
 
     const seenTorrents = new Set<string>();

--- a/packages/core/src/builtins/therarbg/api.ts
+++ b/packages/core/src/builtins/therarbg/api.ts
@@ -13,6 +13,13 @@ import { z } from 'zod';
 
 const logger = createLogger('therarbg');
 
+enum TheRARBGCategory {
+  Movies = 'Movies',
+  TV = 'TV',
+  TVShows = 'TV shows',
+  Anime = 'Anime',
+}
+
 const TheRARBGSearchResultSchema = z
   .looseObject({
     n: z.string(), // name
@@ -70,17 +77,19 @@ class TheRARBGAPI {
   async search(options: {
     query: string;
     page?: number;
+    categories?: string[];
   }): Promise<TheRARBGSearchResponse> {
     const query = options.query;
     const page = options.page ?? 1;
-    const cacheKey = JSON.stringify({ query, page });
+    const categories = options.categories ?? [];
+    const cacheKey = JSON.stringify({ query, page, categories });
 
     return searchWithBackgroundRefresh({
       searchCache: this.searchCache,
       searchCacheKey: cacheKey,
       bgCacheKey: `therarbg:${cacheKey}`,
       cacheTTL: appConfig.builtins.therarbg.searchCacheTtl,
-      fetchFn: () => this.request(query, page),
+      fetchFn: () => this.request(query, page, categories),
       isEmptyResult: (result) => result.results.length === 0,
       logger,
     });
@@ -88,10 +97,12 @@ class TheRARBGAPI {
 
   private async request(
     query: string,
-    page: number
+    page: number,
+    categories: string[]
   ): Promise<TheRARBGSearchResponse> {
+    const categorySegments = categories.map((c) => `:category:${c}`).join('');
     const url = new URL(
-      `/get-posts/order:-a:keywords:${encodeURIComponent(query)}:format:json/`,
+      `/get-posts/order:-a${categorySegments}:keywords:${encodeURIComponent(query)}:format:json/`,
       getApiBaseUrl()
     );
     url.searchParams.set('page', page.toString());
@@ -138,5 +149,5 @@ class TheRARBGAPI {
   }
 }
 
-export { getApiBaseUrl as getTheRARBGUrl };
+export { TheRARBGCategory, getApiBaseUrl as getTheRARBGUrl };
 export default TheRARBGAPI;

--- a/packages/core/src/builtins/torrent-galaxy/addon.ts
+++ b/packages/core/src/builtins/torrent-galaxy/addon.ts
@@ -29,12 +29,6 @@ export type TorrentGalaxyAddonConfig = z.infer<
   typeof TorrentGalaxyAddonConfigSchema
 >;
 
-const WHITELISTED_CATEGORIES = [
-  TorrentGalaxyCategory.Anime,
-  TorrentGalaxyCategory.TV,
-  TorrentGalaxyCategory.Movies,
-];
-
 export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig> {
   readonly id = 'torrent-galaxy';
   readonly name = 'Torrent Galaxy';
@@ -71,7 +65,15 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
       return [];
     }
 
-    logger.info(`Performing torrent galaxy search`, { queries });
+    const categories = [
+      ...(parsedId.mediaType === 'movie' ? [TorrentGalaxyCategory.Movies] : []),
+      ...(parsedId.mediaType === 'series'
+        ? [TorrentGalaxyCategory.TV, TorrentGalaxyCategory.TVShows]
+        : []),
+      ...(metadata.isAnime ? [TorrentGalaxyCategory.Anime] : []),
+    ];
+
+    logger.info(`Performing torrent galaxy search`, { queries, categories });
 
     const searchPromises = queries.map((q) =>
       queryLimit(async () => {
@@ -82,6 +84,7 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
         const firstPageResponse = await this.api.search({
           query: q,
           page: 1,
+          categories,
         });
 
         const { total, pageSize } = firstPageResponse;
@@ -119,6 +122,7 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
           const { results } = await this.api.search({
             query: q,
             page: pageNum,
+            categories,
           });
           logger.debug(`Fetched page ${pageNum} for query "${q}"`, {
             newResults: results.length,
@@ -145,12 +149,9 @@ export class TorrentGalaxyAddon extends BaseDebridAddon<TorrentGalaxyAddonConfig
       .flat()
       .filter(
         (result) =>
-          WHITELISTED_CATEGORIES.some(
-            (category) => result.category === category
-          ) ||
-          (metadata.imdbId && result.imdbId
-            ? result.imdbId === metadata.imdbId
-            : true)
+          !result.imdbId ||
+          !metadata.imdbId ||
+          result.imdbId === metadata.imdbId
       );
 
     const seenTorrents = new Set<string>();

--- a/packages/core/src/builtins/torrent-galaxy/api.ts
+++ b/packages/core/src/builtins/torrent-galaxy/api.ts
@@ -16,6 +16,7 @@ const logger = createLogger('torrent-galaxy');
 enum TorrentGalaxyCategory {
   Movies = 'Movies',
   TV = 'TV',
+  TVShows = 'TV shows',
   Anime = 'Anime',
 }
 
@@ -72,6 +73,7 @@ type TorrentGalaxySearchResponse = z.infer<typeof TorrentGalaxySearchResponse>;
 const TorrentGalaxySearchOptions = z.object({
   query: z.string(),
   page: z.number().default(1),
+  categories: z.array(z.string()).default([]),
 });
 
 type TorrentGalaxySearchOptions = z.infer<typeof TorrentGalaxySearchOptions>;
@@ -109,7 +111,7 @@ class TorrentGalaxyAPI {
       cacheTTL: appConfig.builtins.torrentGalaxy.searchCacheTtl,
       fetchFn: () =>
         this.request<TorrentGalaxySearchResponse>(
-          `/get-posts/keywords:${encodeURIComponent(options.query)}:format:json`,
+          `/get-posts/keywords:${encodeURIComponent(options.query)}${options.categories.map((c) => `:category:${c}`).join('')}:format:json`,
           {
             schema: TorrentGalaxySearchResponse,
             timeout: appConfig.builtins.torrentGalaxy.searchTimeout,


### PR DESCRIPTION
Both support a :category:X path segment server-side, previously unused - filtering was client-side only. Categories are now selected per search based on media type via a shared enum on each site. Also switches the imdb check to a precision filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent search accuracy by applying media-specific categories for films, series, and anime.
  * Search results are now matched more reliably using IMDb identifiers, reducing unrelated results.
  * Category filters are consistently applied across all search pages.
* **Improvements**
  * Added support for TV show category filtering in Torrent Galaxy and TheRARBG searches.
  * Search requests now preserve selected category filters for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->