### PR TITLE
fix(server): expose Content-Range and Accept-Ranges to browser players

### DIFF
--- a/packages/server/src/middlewares/cors.ts
+++ b/packages/server/src/middlewares/cors.ts
@@ -11,6 +11,10 @@ export const corsMiddleware = (
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, HEAD');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader(
+    'Access-Control-Expose-Headers',
+    'Content-Length, Content-Range, Accept-Ranges'
+  );
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   next();
 };


### PR DESCRIPTION
corsMiddleware sends `Access-Control-Allow-Origin: *` but no `Access-Control-Expose-Headers`, so a page on another origin can read only the safelisted response headers. `Content-Range` and `Accept-Ranges` are not on that list. A web player that reads a content proxy link (`/api/v1/proxy/...`) with `fetch()` and Range requests gets `null` for both, so it cannot learn the size of the file or whether the host seeks. Players that hand the URL to a `<video>` element are not affected. This adds `Access-Control-Expose-Headers: Content-Length, Content-Range, Accept-Ranges` next to the existing four headers.

---

I hit this while building a web player that reads AIOStreams proxy links with `fetch()`. I checked it against a real server: built this branch with and without the change, ran it with `AIOSTREAMS_AUTH` and a `proxy` permission, and pointed a `/api/v1/proxy/u.<auth>.<data>/file.mkv` link at a local origin that answers `206` with `Content-Range: bytes 0-0/1000000`. A page on another origin did `fetch(url, { headers: { Range: 'bytes=0-0' } })`. Without the change Chromium, Firefox and WebKit all read `null` for `Content-Range` and `Accept-Ranges`. With it they read `bytes 0-0/1000000` and `bytes`. `curl` shows the new header on the wire next to the existing four. The middleware has no tests, so I did not add one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Browser clients can now access file size, range, and range-support details in server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
