### PR TITLE
feat(filters): add opt-in check to block results predating release/air date

### DIFF
--- a/packages/core/src/db/schemas.ts
+++ b/packages/core/src/db/schemas.ts
@@ -707,6 +707,7 @@ export const UserDataSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       tolerance: z.number().min(0).max(365).optional(),
+      checkResultAge: z.boolean().optional(),
       requestTypes: z.array(z.string()).optional(),
       addons: z.array(z.string()).optional(),
       showInfoOnFilter: z.boolean().optional(),

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -26,7 +26,7 @@ import {
 } from '../parser/utils.js';
 import { normaliseCountryCode } from '../utils/countries.js';
 import { partial_ratio } from 'fuzzball';
-import { formatBitrate, formatBytes } from '../formatters/utils.js';
+import { formatBitrate, formatBytes, formatHours } from '../formatters/utils.js';
 import { iso6391ToLanguage, languageToCode } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
 import { StreamContext, ExtendedMetadata } from './context.js';
@@ -544,9 +544,23 @@ class StreamFilterer {
       });
     }
 
-    const applyDigitalReleaseFilter = (): boolean => {
+    const isDigitalReleaseExempt = (stream: ParsedStream): boolean => {
+      const config = this.userData.digitalReleaseFilter;
+      if (shouldPassthroughStage(stream, 'digitalRelease')) return true;
+      if (
+        config?.addons?.length &&
+        stream.addon.preset.id &&
+        !config.addons.includes(stream.addon.preset.id)
+      ) {
+        return true;
+      }
+      return false;
+    };
+
+    const applyDigitalReleaseFilter = (stream?: ParsedStream): boolean => {
       const config = this.userData.digitalReleaseFilter;
       if (!config?.enabled) return true;
+      if (stream && isDigitalReleaseExempt(stream)) return true;
 
       // Preconditions: check content type is in scope
       const filterRequestTypes = config.requestTypes;
@@ -590,6 +604,18 @@ class StreamFilterer {
           : null;
       const daysSinceEpisode = epDate ? daysBetween(epDate, today) : null;
       const epLabel = `S${parsedId?.season}E${parsedId?.episode}`;
+
+      const referenceDateForAge = isSeries ? epDate : releaseDate;
+      const hoursSinceReference = referenceDateForAge
+        ? (today.getTime() - referenceDateForAge.getTime()) / (1000 * 60 * 60)
+        : null;
+      const streamPredatesRelease =
+        !!config.checkResultAge &&
+        !!stream &&
+        stream.age !== undefined &&
+        hoursSinceReference !== null &&
+        hoursSinceReference >= 0 &&
+        stream.age > hoursSinceReference + tolerance * 24;
 
       // Digital release dates (TMDB types 4-6: Digital, Physical, TV)
       const digitalDates = (releaseDates ?? []).filter(
@@ -644,6 +670,13 @@ class StreamFilterer {
         level?: 'debug' | 'info';
       };
       const rules: FilterRule[] = [
+        {
+          when: () => streamPredatesRelease,
+          allow: false,
+          level: 'info',
+          reason: () =>
+            `Result age (${formatHours(stream!.age!)}) predates ${isSeries ? `episode ${epLabel}` : `"${title}"`}'s ${isSeries ? 'air date' : 'release'} (${formatDate(referenceDateForAge!)})`,
+        },
         // General
         {
           when: () => daysSinceRelease < -tolerance,
@@ -1209,24 +1242,7 @@ class StreamFilterer {
     // Early digital release filter check - if it returns false, filter out streams
     // except those with passthrough for 'digitalRelease' stage or those from addons not in the filter list
     if (!applyDigitalReleaseFilter()) {
-      const digitalReleaseFilterAddons =
-        this.userData.digitalReleaseFilter?.addons;
-      const passthroughDigitalRelease = streams.filter((stream) => {
-        // Check if stream has passthrough for this stage
-        if (shouldPassthroughStage(stream, 'digitalRelease')) {
-          return true;
-        }
-        // If addons filter is set and stream is not from a filtered addon, bypass
-        if (
-          digitalReleaseFilterAddons &&
-          digitalReleaseFilterAddons.length > 0 &&
-          stream.addon.preset.id &&
-          !digitalReleaseFilterAddons.includes(stream.addon.preset.id)
-        ) {
-          return true;
-        }
-        return false;
-      });
+      const passthroughDigitalRelease = streams.filter(isDigitalReleaseExempt);
       const filteredCount = streams.length - passthroughDigitalRelease.length;
       if (filteredCount > 0) {
         this.filterStatistics.removed.noDigitalRelease.total = filteredCount;
@@ -1444,6 +1460,14 @@ class StreamFilterer {
     };
 
     const shouldKeepStream = (stream: ParsedStream): boolean => {
+      if (!applyDigitalReleaseFilter(stream)) {
+        this.incrementRemovalReason(
+          'noDigitalRelease',
+          'No digital release available'
+        );
+        return false;
+      }
+
       const file = stream.parsedFile;
 
       const isPendingServiceWrapResolution = isServiceWrapEligibleP2PStream(

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -26,7 +26,11 @@ import {
 } from '../parser/utils.js';
 import { normaliseCountryCode } from '../utils/countries.js';
 import { partial_ratio } from 'fuzzball';
-import { formatBitrate, formatBytes, formatHours } from '../formatters/utils.js';
+import {
+  formatBitrate,
+  formatBytes,
+  formatHours,
+} from '../formatters/utils.js';
 import { iso6391ToLanguage, languageToCode } from '../utils/languages.js';
 import { ReleaseDate } from '../metadata/tmdb.js';
 import { StreamContext, ExtendedMetadata } from './context.js';
@@ -573,11 +577,16 @@ class StreamFilterer {
       }
       if (!['movie', 'series', 'anime'].includes(type)) return true;
 
-      // Parse and validate release date (required for all subsequent rules)
+      const isSeries = type === 'series';
+
+      // Movies have no other date signal, so they still require this. Series
+      // rely on the episode date below instead, with or without this one.
       const releaseDate = requestedMetadata?.releaseDate
         ? new Date(requestedMetadata.releaseDate)
         : null;
-      if (!releaseDate || isNaN(releaseDate.getTime())) {
+      const validReleaseDate =
+        releaseDate && !isNaN(releaseDate.getTime()) ? releaseDate : null;
+      if (!isSeries && !validReleaseDate) {
         logger.debug(
           `[DigitalReleaseFilter] No valid release date for "${requestedMetadata?.title}", allowing`
         );
@@ -591,8 +600,9 @@ class StreamFilterer {
       const daysBetween = (from: Date, to: Date) =>
         Math.floor((to.getTime() - from.getTime()) / msPerDay);
       const title = requestedMetadata?.title;
-      const daysSinceRelease = daysBetween(releaseDate, today);
-      const isSeries = type === 'series' || type === 'anime';
+      const daysSinceRelease = validReleaseDate
+        ? daysBetween(validReleaseDate, today)
+        : NaN;
 
       // Episode air date (series/anime only)
       const epDateStr = isSeries
@@ -646,7 +656,7 @@ class StreamFilterer {
         });
 
       logger.debug(`[DigitalReleaseFilter] Evaluating "${title}"`, {
-        releaseDate: formatDate(releaseDate),
+        releaseDate: validReleaseDate ? formatDate(validReleaseDate) : 'N/A',
         daysSinceRelease,
         isSeries,
         episodeAirDate: epDate ? formatDate(epDate) : 'N/A',

--- a/packages/core/src/streams/filterer.ts
+++ b/packages/core/src/streams/filterer.ts
@@ -577,7 +577,7 @@ class StreamFilterer {
       }
       if (!['movie', 'series', 'anime'].includes(type)) return true;
 
-      const isSeries = type === 'series';
+      const isSeries = type === 'series' || type === 'anime';
 
       // Movies have no other date signal, so they still require this. Series
       // rely on the episode date below instead, with or without this one.

--- a/packages/frontend/src/components/menu/filters/index.tsx
+++ b/packages/frontend/src/components/menu/filters/index.tsx
@@ -4101,6 +4101,22 @@ function Content() {
                     </div>
                   </div>
                   <p className="text-sm text-[--muted]">Tolerance in days</p>
+                  <Switch
+                    label="Also Check Result Age"
+                    side="right"
+                    disabled={!userData.digitalReleaseFilter?.enabled}
+                    value={userData.digitalReleaseFilter?.checkResultAge ?? false}
+                    moreHelp="Blocks results uploaded before the release/air date (beyond tolerance). Only works when a result's age is known."
+                    onValueChange={(value) => {
+                      setUserData((prev) => ({
+                        ...prev,
+                        digitalReleaseFilter: {
+                          ...prev.digitalReleaseFilter,
+                          checkResultAge: value,
+                        },
+                      }));
+                    }}
+                  />
                   <div className="space-y-4">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <Combobox


### PR DESCRIPTION
Digital Release Filter gets a new opt-in toggle that blocks results whose upload is older than the release date (movies) or episode air date (series/anime), catching mismatched/wrong-timed results.

Required turning applyDigitalReleaseFilter into a per-stream check (was a single request-wide gate) so it can see each stream's age.

---


in combination with https://github.com/Viren070/AIOStreams/pull/1306 this could be highly useful with torznab/newznab to avoid getting incorrect results for content. E.g. Futurama S11 using tmdb/tvdb meta which should not even exist as season pack et, but with imdb meta S11 was released in 2023 I think..

I wasn't and still am not sure if this should be done by digital release filter or warrants another age filter or smth like that..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Also Check Result Age” option to the Digital Release Filter settings.
  - When enabled, results uploaded before the relevant release or episode air date—outside the allowed tolerance—are filtered out when their age is available.
  - Series and anime results use the episode air date when no release date is available.
  - The option is unavailable while the Digital Release Filter is disabled.
  - Digital release exemptions are applied consistently to individual streams and batch filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->