### PR TITLE
fix(anime): recover known bare absolute episodes before filtering

### DIFF
--- a/packages/core/src/parser/bare-anime-episode.test.ts
+++ b/packages/core/src/parser/bare-anime-episode.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { reconcileBareAnimeEpisode } from './utils.js';
+
+describe('bare absolute anime episode recovery', () => {
+  it('recovers a known absolute episode and preserves other parsed fields', () => {
+    const parsed = {
+      title: 'Example Anime 159',
+      seasonPack: true,
+      resolution: '1080p',
+    };
+    assert.deepEqual(
+      reconcileBareAnimeEpisode(parsed, ['Example Anime'], [159]),
+      {
+        ...parsed,
+        title: 'Example Anime',
+        episodes: [159],
+        seasonPack: false,
+      }
+    );
+    assert.equal(parsed.title, 'Example Anime 159');
+  });
+  it('accepts normalized aliases, leading zeros, versions, and relative absolute numbering', () => {
+    assert.deepEqual(
+      reconcileBareAnimeEpisode(
+        { title: 'EXAMPLE: Anime 0159v2' },
+        ['Example Anime'],
+        [300, 159]
+      ),
+      { title: 'EXAMPLE: Anime', episodes: [159], seasonPack: false }
+    );
+  });
+  for (const fixture of [
+    { title: 'Example Anime 158', expected: 159 },
+    { title: 'Different Anime 159', expected: 159 },
+    { title: 'Example Anime 1.5', expected: 1.5 },
+    { title: 'Example Anime 0', expected: 0 },
+    { title: 'Example Anime 2020', expected: 2020 },
+    { title: 'Example Anime 1080', expected: 1080 },
+    { title: 'Example Anime 159', expected: undefined },
+  ]) {
+    it(`does not recover ambiguous or unrequested ${fixture.title} (${fixture.expected})`, () => {
+      const parsed = { title: fixture.title };
+      assert.equal(
+        reconcileBareAnimeEpisode(
+          parsed,
+          ['Example Anime'],
+          [fixture.expected]
+        ),
+        parsed
+      );
+    });
+  }
+  it('keeps numeric titles intact when the complete title is a known alias', () => {
+    const parsed = { title: 'Example Anime 159' };
+    assert.equal(
+      reconcileBareAnimeEpisode(
+        parsed,
+        ['Example Anime', 'Example Anime 159'],
+        [159]
+      ),
+      parsed
+    );
+  });
+  for (const coordinates of [{ seasons: [2] }, { episodes: [158] }]) {
+    it(`does not override parsed ${Object.keys(coordinates)[0]}`, () => {
+      const parsed = { title: 'Example Anime 159', ...coordinates };
+      assert.equal(
+        reconcileBareAnimeEpisode(parsed, ['Example Anime'], [159]),
+        parsed
+      );
+    });
+  }
+});

--- a/packages/core/src/parser/utils.ts
+++ b/packages/core/src/parser/utils.ts
@@ -251,6 +251,43 @@ export function reconcileParsedName(
   };
 }
 
+export function reconcileBareAnimeEpisode<
+  T extends {
+    title?: string;
+    seasons?: number[];
+    episodes?: number[];
+    seasonPack?: boolean;
+  },
+>(parsed: T, titles: string[], absoluteEpisodes: (number | undefined)[]): T {
+  if (!parsed.title || parsed.seasons?.length || parsed.episodes?.length) {
+    return parsed;
+  }
+
+  const match = parsed.title.match(/^(.+?)\s+(\d{1,4})(?:v\d+)?$/i);
+  if (!match) return parsed;
+
+  const episode = Number(match[2]);
+  if (
+    episode < 1 ||
+    !absoluteEpisodes.includes(episode) ||
+    (episode >= 1900 && episode <= 2099) ||
+    [240, 360, 480, 576, 720, 1080, 1440, 2160, 4320].includes(episode)
+  ) {
+    return parsed;
+  }
+
+  const index = getTitleIndex(titles);
+  const known = (index.normalised ??= new Set(titles.map(normaliseTitle)));
+  if (
+    known.has(normaliseTitle(parsed.title)) ||
+    !known.has(normaliseTitle(match[1]))
+  ) {
+    return parsed;
+  }
+
+  return { ...parsed, title: match[1], episodes: [episode], seasonPack: false };
+}
+
 export function preprocessTitle(
   parsedTitle: string,
   names: (string | undefined)[],

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -22,6 +22,7 @@ import {
   normaliseTitle,
   preprocessTitle,
   reconcileParsedName,
+  reconcileBareAnimeEpisode,
   titleMatchWithLang,
 } from '../parser/utils.js';
 import { normaliseCountryCode } from '../utils/countries.js';
@@ -467,6 +468,16 @@ class StreamFilterer {
         );
         stream.parsedFile.title = reconciled.title;
         stream.parsedFile.year = reconciled.year;
+        if (isAnime && type === 'series') {
+          stream.parsedFile = reconcileBareAnimeEpisode(
+            stream.parsedFile,
+            requestedTitleStrings,
+            [
+              requestedMetadata?.absoluteEpisode,
+              requestedMetadata?.relativeAbsoluteEpisode,
+            ]
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes valid anime releases with bare absolute episode numbers being rejected by strict season/episode matching.

AIOStreams already searches anime using absolute episode numbers, but filenames such as `Show Name 159` can be parsed with `159` included in the title and no episode information. Strict matching then rejects the result, even when episode 159 was requested.

This change recovers the episode number before filtering when:
- The request is an anime series.
- No season or episode has already been parsed.
- The trailing number matches the requested absolute or relative-absolute episode.
- The remaining title exactly matches a known metadata alias after normalization.
- The complete title, including the number, is not itself a known alias.

Ambiguous year and resolution numbers are excluded. Recovered results continue through the normal filters without weakening strict matching.

Recovery runs in the shared filtering path for anime series and only applies when no season or episode has already been parsed.

## Validation

- Confirmed three previously rejected bare-number releases survive strict episode matching in a live request.
- Confirmed incorrect episodes remain rejected.
- Checked conflicting seasons, fractional numbers, numeric titles, and year/resolution safeguards.
- TypeScript compilation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved anime episode detection when episode numbers are embedded directly in titles.
  - Recognises valid absolute episode numbers while avoiding resolution, year-like, and already-structured season or episode data.
  - Improves filtering accuracy for anime series with bare episode titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->