### PR TITLE
fix(deduplicator): update mediaInfoQuality on merged languages/subtitles

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -1171,6 +1171,9 @@ export type StreamResponse = z.infer<typeof StreamResponseSchema>;
 
 export type Stream = z.infer<typeof StreamSchema>;
 
+/** Best-to-worst provenance tiers for ParsedFile.mediaInfoQuality. */
+export const MEDIA_INFO_QUALITY_TIERS = ['probe', 'indexer', 'addon'] as const;
+
 export const ParsedFileSchema = z.object({
   releaseGroup: z.string().optional(),
   resolution: z.string().optional(),
@@ -1179,7 +1182,7 @@ export const ParsedFileSchema = z.object({
   audioChannels: z.array(z.string()),
   visualTags: z.array(z.string()),
   audioTags: z.array(z.string()),
-  mediaInfoQuality: z.enum(['probe', 'indexer', 'addon']).optional(),
+  mediaInfoQuality: z.enum(MEDIA_INFO_QUALITY_TIERS).optional(),
   languages: z.array(z.string()),
   subtitles: z.array(z.string()).optional(),
   subbed: z.boolean().optional(),

--- a/packages/core/src/streams/deduplicator.test.ts
+++ b/packages/core/src/streams/deduplicator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import StreamDeduplicator from './deduplicator.js';
+import type { ParsedStream, UserData } from '../db/schemas.js';
+
+function makeStream(
+  mediaInfoQuality: 'probe' | 'indexer' | 'addon' | undefined,
+  languages: string[],
+  subtitles: string[]
+): ParsedStream {
+  return {
+    id: Math.random().toString(),
+    type: 'p2p',
+    parsedFile: {
+      audioChannels: [],
+      visualTags: [],
+      audioTags: [],
+      languages,
+      subtitles,
+      mediaInfoQuality,
+    },
+  } as unknown as ParsedStream;
+}
+
+// Access the private merge method directly to exercise it without
+// standing up a full dedup grouping/winner-selection pipeline.
+function merge(winner: ParsedStream, others: ParsedStream[]) {
+  const dedup = new StreamDeduplicator({} as UserData) as unknown as {
+    mergeLanguagesAndSubtitles: (
+      winner: ParsedStream,
+      others: ParsedStream[],
+      fields: readonly string[]
+    ) => void;
+  };
+  dedup.mergeLanguagesAndSubtitles(winner, others, ['languages', 'subtitles']);
+}
+
+describe('mergeLanguagesAndSubtitles', () => {
+  it('takes only the probe, discarding the indexer entirely', () => {
+    const winner = makeStream(undefined, [], []);
+    const indexerOther = makeStream('indexer', ['English'], ['English']);
+    const probeOther = makeStream('probe', ['French'], ['French']);
+    merge(winner, [indexerOther, probeOther]);
+    assert.deepEqual(winner.parsedFile?.languages, ['French']);
+    assert.deepEqual(winner.parsedFile?.subtitles, ['French']);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, 'probe');
+  });
+
+  it('takes only the indexer, discarding the addon entirely', () => {
+    const winner = makeStream(undefined, [], []);
+    const indexerOther = makeStream('indexer', ['English'], ['English']);
+    const addonOther = makeStream('addon', ['French'], ['French']);
+    merge(winner, [indexerOther, addonOther]);
+    assert.deepEqual(winner.parsedFile?.languages, ['English']);
+    assert.deepEqual(winner.parsedFile?.subtitles, ['English']);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, 'indexer');
+  });
+
+  it('never lets a lower-tier other contaminate a winner already at the best tier', () => {
+    const winner = makeStream('probe', ['English'], ['English']);
+    const other = makeStream('addon', ['French'], ['French']);
+    merge(winner, [other]);
+    assert.deepEqual(winner.parsedFile?.languages, ['English']);
+    assert.deepEqual(winner.parsedFile?.subtitles, ['English']);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, 'probe');
+  });
+
+  it('unions two sources that share the same tier', () => {
+    const winner = makeStream('addon', ['English'], []);
+    const other = makeStream('addon', ['French'], ['French']);
+    merge(winner, [other]);
+    assert.deepEqual(winner.parsedFile?.languages, ['English', 'French']);
+    assert.deepEqual(winner.parsedFile?.subtitles, ['French']);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, 'addon');
+  });
+
+  it('falls back to merging everything when nobody has any tier', () => {
+    const winner = makeStream(undefined, [], []);
+    const other1 = makeStream(undefined, ['English'], []);
+    const other2 = makeStream(undefined, ['French'], ['French']);
+    merge(winner, [other1, other2]);
+    assert.deepEqual(winner.parsedFile?.languages, ['English', 'French']);
+    assert.deepEqual(winner.parsedFile?.subtitles, ['French']);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, undefined);
+  });
+
+  it('any real tier beats a source with no tier at all', () => {
+    const winner = makeStream(undefined, [], []);
+    const addonOther = makeStream('addon', ['English'], []);
+    const unrankedOther = makeStream(undefined, ['French'], ['French']);
+    merge(winner, [addonOther, unrankedOther]);
+    assert.deepEqual(winner.parsedFile?.languages, ['English']);
+    assert.deepEqual(winner.parsedFile?.subtitles, []);
+    assert.equal(winner.parsedFile?.mediaInfoQuality, 'addon');
+  });
+});

--- a/packages/core/src/streams/deduplicator.ts
+++ b/packages/core/src/streams/deduplicator.ts
@@ -1,4 +1,8 @@
-import { ParsedStream, UserData } from '../db/schemas.js';
+import {
+  MEDIA_INFO_QUALITY_TIERS,
+  ParsedStream,
+  UserData,
+} from '../db/schemas.js';
 import {
   createLogger,
   DSU,
@@ -596,8 +600,9 @@ class StreamDeduplicator {
   }
 
   /**
-   * Accuracy-aware merge of parsed `languages`/`subtitles` plus actual subtitle
-   * tracks.
+   * Merge parsed `languages`/`subtitles` plus actual subtitle tracks from
+   * sources at the best mediaInfoQuality tier present, discarding lower
+   * tiers. If nobody has a tier, merges everything as a best effort.
    */
   private mergeLanguagesAndSubtitles(
     winner: ParsedStream,
@@ -605,12 +610,10 @@ class StreamDeduplicator {
     fields: readonly string[]
   ): void {
     const sources = [winner, ...others].filter((s) => s.parsedFile);
-    const accurate = sources.filter(
-      (s) =>
-        (s.parsedFile?.languages?.length ?? 0) > 0 &&
-        (s.parsedFile?.subtitles?.length ?? 0) > 0
-    );
-    const pool = accurate.length > 0 ? accurate : sources;
+    const bestTier = this.bestMediaInfoQualityTier(sources);
+    const pool = bestTier
+      ? sources.filter((s) => s.parsedFile?.mediaInfoQuality === bestTier)
+      : sources;
 
     if (winner.parsedFile) {
       if (fields.includes('languages')) {
@@ -624,6 +627,10 @@ class StreamDeduplicator {
           [],
           pool.flatMap((s) => s.parsedFile?.subtitles ?? [])
         );
+      }
+
+      if (bestTier && bestTier !== winner.parsedFile.mediaInfoQuality) {
+        winner.parsedFile.mediaInfoQuality = bestTier;
       }
     }
 
@@ -642,6 +649,26 @@ class StreamDeduplicator {
       }
       if (merged.length > 0) winner.subtitles = merged;
     }
+  }
+
+  /** Rank of a mediaInfoQuality tier; unranked (undefined) is the lowest rung. */
+  private mediaInfoQualityRank(q?: string): number {
+    const i = MEDIA_INFO_QUALITY_TIERS.indexOf(q as never);
+    return i === -1 ? MEDIA_INFO_QUALITY_TIERS.length : i;
+  }
+
+  /** Best mediaInfoQuality tier present among `sources`, if any. */
+  private bestMediaInfoQualityTier(
+    sources: ParsedStream[]
+  ): (typeof MEDIA_INFO_QUALITY_TIERS)[number] | undefined {
+    return sources.reduce<(typeof MEDIA_INFO_QUALITY_TIERS)[number] | undefined>(
+      (best, s) =>
+        this.mediaInfoQualityRank(s.parsedFile?.mediaInfoQuality) <
+        this.mediaInfoQualityRank(best)
+          ? s.parsedFile?.mediaInfoQuality
+          : best,
+      undefined
+    );
   }
 }
 


### PR DESCRIPTION
Merging languages/subtitles from discarded duplicates into the dedup winner never updated its mediaInfoQuality, so the winner kept showing stale/unknown provenance even after real probed data was merged in.

Behaviour change: the merge itself now prefers the best mediaInfoQuality tier present (probe > indexer > addon) and takes that source's data wholesale, instead of blending languages/subtitles from sources of differing accuracy together.

fyi @Tam-Taro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate stream handling by selecting language and subtitle information from the highest-quality available source.
  * Prevented lower-quality metadata from overriding or contaminating higher-quality results.
  * Improved merging of information from sources with equal quality, while retaining sensible fallback behaviour when quality information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->