### PR TITLE
fix(builtins/easynews-search): preserve season and episode separators

### DIFF
--- a/packages/core/src/builtins/easynews-search/api.test.ts
+++ b/packages/core/src/builtins/easynews-search/api.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { EasynewsApi, type EasynewsSearchItem } from './api.js';
+import FileParser from '../../parser/file.js';
+
+describe('Easynews filename separators', () => {
+  for (const fixture of [
+    {
+      input: 'Show Name S03 - 09',
+      title: 'Show.Name.S03.-.09.mkv',
+      seasons: [3],
+      episodes: [9],
+    },
+    {
+      input: 'Show Name S03-09',
+      title: 'Show.Name.S03-09.mkv',
+      seasons: [3, 4, 5, 6, 7, 8, 9],
+      episodes: [],
+    },
+    {
+      input: 'Show Name S03E09',
+      title: 'Show.Name.S03E09.mkv',
+      seasons: [3],
+      episodes: [9],
+    },
+  ]) {
+    it(fixture.input, () => {
+      // Exercise the production result parser without an authenticated search.
+      const api = new EasynewsApi('test', 'test') as unknown as {
+        parseItem(raw: unknown): EasynewsSearchItem | null;
+      };
+      const item = api.parseItem({
+        hash: 'test-hash',
+        fn: fixture.input,
+        ext: '.mkv',
+        runtime: 1440,
+      });
+      assert.ok(item);
+      assert.equal(item.title, fixture.title);
+      const parsed = FileParser.parse(item.title);
+      assert.deepEqual(parsed.seasons, fixture.seasons);
+      assert.deepEqual(parsed.episodes ?? [], fixture.episodes);
+    });
+  }
+});

--- a/packages/core/src/builtins/easynews-search/api.ts
+++ b/packages/core/src/builtins/easynews-search/api.ts
@@ -755,7 +755,7 @@ export class EasynewsApi {
     let title: string;
     if (displayFn) {
       const cleaned = displayFn.trim();
-      const sanitized = cleaned.replace(/ - /g, '-').split(' ').join('.');
+      const sanitized = cleaned.split(' ').join('.');
       title = ext.startsWith('.')
         ? `${sanitized}${ext}`
         : `${sanitized}.${ext}`;


### PR DESCRIPTION
## Summary

Fixes Easynews filenames with spaced season and episode separators being incorrectly interpreted as season ranges.

Easynews can return an individual episode formatted like `Show Name S03 - 09`. AIOStreams previously removed the spaces surrounding the hyphen, converting it to `Show.Name.S03-09`.

The parser interprets `S03-09` as a season range covering seasons 3 through 9 rather than season 3, episode 9. This causes the result to be treated as a season pack and can allow the wrong episode through season and episode matching.

This change preserves the separator structure by converting the filename to `Show.Name.S03.-.09`, allowing it to be correctly parsed as season 3, episode 9.

Explicit season ranges already written as `S03-09` remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title formatting in Easynews search results by handling spaced and hyphenated filename separators more consistently.
  * Improved recognition of season and episode information, including `SxxExx` formats.

* **Tests**
  * Added coverage for Easynews filename parsing across spaced, hyphenated, and `SxxExx` episode formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->