### PR TITLE
fix(builtins): compute torrent age from pubDate for torznab/prowlarr

### DIFF
--- a/packages/core/src/builtins/newznab/addon.ts
+++ b/packages/core/src/builtins/newznab/addon.ts
@@ -17,6 +17,7 @@ import {
   NabAddonConfig,
   parseNabParsedFileInfo,
 } from '../base/nab/addon.js';
+import { ageInHoursSince } from '../utils/general.js';
 import { BuiltinProxy, createProxy } from '../../proxy/index.js';
 import type { BuiltinServiceId } from '../../utils/index.js';
 import type { Stream } from '../../db/index.js';
@@ -185,10 +186,7 @@ export class NewznabAddon extends BaseNabAddon<NewznabAddonConfig, NewznabApi> {
       if (typeof result.newznab?.usenetdate === 'string') {
         date = result.newznab.usenetdate;
       }
-      const age = Math.ceil(
-        Math.abs(new Date().getTime() - new Date(date).getTime()) /
-          (1000 * 60 * 60)
-      );
+      const age = ageInHoursSince(date);
       const parsedMediaInfo = parseNabParsedFileInfo({
         audioLanguages: result.newznab?.language,
         subtitleLanguages: result.newznab?.subs,

--- a/packages/core/src/builtins/prowlarr/addon.ts
+++ b/packages/core/src/builtins/prowlarr/addon.ts
@@ -262,6 +262,7 @@ export class ProwlarrAddon extends BaseDebridAddon<ProwlarrAddonConfig> {
         title: result.title,
         size: result.size,
         indexer: result.indexer,
+        age: result.ageHours >= 0 ? Math.ceil(result.ageHours) : undefined,
         type: 'torrent',
       });
     }
@@ -287,7 +288,7 @@ export class ProwlarrAddon extends BaseDebridAddon<ProwlarrAddonConfig> {
       nzbs.push({
         hash,
         nzb: nzbUrl,
-        age: Math.ceil(result.age * 24),
+        age: result.ageHours >= 0 ? Math.ceil(result.ageHours) : undefined,
         title: result.title,
         size: result.size,
         indexer: result.indexer,

--- a/packages/core/src/builtins/prowlarr/api.ts
+++ b/packages/core/src/builtins/prowlarr/api.ts
@@ -65,7 +65,7 @@ const ProwlarrApiIndexersListSchema = z.array(ProwlarrApiIndexerSchema);
 
 const ProwlarrApiSearchItemSchema = z.object({
   guid: z.string().optional(), // can sometimes be the raw magnet url
-  age: z.number(), // in days
+  ageHours: z.number(),
   size: z.number(),
   indexerId: z.number(),
   indexer: z.string(),

--- a/packages/core/src/builtins/torznab/addon.ts
+++ b/packages/core/src/builtins/torznab/addon.ts
@@ -13,6 +13,7 @@ import {
   NabAddonConfig,
   parseNabParsedFileInfo,
 } from '../base/nab/addon.js';
+import { ageInHoursSince } from '../utils/general.js';
 
 const logger = createLogger('torznab');
 
@@ -70,6 +71,7 @@ export class TorznabAddon extends BaseNabAddon<NabAddonConfig, TorznabApi> {
         hash: infoHash,
         guid: result.guid,
         downloadUrl,
+        age: ageInHoursSince(result.pubDate),
         sources: result.torznab?.magneturl?.toString()
           ? extractTrackersFromMagnet(result.torznab.magneturl.toString())
           : [],

--- a/packages/core/src/builtins/utils/general.test.ts
+++ b/packages/core/src/builtins/utils/general.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import '../../utils/index.js';
+import { ageInHoursSince } from './general.js';
+
+describe('ageInHoursSince', () => {
+  it('rounds up to the next full hour', () => {
+    const date = new Date(Date.now() - 47.5 * 60 * 60 * 1000).toISOString();
+    assert.equal(ageInHoursSince(date), 48);
+  });
+
+  it('returns undefined for an unparsable date', () => {
+    assert.equal(ageInHoursSince('not-a-date'), undefined);
+  });
+
+  it('returns undefined for a date in the future', () => {
+    const date = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    assert.equal(ageInHoursSince(date), undefined);
+  });
+});

--- a/packages/core/src/builtins/utils/general.ts
+++ b/packages/core/src/builtins/utils/general.ts
@@ -9,6 +9,13 @@ const logger = createLogger('builtin:scrape');
 export const createQueryLimit = () =>
   pLimit(appConfig.builtins.scrape.queryConcurrency);
 
+/** Hours since `date` (e.g. an indexer's pubDate), or undefined if unparsable or in the future. */
+export function ageInHoursSince(date: string): number | undefined {
+  const diffMs = Date.now() - new Date(date).getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return undefined;
+  return Math.ceil(diffMs / (1000 * 60 * 60));
+}
+
 /**
  * Checks whether a raw release title contains one of the given air dates
  * ('YYYY-MM-DD')


### PR DESCRIPTION
Torrent results from torznab (Jackett) and Prowlarr indexers never got an age value, unlike NZBs. Adds a shared ageInHoursSince() helper and applies result.pubDate/result.ageHours consistently, treating unparsable or future-dated values as unknown rather than fabricating an age.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search results from supported indexers now consistently include item ages in hours.
  * Age values are calculated and rounded consistently across Newznab, Prowlarr and Torznab sources.
  * Age information is now consistent across torrent and NZB search results.
* **Bug Fixes**
  * Invalid or future publication dates no longer display misleading age information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->