### PR TITLE
fix(anime-database): preserve IMDb identity for episode mappings

### DIFF
--- a/packages/core/src/anime-database/merger.test.ts
+++ b/packages/core/src/anime-database/merger.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeSources } from './merger.js';
+import type { SourceEntry } from './types.js';
+
+function merge(...entries: SourceEntry[]) {
+  return mergeSources(
+    entries.map((entry, index) => ({
+      sourceId: `source-${index}`,
+      entries: [entry],
+    }))
+  )[0]!;
+}
+
+describe('IMDb mapping identity', () => {
+  it('preserves paired hints and ID while still merging other IDs', () => {
+    const record = merge(
+      {
+        ids: { kitsuId: 48015, imdbId: 'tt14986406' },
+        imdb: { fromSeason: 3, fromEpisode: 1 },
+      },
+      {
+        ids: { kitsuId: 48015, imdbId: 'tt0434665', thetvdbId: 74796 },
+      }
+    );
+    assert.equal(record.ids.imdbId, 'tt14986406');
+    assert.deepEqual(record.imdb, { fromSeason: 3, fromEpisode: 1 });
+    assert.equal(record.ids.thetvdbId, 74796);
+  });
+
+  it('does not replace a paired mapping with an empty hint object', () => {
+    const record = merge(
+      {
+        ids: { kitsuId: 1, imdbId: 'tt1' },
+        imdb: { fromSeason: 3, fromEpisode: 1 },
+      },
+      { ids: { kitsuId: 1, imdbId: 'tt2' }, imdb: {} }
+    );
+    assert.equal(record.ids.imdbId, 'tt1');
+    assert.deepEqual(record.imdb, { fromSeason: 3, fromEpisode: 1 });
+  });
+
+  it('replaces hints cleanly when a different ID supplies a mapping', () => {
+    const record = merge(
+      {
+        ids: { kitsuId: 1, imdbId: 'tt1' },
+        imdb: {
+          fromSeason: 3,
+          fromEpisode: 14,
+          title: 'Old',
+          nonImdbEpisodes: [2],
+        },
+      },
+      {
+        ids: { kitsuId: 1, imdbId: 'tt2' },
+        imdb: { fromSeason: 1 },
+      }
+    );
+    assert.equal(record.ids.imdbId, 'tt2');
+    assert.deepEqual(record.imdb, { fromSeason: 1 });
+  });
+
+  it('continues to merge partial hints for the same ID', () => {
+    const record = merge(
+      {
+        ids: { kitsuId: 1, imdbId: 'tt1' },
+        imdb: { fromSeason: 3, fromEpisode: 1 },
+      },
+      { ids: { kitsuId: 1, imdbId: 'tt1' }, imdb: { fromEpisode: 14 } }
+    );
+    assert.deepEqual(record.imdb, { fromSeason: 3, fromEpisode: 14 });
+  });
+
+  it('retains last-writer-wins for IDs without hints', () => {
+    const record = merge(
+      { ids: { kitsuId: 1, imdbId: 'tt1' } },
+      { ids: { kitsuId: 1, imdbId: 'tt2' } }
+    );
+    assert.equal(record.ids.imdbId, 'tt2');
+    assert.equal(record.imdb, undefined);
+  });
+});

--- a/packages/core/src/anime-database/merger.ts
+++ b/packages/core/src/anime-database/merger.ts
@@ -145,6 +145,16 @@ function foldEntry(record: AnimeRecord, entry: SourceEntry): void {
     [IdType, IdValue | undefined]
   >) {
     if (v === undefined || v === null || v === ('' as unknown)) continue;
+    if (k === 'imdbId' && record.ids.imdbId && record.ids.imdbId !== v) {
+      const hasIncomingHints =
+        entry.imdb && Object.values(entry.imdb).some((hint) => hint != null);
+      // Keep IMDb hints paired with the show they describe. A show-level ID
+      // from another source must not reassign a cour's season/episode mapping.
+      if (record.imdb && !hasIncomingHints) continue;
+      // A replacement mapping belongs to a different show; do not inherit
+      // omitted offsets, titles or episode exclusions from the previous one.
+      delete record.imdb;
+    }
     // Last-writer-wins per field; sources later in the registry win.
     record.ids[k] = v;
   }


### PR DESCRIPTION
## Summary

Keeps IMDb IDs paired with their associated season and episode mappings when merging anime database sources.

Previously, a later source could overwrite a record’s IMDb ID without supplying replacement mapping hints. This left season offsets and other hints from a different IMDb show attached to the new ID, causing incorrect anime selection and episode searches.

For example, a Bleach S15E06 lookup could select a Thousand-Year Blood War record and search for both absolute episode 322 and an incorrectly calculated episode 281.

## Changes

* Preserve the existing IMDb ID when it has mapping hints and a conflicting incoming ID supplies no populated replacement hints.
* Treat an empty incoming hint object as missing replacement hints.
* Clear previous hints when accepting a different IMDb ID with a replacement mapping, preventing omitted fields from carrying over.
* Preserve partial hint merging for the same IMDb ID and existing precedence for other IDs.

## Validation

Five automated regression tests pass, covering:

* Preservation of paired IMDb IDs and hints.
* Conflicting IDs with empty incoming hints.
* Clean replacement of hints when the IMDb ID changes.
* Partial hint updates for the same IMDb ID.
* Last-writer precedence when no mapping hints exist.

A previously performed live Bleach S15E06 lookup confirmed that the incorrect episode 281 search disappears after rebuilding the anime database.

## Upgrade note

Run **Dashboard → Tasks → Rebuild anime database** after upgrading to apply the correction immediately to existing stored records.
