### PR TITLE
fix(anime): reconcile season-tagged absolute episode numbers

### DIFF
--- a/packages/core/src/parser/anime-season-episode.test.ts
+++ b/packages/core/src/parser/anime-season-episode.test.ts
@@ -1,0 +1,199 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTorrentTitle } from '@viren070/parse-torrent-title';
+import {
+  getAnimeSeasonEpisodeMapping,
+  reconcileAnimeSeasonEpisode,
+} from './anime-season-episode.js';
+import type { ExtendedMetadata } from '../streams/context.js';
+
+export const conanMetadata: ExtendedMetadata = {
+  title: 'Detective Conan',
+  titles: [{ title: 'Detective Conan' }],
+  absoluteEpisode: 233,
+  resolvedSeasonNumber: 9,
+  resolvedSeasonFirstEpisode: 1,
+  seasons: [28, 26, 28, 24, 28, 28, 31, 26, 35, 31].map(
+    (episode_count, index) => ({ season_number: index + 1, episode_count })
+  ),
+};
+
+describe('anime season + absolute episode reconciliation', () => {
+  const mapping = getAnimeSeasonEpisodeMapping(9, 14, conanMetadata)!;
+
+  for (const token of [
+    '233',
+    '0233',
+    'E233',
+    'e0233',
+    '- 233',
+    '.-.233',
+    '233v2',
+  ]) {
+    it(`maps S09 ${token} to S09E14 using the real parser`, () => {
+      const filename = `Detective Conan (2001) S09 ${token}.mkv`;
+      const parsed = Object.freeze(parseTorrentTitle(filename));
+      const before = structuredClone(parsed);
+      const result = reconcileAnimeSeasonEpisode(parsed, filename, mapping);
+      assert.deepEqual(result.seasons, [9]);
+      assert.deepEqual(result.episodes, [14]);
+      assert.equal(result.seasonPack, false);
+      assert.deepEqual(parsed, before);
+    });
+  }
+
+  it('handles adjoining E notation', () => {
+    const filename = 'Detective.Conan.S09E233.1080p.mkv';
+    assert.deepEqual(
+      reconcileAnimeSeasonEpisode(
+        parseTorrentTitle(filename),
+        filename,
+        mapping
+      ).episodes,
+      [14]
+    );
+  });
+
+  it('allows hyphen-separated quality suffixes after absolute episodes', () => {
+    for (const token of ['233', 'E233']) {
+      for (const quality of ['1080p', '720p', '10bit']) {
+        const filename = `Detective Conan S09 ${token} - ${quality}.mkv`;
+        assert.deepEqual(
+          reconcileAnimeSeasonEpisode(
+            parseTorrentTitle(filename),
+            filename,
+            mapping
+          ).episodes,
+          [14],
+          filename
+        );
+      }
+    }
+  });
+
+  it('preserves numeric continuations even when the parser extracts only one episode', () => {
+    for (const tail of [
+      ' - 234',
+      ' - 234v2',
+      '+234',
+      ',234',
+      ' E234v2',
+      '.5',
+      '-0306-16',
+    ]) {
+      const filename = `Detective Conan S09 E233${tail}.mkv`;
+      const parsed = { seasons: [9], episodes: [233] };
+      assert.equal(
+        reconcileAnimeSeasonEpisode(parsed, filename, mapping),
+        parsed,
+        filename
+      );
+    }
+  });
+
+  it('recovers wrong bare episodes as their actual relative episodes', () => {
+    for (const [absolute, relative] of [
+      [236, 17],
+      [252, 33],
+    ]) {
+      const filename = `Detective Conan (2001) S09 0${absolute}.mkv`;
+      assert.deepEqual(
+        reconcileAnimeSeasonEpisode(
+          parseTorrentTitle(filename),
+          filename,
+          mapping
+        ).episodes,
+        [relative]
+      );
+    }
+  });
+
+  for (const token of [
+    'S09',
+    'S09E14',
+    'S09E15',
+    'S08 E233',
+    'S09-13',
+    'S09-233',
+    'S09 E233-E234',
+    'S09 233-234',
+    'S09 233.5',
+    'S09 233v2.5',
+    'S09 233+234',
+    'S09 233,234',
+    'S09 233 234',
+    'S09 E233E234',
+    'S09 240',
+    'S09 1080p',
+    'S09 2001',
+    'S09 999',
+    'S09 233 S10E1',
+  ]) {
+    it(`preserves ambiguous, conflicting or unrelated ${token}`, () => {
+      const filename = `Detective Conan ${token}.mkv`;
+      const parsed = parseTorrentTitle(filename);
+      assert.equal(
+        reconcileAnimeSeasonEpisode(parsed, filename, mapping),
+        parsed
+      );
+    });
+  }
+
+  it('does not use a parent folder to identify an unnamed file', () => {
+    const filename = 'Detective Conan S09 233/unknown.mkv';
+    const parsed = { seasons: [9] };
+    assert.equal(
+      reconcileAnimeSeasonEpisode(parsed, filename, mapping),
+      parsed
+    );
+  });
+
+  it('preserves a valid local E45 when absolute 45 would mean E5', () => {
+    const metadata = {
+      ...conanMetadata,
+      absoluteEpisode: 45,
+      resolvedSeasonNumber: 3,
+      seasons: [20, 20, 50, 12].map((episode_count, i) => ({
+        season_number: i + 1,
+        episode_count,
+      })),
+    };
+    const overlap = getAnimeSeasonEpisodeMapping(3, 5, metadata);
+    assert.ok(overlap);
+    for (const token of ['E45', '45', '045']) {
+      const filename = `Show S03 ${token}.mkv`;
+      const parsed = parseTorrentTitle(filename);
+      assert.equal(
+        reconcileAnimeSeasonEpisode(parsed, filename, overlap),
+        parsed
+      );
+    }
+  });
+
+  it('requires complete, consistent and historical season metadata', () => {
+    for (const patch of [
+      { seasons: undefined },
+      { seasons: conanMetadata.seasons!.filter((s) => s.season_number !== 4) },
+      { seasons: [...conanMetadata.seasons!, conanMetadata.seasons![0]] },
+      {
+        seasons: conanMetadata.seasons!.map((s) => ({
+          ...s,
+          episode_count: 0,
+        })),
+      },
+      { seasons: conanMetadata.seasons!.slice(0, 9) },
+      { absoluteEpisode: 234 },
+      { resolvedSeasonFirstEpisode: 220 },
+      { resolvedSeasonFirstEpisode: undefined },
+      { resolvedSeasonNumber: 1 },
+      { isDateBased: true },
+    ]) {
+      assert.equal(
+        getAnimeSeasonEpisodeMapping(9, 14, { ...conanMetadata, ...patch }),
+        undefined
+      );
+    }
+    assert.equal(getAnimeSeasonEpisodeMapping(9, 36, conanMetadata), undefined);
+    assert.equal(getAnimeSeasonEpisodeMapping(0, 14, conanMetadata), undefined);
+  });
+});

--- a/packages/core/src/parser/anime-season-episode.ts
+++ b/packages/core/src/parser/anime-season-episode.ts
@@ -1,0 +1,153 @@
+import type { ExtendedMetadata } from '../streams/context.js';
+
+interface SeasonEpisodeMapping {
+  season: number;
+  episodeCount: number;
+  offset: number;
+}
+
+/** Only infer absolute numbering from a complete, consistent historical season. */
+export function getAnimeSeasonEpisodeMapping(
+  season: number,
+  episode: number,
+  metadata: ExtendedMetadata | undefined
+): SeasonEpisodeMapping | undefined {
+  if (
+    !Number.isInteger(season) ||
+    season <= 1 ||
+    !Number.isInteger(episode) ||
+    episode < 1 ||
+    !metadata?.seasons ||
+    metadata.isDateBased ||
+    metadata.resolvedSeasonNumber !== season ||
+    metadata.resolvedSeasonFirstEpisode !== 1
+  )
+    return undefined;
+
+  // A current season's episode count may still be growing. Do not use it to
+  // rule out season-relative numbering; require a later populated season.
+  // This is a metadata-based safeguard, not verification of episode air dates.
+  if (
+    !metadata.seasons.some(
+      (s) => s.season_number > season && s.episode_count > 0
+    )
+  ) {
+    return undefined;
+  }
+
+  let offset = 0;
+  let episodeCount = 0;
+  for (let number = 1; number <= season; number++) {
+    const records = metadata.seasons.filter((s) => s.season_number === number);
+    if (records.length !== 1) return undefined;
+    const count = records[0].episode_count;
+    if (!Number.isInteger(count) || count <= 0) return undefined;
+    if (number < season) offset += count;
+    else episodeCount = count;
+  }
+
+  // Reject incomplete/alternate numbering, including adjusted absolute offsets.
+  // This checks consistency with the request's coordinate, not an independent
+  // metadata source; both calculations can share the same season counts.
+  if (episode > episodeCount || metadata.absoluteEpisode !== offset + episode) {
+    return undefined;
+  }
+  return { season, episodeCount, offset };
+}
+
+/**
+ * Convert an unambiguous season + absolute episode into season-relative data.
+ * Recover wrong episodes too, so the ordinary matcher can reject them.
+ * Never mutate the shared filename-parser cache.
+ * Runs as normalization before filters/expressions, even when episode matching
+ * is disabled. The matching settings still control whether results are rejected.
+ */
+export function reconcileAnimeSeasonEpisode<
+  T extends {
+    seasons?: number[];
+    episodes?: number[];
+    seasonPack?: boolean;
+    date?: string;
+  },
+>(
+  parsed: T,
+  filename: string | undefined,
+  mapping: SeasonEpisodeMapping | undefined
+): T {
+  if (
+    !mapping ||
+    parsed.date ||
+    parsed.seasons?.length !== 1 ||
+    parsed.seasons[0] !== mapping.season ||
+    (parsed.episodes?.length ?? 0) > 1
+  )
+    return parsed;
+
+  const normalizeAbsolute = (absoluteEpisode: number): T => {
+    // Conservative tradeoff: real episodes numbered 240, 720, etc. also skip
+    // reconciliation (including parsed E notation). Preserve existing behavior
+    // rather than risk treating a year/resolution as an episode coordinate.
+    if (
+      !Number.isInteger(absoluteEpisode) ||
+      (absoluteEpisode >= 1900 && absoluteEpisode <= 2099) ||
+      [240, 360, 480, 576, 720, 1080, 1440, 2160, 4320].includes(
+        absoluteEpisode
+      ) ||
+      absoluteEpisode <= mapping.episodeCount ||
+      absoluteEpisode <= mapping.offset ||
+      absoluteEpisode > mapping.offset + mapping.episodeCount
+    )
+      return parsed;
+    return {
+      ...parsed,
+      episodes: [absoluteEpisode - mapping.offset],
+      seasonPack: false,
+    };
+  };
+
+  const leaf = filename?.split(/[\\/]/).pop();
+  // The parser can truncate fractional episodes, so preserve raw continuation
+  // evidence even when it has already extracted a single integer episode.
+  // After the episode and optional version, reject tails such as ".5"
+  // (305.5 or 305v2.5), "-0306-16", "+306" and " E306".
+  // Bound numeric continuations so quality suffixes such as "- 1080p"
+  // and "- 10bit" are allowed, while "- 306v2" remains a continuation.
+  const isContinuation =
+    /^(?:\.\d+(?:v\d+)?(?=$|[^\p{L}\p{N}])|[ ._]*(?:[-+&,/]|to\b)[ ._]*(?:e[ ._]*)?\d+(?:v\d+)?(?=$|[^\p{L}\p{N}])|[ ._]+e\d+(?:v\d+)?(?=$|[^\p{L}\p{N}])|[ ._]+\d+(?=$|[ ._-]))/iu;
+  if (parsed.episodes?.length === 1) {
+    const episode = parsed.episodes[0];
+    if (!Number.isInteger(episode)) return parsed;
+    if (leaf) {
+      const tokens = leaf.matchAll(
+        new RegExp(
+          `(?:^|[^\\d])0*${episode}(?:v\\d+)?(?=$|[^\\p{L}\\p{N}])`,
+          'giu'
+        )
+      );
+      for (const token of tokens) {
+        if (isContinuation.test(leaf.slice(token.index! + token[0].length)))
+          return parsed;
+      }
+    }
+    // Parsed coordinates are independent of spelling (EP305, 11x305, etc.).
+    // Only missing episode numbers require the narrow raw-filename recovery.
+    return normalizeAbsolute(episode);
+  }
+  if (!leaf) return parsed;
+
+  // Inspect the leaf filename only. Preserve multi-season packs and ranges.
+  const matches = [
+    ...leaf.matchAll(
+      /(?:^|[^\p{L}\p{N}])S(\d{1,3})(?:[ ._-]*E[ ._-]*|[ ._]+(?:-[ ._]*)?|-[ ._]*)(\d{1,4})(?:v\d+)?(?=$|[^\p{L}\p{N}])/giu
+    ),
+  ];
+  if (matches.length !== 1) return parsed;
+  const match = matches[0];
+  const season = Number(match[1]);
+  const absoluteEpisode = Number(match[2]);
+  const tail = leaf.slice(match.index! + match[0].length);
+  if (isContinuation.test(tail) || season !== mapping.season) return parsed;
+
+  // Bare years and resolutions are excluded by the shared numeric safeguards.
+  return normalizeAbsolute(absoluteEpisode);
+}

--- a/packages/core/src/streams/filterer.anime-season-episode.test.ts
+++ b/packages/core/src/streams/filterer.anime-season-episode.test.ts
@@ -1,0 +1,174 @@
+import { before, after, describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import StreamFilterer from './filterer.js';
+import FileParser from '../parser/file.js';
+import type { StreamContext, ExtendedMetadata } from './context.js';
+import type { ParsedStream, UserData } from '../db/schemas.js';
+import { settingsStore } from '../config/index.js';
+import { SettingsRepository } from '../db/repositories/settings.js';
+import { ReleaseBlocklistRepository } from '../db/repositories/release-blocklist.js';
+import { RegexAccess } from '../utils/regex-access.js';
+
+before(async () => {
+  mock.method(SettingsRepository, 'getAll', async () => []);
+  mock.method(SettingsRepository, 'getVersion', async () => 0);
+  mock.method(ReleaseBlocklistRepository, 'hasEntries', async () => false);
+  mock.method(RegexAccess, 'isRegexAllowed', async () => true);
+  await settingsStore.initialise();
+});
+after(() => mock.restoreAll());
+
+const seasons = [28, 26, 28, 24, 28, 28, 31, 26, 35, 31].map(
+  (episode_count, index) => ({ season_number: index + 1, episode_count })
+);
+
+function makeContext(
+  episode: number,
+  options: { isAnime?: boolean; metadata?: Partial<ExtendedMetadata> } = {}
+) {
+  const metadata: ExtendedMetadata = {
+    title: 'Detective Conan',
+    titles: [{ title: 'Detective Conan' }],
+    seasons,
+    absoluteEpisode: 219 + episode,
+    resolvedSeasonNumber: 9,
+    resolvedSeasonFirstEpisode: 1,
+    ...options.metadata,
+  };
+  return {
+    type: 'series',
+    id: `tt0131179:9:${episode}`,
+    parsedId: {
+      type: 'imdbId',
+      value: 'tt0131179',
+      season: '9',
+      episode: String(episode),
+    },
+    isAnime: options.isAnime ?? true,
+    animeEntry: null,
+    getMetadata: async () => metadata,
+    getReleaseDates: async () => undefined,
+    getEpisodeAirDate: async () => undefined,
+    getEpisodeRuntime: async () => undefined,
+    toExpressionContext: () => ({ type: 'series', isAnime: true }),
+  } as unknown as StreamContext;
+}
+
+function makeStream(token: string): ParsedStream {
+  const filename = `Detective Conan (2001) ${token}.mkv`;
+  return {
+    id: token,
+    type: 'usenet',
+    filename,
+    parsedFile: FileParser.parse(filename),
+    addon: { name: 'Test', preset: { id: 'test' } },
+  } as ParsedStream;
+}
+
+function makeFilterer() {
+  return new StreamFilterer({
+    seasonEpisodeMatching: { enabled: true, strict: true },
+    titleMatching: { enabled: true, strict: true },
+  } as unknown as UserData);
+}
+
+describe('strict filtering of anime season + absolute episode filenames', () => {
+  it('handles S11 absolute 305 independently of the parsed filename spelling', async () => {
+    const context = makeContext(20, {
+      metadata: {
+        absoluteEpisode: 305,
+        resolvedSeasonNumber: 11,
+        seasons: [
+          ...seasons,
+          { season_number: 11, episode_count: 30 },
+          { season_number: 12, episode_count: 38 },
+        ],
+      },
+    });
+    context.parsedId!.season = '11';
+    const matching = [
+      'S11E305',
+      'S11 EP305',
+      '11x305',
+      'Season 11 Episode 305',
+      'S11 0305',
+      'S11E20',
+    ];
+    const wrong = [
+      'S11E306',
+      'S11 0306',
+      'S11E305.5',
+      'S11 E305v2.5',
+      'S11 EP305.5',
+      '11x305.5',
+    ];
+    const result = await makeFilterer().filter(
+      [...matching, ...wrong].map(makeStream),
+      context
+    );
+    assert.deepEqual(
+      result.map((s) => s.id),
+      matching
+    );
+  });
+
+  for (const episode of [14, 24]) {
+    it(`keeps the requested S09E${episode} and rejects 236/252 without expressions`, async () => {
+      const absolute = 219 + episode;
+      const matching = [
+        `S09 E${absolute}`,
+        `S09 0${absolute}`,
+        `S09.-.${absolute}`,
+        `S09E${episode}`,
+      ];
+      const streams = [
+        ...matching,
+        'S09 0236',
+        'S09 0252',
+        'S08 E233',
+        'S09',
+      ].map(makeStream);
+      const filterer = makeFilterer();
+      const context = makeContext(episode);
+      const result = await filterer.filter(streams, context);
+      assert.deepEqual(
+        result.map((s) => s.id),
+        [...matching, 'S09']
+      );
+      // Filtering the same objects again must retain the normalized coordinates.
+      assert.deepEqual(
+        (await filterer.filter(result, context)).map((s) => s.id),
+        [...matching, 'S09']
+      );
+    });
+  }
+
+  it('does not enable the new absolute interpretation for non-anime', async () => {
+    const result = await makeFilterer().filter(
+      [makeStream('S09E233')],
+      makeContext(14, { isAnime: false })
+    );
+    assert.equal(result.length, 0);
+  });
+
+  it('preserves local numbering when both E45 interpretations are possible', async () => {
+    const context = makeContext(5, {
+      metadata: {
+        absoluteEpisode: 45,
+        resolvedSeasonNumber: 3,
+        seasons: [20, 20, 50, 12].map((episode_count, i) => ({
+          season_number: i + 1,
+          episode_count,
+        })),
+      },
+    });
+    context.parsedId!.season = '3';
+    const stream = makeStream('S03E45');
+    assert.equal((await makeFilterer().filter([stream], context)).length, 0);
+    context.parsedId!.episode = '45';
+    assert.equal(
+      (await makeFilterer().filter([makeStream('S03E45')], context)).length,
+      1
+    );
+  });
+});

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -30,6 +30,10 @@ import { formatBitrate, formatBytes } from '../formatters/utils.js';
 import { iso6391ToLanguage, languageToCode } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
 import { StreamContext, ExtendedMetadata } from './context.js';
+import {
+  getAnimeSeasonEpisodeMapping,
+  reconcileAnimeSeasonEpisode,
+} from '../parser/anime-season-episode.js';
 
 const logger = createLogger('filterer');
 
@@ -467,6 +471,37 @@ class StreamFilterer {
         );
         stream.parsedFile.title = reconciled.title;
         stream.parsedFile.year = reconciled.year;
+      }
+    }
+
+    const animeSeasonMapping =
+      isAnime &&
+      type === 'series' &&
+      !context.animeEntry?.imdb?.nonImdbEpisodes?.length
+        ? getAnimeSeasonEpisodeMapping(
+            Number(parsedId?.season),
+            Number(parsedId?.episode),
+            requestedMetadata
+          )
+        : undefined;
+    if (animeSeasonMapping) {
+      for (const stream of streams) {
+        if (!stream.parsedFile) continue;
+        const reconciled = reconcileAnimeSeasonEpisode(
+          stream.parsedFile,
+          stream.filename,
+          animeSeasonMapping
+        );
+        if (reconciled !== stream.parsedFile) {
+          logger.debug('Reconciled anime season/absolute episode filename', {
+            filename: stream.filename,
+            season: reconciled.seasons?.[0],
+            episode: reconciled.episodes?.[0],
+            absoluteEpisode:
+              reconciled.episodes![0] + animeSeasonMapping.offset,
+          });
+          stream.parsedFile = reconciled;
+        }
       }
     }
 
@@ -2231,6 +2266,22 @@ class StreamFilterer {
           const pad = (n: number) => n.toString().padStart(2, '0');
           const s = stream.parsedFile?.seasons;
           const e = stream.parsedFile?.episodes;
+          if (
+            isAnime &&
+            requestedMetadata?.absoluteEpisode &&
+            s?.includes(Number(parsedId?.season)) &&
+            e?.includes(requestedMetadata.absoluteEpisode)
+          ) {
+            logger.debug('Rejected anime season/absolute episode candidate', {
+              filename: stream.filename,
+              folderName: stream.folderName,
+              seasons: s,
+              episodes: e,
+              requestedEpisode: Number(parsedId?.episode),
+              absoluteEpisode: requestedMetadata.absoluteEpisode,
+              hasSeasonMapping: !!animeSeasonMapping,
+            });
+          }
           const formattedSeasonString = s?.length
             ? `S${pad(s[0])}${s.length > 1 ? `-${pad(s[s.length - 1])}` : ''}`
             : undefined;


### PR DESCRIPTION
Some anime releases combine a season tag with an absolute episode number. For example, Detective Conan `S09 E233` represents S09E14. Existing absolute-episode fallback matching does not cover this season-tagged case, while bare forms such as `S09 0233` can be interpreted as season-only releases.

This PR reconciles unambiguous season-tagged absolute numbers into season-relative episodes before filtering. Correct episodes can pass matching, and incorrect episodes receive their actual relative number so existing matching filters can reject them.

* Uses existing season metadata and requires the calculated offset to agree with the requested absolute episode.
* Handles parsed episode coordinates and narrowly recovers missing numbers from filenames.
* Preserves shared parser results without mutation.
* Leaves ambiguous ranges, fractional episodes, conflicting seasons, and numbers valid as season-relative episodes unchanged.
* Allows quality suffixes such as `- 1080p` without mistaking them for episode ranges.

The normalization is anime-only and does not introduce a toggle; existing matching settings still control rejection.

Conservative limits: a later populated season is required, so final seasons are excluded. Year-like and common resolution numbers are also excluded, even when they could represent real absolute episodes.

Validation: 38 parser and filtering tests pass, including real-parser regression cases, input immutability, repeated filtering, and quality-suffix handling. Core TypeScript build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved anime season and episode matching for absolute episode numbering.
  * Correctly reconciles compatible season metadata and alternate filename formats.
  * Preserves local episode numbering when interpretations conflict.
* **Bug Fixes**
  * Rejects incorrect, fractional, ambiguous, or incomplete episode information more reliably.
  * Prevents year, resolution, and continuation values from being mistaken for episode numbers.
  * Applies consistent filtering across repeated checks and non-anime content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->