### PR TITLE
fix(debrid/torbox): align timeoutMs with stremthru

### DIFF
--- a/packages/core/src/debrid/torbox.ts
+++ b/packages/core/src/debrid/torbox.ts
@@ -173,6 +173,7 @@ export class TorboxDebridService
     this.maxWaitTime = options?.maxWaitTime ?? Time.Minute * 2;
     this.torboxApi = new TorboxApi({
       token: config.token,
+      timeoutMs: 30000,
     });
 
     this.stremthru = new StremThruService({


### PR DESCRIPTION
This is a simplified version of https://github.com/Viren070/AIOStreams/pull/1250

StremThru uses 30s for add and 10s for all other requests. Since TorBox supports only one global timeout, going with 30s makes sense I suppose.

The TorBox SDK is only used for usenet debrid actions.

See also https://github.com/Viren070/AIOStreams/blob/e694b6ace7309091289a8680c3f817210e261e46/packages/core/src/debrid/stremthru.ts#L116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout to requests made through the Torbox integration, helping prevent requests from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->