### PR TITLE
fix(frontend): clarify digital release filter description scope

### DIFF
--- a/packages/frontend/src/components/menu/filters/index.tsx
+++ b/packages/frontend/src/components/menu/filters/index.tsx
@@ -4040,7 +4040,7 @@ function Content() {
                 <SettingsCard
                   id="digitalReleaseFilter"
                   title="Digital Release Filter"
-                  description="This will filter out all results for movies that are determined to not have a digital release."
+                  description="Filters out movies, series, and anime that haven't released yet, based on release dates (movies) or episode air dates (series/anime)."
                 >
                   <Switch
                     label="Enabled"


### PR DESCRIPTION
The card description said it only applies to movies, but the filter and its Request Types selector already cover series and anime too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Digital Release Filter identifies unreleased films, series and anime using release dates or episode air dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->