### PR TITLE
fix: preserve clicked native Usenet file selection

### DIFF
--- a/packages/core/src/usenet/integration/library-selection.test.ts
+++ b/packages/core/src/usenet/integration/library-selection.test.ts
@@ -1,0 +1,190 @@
+import '../../parser/utils.js';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { DebridFile, PlaybackInfo } from '../../debrid/base.js';
+import { selectFileInTorrentOrNZB, type NZB } from '../../debrid/utils.js';
+import { selectStreamFile, toDebridFiles } from './library.js';
+
+const clicked = '[Seisenshi]_Legend_Of_DUO_02_-_.[892413EB].mkv';
+const files = toDebridFiles([
+  {
+    name: '[Seisenshi]_Legend_Of_DUO_01_-_ [F481AAA2].mkv',
+    path: 'Legend of Duo/[Seisenshi]_Legend_Of_DUO_01_-_ [F481AAA2].mkv',
+    size: 31_527_631,
+    index: 0,
+    streamable: true,
+  },
+  {
+    name: '[Seisenshi]_Legend_Of_DUO_02_-_ [892413EB].mkv',
+    path: 'Legend of Duo/[Seisenshi]_Legend_Of_DUO_02_-_ [892413EB].mkv',
+    size: 28_636_136,
+    index: 1,
+    streamable: true,
+  },
+  {
+    name: '[Seisenshi]_Legend_Of_DUO_03_-_ [CDF931A9].mkv',
+    path: 'Legend of Duo/[Seisenshi]_Legend_Of_DUO_03_-_ [CDF931A9].mkv',
+    size: 31_394_436,
+    index: 2,
+    streamable: false,
+  },
+]);
+const playback: PlaybackInfo & { type: 'usenet' } = {
+  type: 'usenet',
+  nzb: 'https://example.com/legend-of-duo.nzb',
+  hash: 'legend-of-duo',
+  filename: clicked,
+  metadata: {
+    titles: ['Legend of Duo'],
+    season: 1,
+    episode: 2,
+    absoluteEpisode: 2,
+  },
+};
+const packFiles: DebridFile[] = [
+  { name: 'Legend of Duo S01E01.mkv', size: 31_527_631, index: 4 },
+  { name: 'Legend of Duo S01E02.mkv', size: 28_636_136, index: 7 },
+];
+
+describe('native Usenet resolved-file selection', () => {
+  it('preserves clicked E02 after an unseen NZB acquires inner files', async () => {
+    const nzb: NZB = { ...playback, title: clicked, size: 100_000_000 };
+    const placeholder = await selectFileInTorrentOrNZB(
+      nzb,
+      { id: playback.hash, status: 'cached' },
+      new Map(),
+      playback.metadata
+    );
+    assert.equal(placeholder?.index, -1);
+    assert.equal(placeholder?.name, clicked);
+    assert.equal(files.length, 2); // Incomplete E03 is not a playback target.
+    const selected = await selectStreamFile(
+      { ...playback, index: placeholder!.index, filename: placeholder!.name },
+      clicked,
+      files
+    );
+    assert.equal(selected, files[1]);
+    assert.equal(selected?.path, files[1].path);
+  });
+
+  for (const index of [undefined, -1, 99]) {
+    it(`matches clicked E02 when index is ${index}`, async () => {
+      assert.equal(
+        await selectStreamFile({ ...playback, index }, clicked, files),
+        files[1]
+      );
+    });
+  }
+
+  it('keeps explicit fileIndex ahead of index, filename and metadata', async () => {
+    assert.equal(
+      await selectStreamFile(
+        { ...playback, fileIndex: 0, index: 1 },
+        clicked,
+        files
+      ),
+      files[0]
+    );
+  });
+
+  it('honours a real index by identity, not its position in the filtered list', async () => {
+    assert.equal(
+      await selectStreamFile({ ...playback, index: 4 }, clicked, packFiles),
+      packFiles[0]
+    );
+  });
+
+  it('tries index when an explicit fileIndex no longer exists', async () => {
+    assert.equal(
+      await selectStreamFile(
+        { ...playback, fileIndex: 99, index: 0 },
+        clicked,
+        files
+      ),
+      files[0]
+    );
+  });
+
+  it('uses the filename argument when playbackInfo has no filename', async () => {
+    assert.equal(
+      await selectStreamFile(
+        { ...playback, filename: undefined },
+        clicked,
+        files
+      ),
+      files[1]
+    );
+  });
+
+  it('compares basenames across paths and separator/case differences', async () => {
+    const nested = files.map((file) => ({ ...file, name: file.path }));
+    assert.equal(
+      await selectStreamFile(
+        { ...playback, filename: `Downloads\\${clicked.toLowerCase()}` },
+        clicked,
+        nested
+      ),
+      nested[1]
+    );
+  });
+
+  for (const index of [undefined, -1, 99]) {
+    it(`scores a season pack using metadata with index ${index}`, async () => {
+      assert.equal(
+        await selectStreamFile(
+          { ...playback, index, filename: 'Legend of Duo S01 Complete' },
+          'Legend of Duo S01 Complete',
+          packFiles
+        ),
+        packFiles[1]
+      );
+    });
+  }
+
+  it('falls back to metadata when multiple basenames normalise to the clicked name', async () => {
+    const ambiguous = [
+      { ...files[1], name: `First/${clicked}`, index: 10 },
+      { ...files[1], name: `Second/${files[1].name}`, index: 20 },
+      packFiles[1],
+    ];
+    // Even one exact basename must not bypass the normalised ambiguity check.
+    assert.equal(
+      await selectStreamFile(playback, clicked, ambiguous),
+      packFiles[1]
+    );
+  });
+
+  it('does not give a stale fileIndex an array-position bonus during fallback', async () => {
+    const candidates = files.map((file, i) => ({ ...file, index: 10 + i }));
+    assert.equal(
+      await selectStreamFile(
+        { ...playback, filename: 'Legend of Duo Complete', fileIndex: 1 },
+        'Legend of Duo Complete',
+        candidates
+      ),
+      candidates[0]
+    );
+  });
+
+  for (const filename of [
+    clicked.replace('892413EB', '00000000'),
+    clicked.replace('DUO_02', 'DUO_0_2'),
+    clicked.replace('.mkv', '.avi'),
+  ]) {
+    it(`does not discard identifying tokens from ${filename}`, async () => {
+      const candidates = [...files, packFiles[1]];
+      assert.equal(
+        await selectStreamFile({ ...playback, filename }, filename, candidates),
+        packFiles[1]
+      );
+    });
+  }
+
+  it('retains the empty- and single-file shortcuts', async () => {
+    assert.equal(await selectStreamFile(playback, clicked, []), undefined);
+    assert.equal(
+      await selectStreamFile(playback, clicked, [files[1]]),
+      files[1]
+    );
+  });
+});

--- a/packages/core/src/usenet/integration/library.ts
+++ b/packages/core/src/usenet/integration/library.ts
@@ -904,10 +904,19 @@ export async function clearUsenetLibrary(): Promise<void> {
   await UsenetLibraryRepository.clear();
 }
 
+/** Fold basename separators without dropping hashes, groups or numeric punctuation. */
+function normalisePlaybackBasename(filename: string): string {
+  return baseName(filename.replace(/\\/g, '/'))
+    .toLowerCase()
+    .replace(/(?<!\d)\.|\.(?!\d)/g, ' ')
+    .replace(/[_\s]+/g, ' ')
+    .trim();
+}
+
 /**
- * Pick the file to play. Honours an explicit `fileIndex`, short-circuits a
- * single-file NZB, and otherwise defers to the shared metadata-aware
- * {@link selectFileInTorrentOrNZB} scorer.
+ * Pick the file to play. Preserve a resolved `fileIndex` or `index`, then a
+ * unique clicked-basename match. Packs and ambiguous names defer to the shared
+ * metadata-aware {@link selectFileInTorrentOrNZB} scorer.
  */
 export async function selectStreamFile(
   playbackInfo: PlaybackInfo & { type: 'usenet' },
@@ -919,9 +928,29 @@ export async function selectStreamFile(
     const match = files.find((f) => f.index === playbackInfo.fileIndex);
     if (match) return match;
   }
+  // Builtins carry the selected file in `index`; -1 means the NZB had not
+  // been inspected yet, so only a real resolved-file index is authoritative.
+  if (
+    playbackInfo.index !== undefined &&
+    Number.isInteger(playbackInfo.index) &&
+    playbackInfo.index >= 0
+  ) {
+    const match = files.find((f) => f.index === playbackInfo.index);
+    if (match) return match;
+  }
   if (files.length === 1) return files[0];
 
   const title = playbackInfo.filename ?? filename;
+  const clickedBasename = normalisePlaybackBasename(title);
+  if (clickedBasename) {
+    const matches = files.filter(
+      (f) => f.name && normalisePlaybackBasename(f.name) === clickedBasename
+    );
+    // An unseen NZB can be named after one inner video even when the parser
+    // cannot extract its episode. Never guess between duplicate basenames.
+    if (matches.length === 1) return matches[0];
+  }
+
   const totalSize = files.reduce((s, f) => s + f.size, 0);
   const parsedFiles = new Map<string, ParsedResult>();
   for (const s of [title, ...files.map((f) => f.name ?? '')]) {
@@ -947,8 +976,7 @@ export async function selectStreamFile(
     nzbInfo,
     debridDownload,
     parsedFiles,
-    playbackInfo.metadata,
-    { chosenIndex: playbackInfo.fileIndex }
+    playbackInfo.metadata
   );
 }
 


### PR DESCRIPTION
Native Usenet could select the wrong inner video when archive inspection revealed multiple files whose episode numbers weren’t recognized by the parser.

* Preserve explicit file selections using valid resolved indices.
* Prefer a unique normalized match to the clicked filename before rescoring.
* Retain metadata-based selection for season packs, unmatched filenames, and ambiguous matches.
* Prevent stale file indices from influencing fallback scoring.

Adds 18 regression tests. All 52 core tests and the core TypeScript check pass. Playback of episodes 1 and 2 from the same affected NZB was also verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Usenet playback file selection for episodes and season packs.
  - File selection now more reliably honours the clicked episode, explicit file choices and valid playback indexes.
  - Improved matching when filenames differ by folder paths, capitalisation, punctuation or separators.
  - Added fallback handling for missing, outdated or unavailable file indexes.
  - Preserved reliable selection for single-file and empty-library cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->